### PR TITLE
Refine header layout and collection visuals

### DIFF
--- a/components/FilterModal.tsx
+++ b/components/FilterModal.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { X, Filter, RotateCcw } from 'lucide-react';
+import { X, Filter, RotateCcw, ChevronDown } from 'lucide-react';
 import { FieldDefinition } from '../types';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
@@ -21,7 +21,9 @@ export const FilterModal: React.FC<FilterModalProps> = ({ isOpen, onClose, field
   const surfaceClass = panelSurfaceClasses[theme];
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
-  const inputSurface = theme === 'vault' ? 'bg-white/5 border border-white/10 text-white placeholder:text-stone-400' : 'bg-stone-50 border border-stone-200';
+  const inputSurface = theme === 'vault'
+    ? 'bg-white/5 border border-white/10 text-white placeholder:text-stone-400'
+    : 'bg-white border border-stone-200 text-stone-800 placeholder:text-stone-300';
   const mutedText = mutedTextClasses[theme];
 
   useEffect(() => {
@@ -45,40 +47,49 @@ export const FilterModal: React.FC<FilterModalProps> = ({ isOpen, onClose, field
 
   return (
     <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 ${overlayClass} backdrop-blur-sm`}>
-      <div className={`${surfaceClass} rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col max-h-[85vh] motion-panel border`}>
-        <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
+      <div className={`${surfaceClass} rounded-[1.75rem] shadow-2xl w-full max-w-lg overflow-hidden flex flex-col max-h-[85vh] motion-panel border`}>
+        <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
               <div className={`p-1.5 rounded-lg ${theme === 'vault' ? 'bg-white/5 text-white' : 'bg-stone-100 text-stone-600'}`}><Filter size={18} /></div>
               <h2 className={`font-serif font-bold text-lg ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}>{t('filterCollection')}</h2>
           </div>
           <button onClick={onClose} className={`p-1 rounded-full transition-colors ${theme === 'vault' ? 'hover:bg-white/5 text-stone-300 hover:text-white' : 'hover:bg-stone-100 text-stone-400 hover:text-stone-800'}`}><X size={20} /></button>
         </div>
-        <div className="p-6 space-y-5 overflow-y-auto flex-1">
-            <div>
-                 <label className={`block text-[12px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-2`}>{t('rating')}</label>
-                 <select value={localFilters['rating'] || ''} onChange={e => setLocalFilters({...localFilters, rating: e.target.value})} className={`w-full p-2.5 rounded-xl text-sm outline-none ${inputSurface}`}>
+        <div className="px-6 py-5 space-y-5 overflow-y-auto flex-1">
+            <div className="space-y-2">
+                 <label className={`block text-[11px] font-semibold uppercase tracking-[0.18em] ${mutedText}`}>{t('rating')}</label>
+                 <div className="relative">
+                   <select
+                     value={localFilters['rating'] || ''}
+                     onChange={e => setLocalFilters({ ...localFilters, rating: e.target.value })}
+                     className={`w-full p-3 rounded-2xl text-sm outline-none appearance-none ${inputSurface}`}
+                   >
                      <option value="">{t('anyRating')}</option>
                      <option value="5">5 Stars</option>
                      <option value="4">4+ Stars</option>
                      <option value="3">3+ Stars</option>
-                 </select>
+                   </select>
+                   <ChevronDown size={16} className={`absolute right-3 top-1/2 -translate-y-1/2 ${theme === 'vault' ? 'text-white/50' : 'text-stone-400'}`} />
+                 </div>
             </div>
             {fields.map(field => (
-                <div key={field.id}>
-                    <label className={`block text-[12px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-2`}>{field.label}</label>
+                <div key={field.id} className="space-y-2">
+                    <label className={`block text-[11px] font-semibold uppercase tracking-[0.18em] ${mutedText}`}>{field.label}</label>
                     <input 
                       type="text" 
                       value={localFilters[field.id] || ''} 
-                      onChange={e => setLocalFilters({...localFilters, [field.id]: e.target.value})} 
-                      className={`w-full p-2.5 rounded-xl text-sm outline-none ${inputSurface}`} 
-                      placeholder="..."
+                      onChange={e => setLocalFilters({ ...localFilters, [field.id]: e.target.value })}
+                      className={`w-full p-3 rounded-2xl text-sm outline-none ${inputSurface}`} 
+                      placeholder="Type to filter"
                     />
                 </div>
             ))}
         </div>
-        <div className={`p-4 border-t flex justify-between items-center gap-3 ${theme === 'vault' ? 'border-white/10 bg-white/5' : 'border-stone-100 bg-white'}`}>
-             <button onClick={handleClear} className="text-stone-500 hover:text-stone-800 text-sm font-medium flex items-center gap-1 px-2"><RotateCcw size={14} /> {t('clear')}</button>
-             <div className="flex gap-2">
+        <div className={`px-6 py-4 border-t flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 ${theme === 'vault' ? 'border-white/10 bg-white/5' : 'border-stone-100 bg-white'}`}>
+             <button onClick={handleClear} className="text-stone-500 hover:text-stone-800 text-sm font-medium flex items-center gap-1 px-2">
+               <RotateCcw size={14} /> {t('clear')}
+             </button>
+             <div className="flex items-center gap-2 justify-end">
                 <Button variant="ghost" onClick={onClose}>{t('cancel')}</Button>
                 <Button onClick={handleApply}>{t('apply')} {activeCount > 0 ? `(${activeCount})` : ''}</Button>
              </div>

--- a/components/ItemCard.tsx
+++ b/components/ItemCard.tsx
@@ -25,6 +25,9 @@ export const ItemCard: React.FC<ItemCardProps> = ({ item, fields, displayFields,
     ? 'bg-white/10 text-white border border-white/10'
     : 'bg-stone-100 text-stone-600';
   const ratingSurface = theme === 'vault' ? 'bg-stone-900/80 text-white' : 'bg-white/90 text-stone-700';
+  const cardShadow = theme === 'vault'
+    ? 'shadow-[0_20px_50px_rgba(0,0,0,0.45)] hover:shadow-[0_24px_60px_rgba(0,0,0,0.55)]'
+    : 'shadow-[0_18px_40px_rgba(15,23,42,0.08)] hover:shadow-[0_24px_50px_rgba(15,23,42,0.12)]';
   
   const getValue = (fieldId: string) => {
     const val = item.data[fieldId];
@@ -49,7 +52,7 @@ export const ItemCard: React.FC<ItemCardProps> = ({ item, fields, displayFields,
   return (
     <div 
       onClick={onClick}
-      className={`group rounded-xl shadow-sm hover:shadow-md transition-all duration-300 overflow-hidden border cursor-pointer flex flex-col ${layout === 'grid' ? 'h-full' : ''} motion-card ${cardSurface}`}
+      className={`group rounded-2xl transition-all duration-300 overflow-hidden border cursor-pointer flex flex-col ${layout === 'grid' ? 'h-full' : ''} motion-card ${cardSurface} ${cardShadow}`}
     >
       <div className={`${layout === 'grid' ? 'aspect-[4/3]' : ''} ${theme === 'vault' ? 'bg-stone-800' : 'bg-stone-100'} overflow-hidden relative`}>
         <ItemImage 

--- a/components/ItemImage.tsx
+++ b/components/ItemImage.tsx
@@ -1,6 +1,6 @@
 
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { getAsset } from '../services/db';
 import { Loader2, Camera, AlertCircle } from 'lucide-react';
 
@@ -19,9 +19,21 @@ export const ItemImage: React.FC<ItemImageProps> = ({ itemId, photoUrl, classNam
   const [fallbackSrc, setFallbackSrc] = useState<string | null>(null);
   const currentUrlRef = useRef<string | null>(null);
   const defaultFallback = `${import.meta.env.BASE_URL}assets/sample-vinyl.jpg`;
+  const resolvedPhotoUrl = useMemo(() => {
+    if (!photoUrl) return photoUrl;
+    if (
+      photoUrl.startsWith('http') ||
+      photoUrl.startsWith('data:') ||
+      photoUrl.startsWith('blob:') ||
+      photoUrl.startsWith('/')
+    ) {
+      return photoUrl;
+    }
+    return `${import.meta.env.BASE_URL}${photoUrl}`;
+  }, [photoUrl]);
 
   // If photoUrl is anything other than 'asset', it's a direct reference (URL or path)
-  const isDirectSource = photoUrl && photoUrl !== 'asset' && photoUrl !== '';
+  const isDirectSource = resolvedPhotoUrl && resolvedPhotoUrl !== 'asset' && resolvedPhotoUrl !== '';
 
   useEffect(() => {
     // Reset fallback/error when the source changes
@@ -91,7 +103,7 @@ export const ItemImage: React.FC<ItemImageProps> = ({ itemId, photoUrl, classNam
     };
   }, []);
 
-  const finalSrc = fallbackSrc || (isDirectSource ? photoUrl : dbUrl);
+  const finalSrc = fallbackSrc || (isDirectSource ? resolvedPhotoUrl : dbUrl);
 
   if (loading && !finalSrc) {
     return (

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { Home, Plus, User, LogOut, Cloud, CloudOff, Zap, ArrowUpRight, Download } from 'lucide-react';
+import { Home, User, LogOut, Cloud, CloudOff, Zap, ArrowUpRight, Download } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from '../i18n';
 import { ThemePicker } from './ThemePicker';
@@ -8,7 +8,6 @@ import { useTheme, cardSurfaceClasses } from '../theme';
 
 interface LayoutProps {
   children: React.ReactNode;
-  onAddItem: () => void;
   onOpenAuth: () => void;
   onSignOut: () => void;
   onImportLocal?: () => void;
@@ -20,7 +19,7 @@ interface LayoutProps {
   headerExtras?: React.ReactNode;
 }
 
-export const Layout: React.FC<LayoutProps> = ({ children, onAddItem, onOpenAuth, onSignOut, onImportLocal, hasLocalImport = false, importState = 'idle', importMessage = null, user, isSupabaseConfigured, headerExtras }) => {
+export const Layout: React.FC<LayoutProps> = ({ children, onOpenAuth, onSignOut, onImportLocal, hasLocalImport = false, importState = 'idle', importMessage = null, user, isSupabaseConfigured, headerExtras }) => {
   const { t } = useTranslation();
   const { theme } = useTheme();
   const location = useLocation();
@@ -54,9 +53,6 @@ export const Layout: React.FC<LayoutProps> = ({ children, onAddItem, onOpenAuth,
     : 'hover:bg-stone-100 text-stone-500 hover:text-stone-900';
   const dropdownSurface = cardSurfaceClasses[theme];
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
-  const primaryCta = theme === 'vault'
-    ? 'bg-amber-500 hover:bg-amber-400 text-stone-950'
-    : 'bg-stone-900 hover:bg-amber-600 text-white';
   const footerGradient = theme === 'vault'
     ? 'from-stone-950 via-stone-950 to-transparent'
     : theme === 'atelier'
@@ -74,7 +70,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, onAddItem, onOpenAuth,
             <span className="font-serif text-xl font-bold tracking-tight leading-none">{t('appTitle')}</span>
           </Link>
           
-          <nav className="flex w-full items-center gap-2 flex-wrap justify-between sm:w-auto sm:flex-nowrap sm:justify-end">
+          <nav className="flex items-center gap-2 flex-wrap justify-end">
             {headerExtras}
             
             <div className="relative">
@@ -167,14 +163,6 @@ export const Layout: React.FC<LayoutProps> = ({ children, onAddItem, onOpenAuth,
                     </button>
             </Link>
             )}
-            <button 
-                onClick={onAddItem}
-                className={`${primaryCta} rounded-full px-4 py-1.5 text-sm font-medium flex items-center gap-2 transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0 flex-shrink-0`}
-            >
-              <Plus size={16} />
-              <span className="hidden sm:inline">{isAuthenticated ? t('addItem') : t('login')}</span>
-              <span className="sm:hidden">{isAuthenticated ? t('add') : t('login')}</span>
-            </button>
           </nav>
         </div>
       </header>


### PR DESCRIPTION
### Motivation
- Reduce header clutter by removing duplicated add controls and large inline controls that belong in context-specific places.
- Surface collection-level actions (like adding items) where they make sense instead of in the global header.
- Improve the filters panel and form controls to match the app theme and deliver a more polished, consistent UX.
- Ensure sample and private collection images resolve correctly, falling back to cloud storage when appropriate.

### Description
- Simplified the header by removing the inline add-item CTA and reverting the inline `ThemePicker` placement, and adjusted header nav spacing in `components/Layout.tsx`.
- Added a collection-scoped add-item control in `App.tsx` (uses `setIsAddModalOpen`) so `AddItemModal` is reachable from the collection screen only when allowed.
- Restyled the filter modal in `components/FilterModal.tsx` with updated spacing, rounded controls, improved `select` appearance, and a chevron icon for affordance.
- Improved image handling in `components/ItemImage.tsx` by resolving relative paths to absolute URLs, using a resolved `SEED_IMAGE_PATH` that falls back to a Supabase public URL when available, and refined card shadows in `components/ItemCard.tsx` for visual consistency.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app at `http://localhost:4173/` (succeeded).
- Ran a Playwright script that loaded the homepage, navigated to the sample collection, opened the filter modal, and produced a screenshot artifact (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955835d84ac83208a7399454f4102ab)