### PR TITLE
Fix Supabase asset paths and cloud image retrieval

### DIFF
--- a/components/ItemImage.tsx
+++ b/components/ItemImage.tsx
@@ -19,8 +19,18 @@ export const ItemImage: React.FC<ItemImageProps> = ({ itemId, photoUrl, classNam
   const [fallbackSrc, setFallbackSrc] = useState<string | null>(null);
   const currentUrlRef = useRef<string | null>(null);
   const defaultFallback = `${import.meta.env.BASE_URL}assets/sample-vinyl.jpg`;
+  const remoteAssetPath = useMemo(() => {
+    if (!photoUrl) return null;
+    if (photoUrl.startsWith('http') || photoUrl.startsWith('data:') || photoUrl.startsWith('blob:') || photoUrl.startsWith('/')) {
+      return null;
+    }
+    if (photoUrl.endsWith('.jpg') || photoUrl.endsWith('.jpeg') || photoUrl.endsWith('.png') || photoUrl.endsWith('.webp')) {
+      return photoUrl;
+    }
+    return null;
+  }, [photoUrl]);
   const resolvedPhotoUrl = useMemo(() => {
-    if (!photoUrl) return photoUrl;
+    if (!photoUrl || remoteAssetPath) return null;
     if (
       photoUrl.startsWith('http') ||
       photoUrl.startsWith('data:') ||
@@ -51,17 +61,17 @@ export const ItemImage: React.FC<ItemImageProps> = ({ itemId, photoUrl, classNam
     }
 
     // If it's the 'asset' keyword, we fetch from IndexedDB
-    if (itemId && photoUrl === 'asset') {
+    if (itemId && (photoUrl === 'asset' || remoteAssetPath)) {
       let isMounted = true;
       const loadFromDB = async () => {
         setLoading(true);
         setError(false);
         try {
           // Fix: Assert 'type' as the expected union literal to prevent widening to 'string'
-          let blob = await getAsset(itemId, type as 'master' | 'thumb');
+          let blob = await getAsset(itemId, type as 'master' | 'thumb', remoteAssetPath || undefined);
           // Fallback to master if thumb is missing
           if ((!blob || blob.size === 0) && type === 'thumb') {
-            blob = await getAsset(itemId, 'master');
+            blob = await getAsset(itemId, 'master', remoteAssetPath || undefined);
           }
 
           if (blob && blob.size > 0 && isMounted) {
@@ -91,7 +101,7 @@ export const ItemImage: React.FC<ItemImageProps> = ({ itemId, photoUrl, classNam
       setLoading(false);
       setError(false);
     }
-  }, [itemId, photoUrl, type, isDirectSource]);
+  }, [itemId, photoUrl, type, isDirectSource, remoteAssetPath]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- Seed/sample and uploaded images were not resolving from Supabase storage which caused images to fail to display and AI analysis to error.  
- Cloud-backed items stored as the `asset` keyword needed stable storage paths so public and remote collections can be downloaded.  
- Ensure that image fetches fall back correctly from thumbnail to master and cache assets locally for performance.  

### Description
- Update `saveCollection` in `services/db.ts` to store `photo_path` as a Supabase storage path for items with `photoUrl === 'asset'` (e.g. `userId/itemId_master.jpg`).  
- Extend `getAsset` in `services/db.ts` to accept an optional `remotePath` parameter, normalize thumb/master paths, download from Supabase storage using the provided remote path when present, and cache downloaded blobs into IndexedDB.  
- Enhance `components/ItemImage.tsx` to detect remote storage image paths, pass them to `getAsset`, and gracefully fall back from thumb to master and to a bundled sample image when needed.  

### Testing
- No automated tests were executed as part of this change.  
- Changes were limited to `services/db.ts` and `components/ItemImage.tsx` and compiled via local edits and commit.  
- Recommend validating end-to-end by uploading an item into a non-public collection and confirming the image appears when viewing as another user and that AI analysis runs without image retrieval errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695586f34990832095f7c297d8683157)