### PR TITLE
Remove cloud item records on delete and soften UI shadows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,7 @@ import { UserCollection, CollectionItem, AppTheme } from './types';
 import { TEMPLATES } from './constants';
 import { Plus, SlidersHorizontal, ArrowLeft, Trash2, LayoutGrid, LayoutTemplate, Printer, Camera, Search, Loader2, Sparkles, Mic, Play, Quote, Sparkle, Globe, Calendar, Lock, AlertCircle, X } from 'lucide-react';
 import { Button } from './components/ui/Button';
-import { fetchCloudCollections, getLocalCollections, hasLocalOnlyData, importLocalCollectionsToCloud, saveCollection, saveAllCollections, saveAsset, deleteAsset, requestPersistence, getSeedVersion, setSeedVersion, initDB } from './services/db';
+import { fetchCloudCollections, getLocalCollections, hasLocalOnlyData, importLocalCollectionsToCloud, saveCollection, saveAllCollections, saveAsset, deleteAsset, deleteCloudItem, requestPersistence, getSeedVersion, setSeedVersion, initDB } from './services/db';
 import { processImage } from './services/imageProcessor';
 import { ItemImage } from './components/ItemImage';
 import { MuseumGuide } from './components/MuseumGuide';
@@ -339,6 +339,7 @@ const AppContent: React.FC = () => {
                   const newC = { ...c, items: c.items.filter(i => i.id !== itemId) };
                   saveCollection(newC);
                   deleteAsset(itemId);
+                  void deleteCloudItem(collectionId, itemId);
                   return newC;
               }
               return c;
@@ -602,7 +603,7 @@ const AppContent: React.FC = () => {
 
         <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
             <div className="flex items-center gap-4 sm:gap-6">
-                <Link to="/" className={`p-3 sm:p-4 border rounded-2xl shadow-lg transition-all hover:scale-105 active:scale-95 ${theme === 'vault' ? 'bg-stone-900 border-white/5 text-stone-400' : 'bg-white border-stone-100 text-stone-400'}`}>
+                <Link to="/" className={`p-3 sm:p-4 border rounded-2xl shadow-md transition-all hover:scale-105 active:scale-95 ${theme === 'vault' ? 'bg-stone-900 border-white/5 text-stone-400' : 'bg-white border-stone-100 text-stone-400'}`}>
                     <ArrowLeft size={20} className="sm:w-6 sm:h-6" />
                 </Link>
                 <div>
@@ -626,7 +627,7 @@ const AppContent: React.FC = () => {
                      variant="primary"
                      onClick={() => setIsAddModalOpen(true)} 
                      icon={<Plus size={16} />}
-                     className="shadow-xl"
+                     className="shadow-md"
                    >
                      {t('addItem')}
                    </Button>
@@ -636,7 +637,7 @@ const AppContent: React.FC = () => {
                    onClick={() => setIsExhibitionOpen(true)} 
                    disabled={collection.items.length === 0}
                    icon={<Play size={16} />}
-                   className="shadow-xl"
+                   className="shadow-md"
                  >
                    {t('enterExhibition')}
                  </Button>

--- a/components/ItemCard.tsx
+++ b/components/ItemCard.tsx
@@ -26,8 +26,8 @@ export const ItemCard: React.FC<ItemCardProps> = ({ item, fields, displayFields,
     : 'bg-stone-100 text-stone-600';
   const ratingSurface = theme === 'vault' ? 'bg-stone-900/80 text-white' : 'bg-white/90 text-stone-700';
   const cardShadow = theme === 'vault'
-    ? 'shadow-[0_20px_50px_rgba(0,0,0,0.45)] hover:shadow-[0_24px_60px_rgba(0,0,0,0.55)]'
-    : 'shadow-[0_18px_40px_rgba(15,23,42,0.08)] hover:shadow-[0_24px_50px_rgba(15,23,42,0.12)]';
+    ? 'shadow-[0_10px_30px_rgba(0,0,0,0.35)] hover:shadow-[0_16px_40px_rgba(0,0,0,0.45)]'
+    : 'shadow-sm hover:shadow-md';
   
   const getValue = (fieldId: string) => {
     const val = item.data[fieldId];

--- a/services/db.ts
+++ b/services/db.ts
@@ -442,6 +442,27 @@ export const deleteAsset = async (id: string): Promise<void> => {
     }
 };
 
+export const deleteCloudItem = async (collectionId: string, itemId: string): Promise<void> => {
+  if (!isSupabaseConfigured() || !supabase) return;
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { error } = await supabase
+      .from('items')
+      .delete()
+      .eq('id', itemId)
+      .eq('collection_id', collectionId);
+
+    if (error) {
+      console.warn('Cloud item deletion failed:', error);
+    }
+  } catch (e) {
+    console.warn('Cloud item deletion failed:', e);
+  }
+};
+
 export const loadCollections = async (): Promise<UserCollection[]> => {
   const localCollections = await loadLocalCollections();
 


### PR DESCRIPTION
### Motivation
- Ensure items deleted locally are also removed from the cloud database so deleted items don't reappear without images.
- Soften heavy drop shadows that caused visual artifacts on item cards and header actions.
- Make collection header/back button shadows consistent with the new, lighter card styling.

### Description
- Add `deleteCloudItem(collectionId, itemId)` in `services/db.ts` to delete the item row from the `items` table in Supabase when configured.
- Call `deleteCloudItem` from the `deleteItem` flow in `App.tsx` after local asset removal and import the new helper.
- Reduce card shadow intensity in `components/ItemCard.tsx` by replacing large custom shadow values with milder shadows and `shadow-sm hover:shadow-md` for non-vault theme.
- Refine collection header and primary action shadows in `App.tsx` by replacing `shadow-lg`/`shadow-xl` with `shadow-md` to match the softened visual style.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` (Vite), which launched successfully and served the app.
- Ran a headless Playwright script that navigated to `/collection/sample-vinyl` and captured a screenshot artifact at `artifacts/curio-collection.png` to verify the real collection and item card UI.
- No automated test suites failed during these checks and the visual verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956707d20d483209a02af8b5ff82f96)