### PR TITLE
Dynamically detect Gemini proxy and enable AI when configured

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 // Added Plus icon to the lucide-react imports
 import { Camera, Upload, X, Loader2, Sparkles, Check, Zap, ArrowRight, Trash2, Plus } from 'lucide-react';
 import { UserCollection, CollectionItem } from '../types';
-import { analyzeImage, isAiEnabled } from '../services/geminiService';
+import { analyzeImage, refreshAiEnabled } from '../services/geminiService';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
@@ -123,7 +123,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
     });
 
     const analyzeBatchImages = async (images: string[]) => {
-      if (!isAiEnabled()) {
+      const aiEnabled = await refreshAiEnabled();
+      if (!aiEnabled) {
         setError(t('aiUnavailableManual'));
         return images.map(image => createBatchItem(image));
       }
@@ -186,7 +187,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
     const runId = ++analysisRunId.current;
     setError(null);
     setFormData(createEmptyForm());
-    if (!isAiEnabled()) {
+    const aiEnabled = await refreshAiEnabled();
+    if (!aiEnabled) {
       setError(t('aiUnavailableManual'));
       setStep('verify');
       return;

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,9 +1,12 @@
 import { FieldDefinition, UserCollection } from "../types";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
-const AI_ENABLED = import.meta.env.VITE_AI_ENABLED === 'true';
+const AI_ENABLED_ENV = import.meta.env.VITE_AI_ENABLED;
+const AI_ENABLED = AI_ENABLED_ENV === undefined ? null : AI_ENABLED_ENV === 'true';
 const VOICE_GUIDE_ENABLED = import.meta.env.VITE_VOICE_GUIDE_ENABLED === 'true';
 const REQUEST_TIMEOUT_MS = 30000;
+let aiEnabledCache: boolean | null = AI_ENABLED;
+let aiEnabledPromise: Promise<boolean> | null = null;
 
 const postJson = async <T>(path: string, body: unknown): Promise<T> => {
   const controller = new AbortController();
@@ -26,14 +29,39 @@ const postJson = async <T>(path: string, body: unknown): Promise<T> => {
   }
 };
 
-export const isAiEnabled = () => AI_ENABLED;
-export const isVoiceGuideEnabled = () => AI_ENABLED && VOICE_GUIDE_ENABLED;
+const fetchAiHealth = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/health`);
+    if (!response.ok) return false;
+    const payload = await response.json().catch(() => ({}));
+    return Boolean(payload?.geminiConfigured);
+  } catch {
+    return false;
+  }
+};
+
+export const refreshAiEnabled = async (): Promise<boolean> => {
+  if (aiEnabledCache !== null) return aiEnabledCache;
+  if (aiEnabledPromise) return aiEnabledPromise;
+  aiEnabledPromise = fetchAiHealth()
+    .then((enabled) => {
+      aiEnabledCache = enabled;
+      return enabled;
+    })
+    .finally(() => {
+      aiEnabledPromise = null;
+    });
+  return aiEnabledPromise;
+};
+
+export const isAiEnabled = () => aiEnabledCache === true;
+export const isVoiceGuideEnabled = () => isAiEnabled() && VOICE_GUIDE_ENABLED;
 
 export const analyzeImage = async (
   base64Image: string,
   fields: FieldDefinition[]
 ): Promise<{ title: string; data: Record<string, any>; notes: string }> => {
-  if (!AI_ENABLED) {
+  if (!(await refreshAiEnabled())) {
     throw new Error('AI is disabled');
   }
   return postJson('/api/gemini/analyze', { imageBase64: base64Image, fields });


### PR DESCRIPTION
### Motivation
- The client always relied on `VITE_AI_ENABLED` which defaulted to disabled when unset, causing AI flows to immediately fall back to manual entry even if the server had a configured Gemini key. 
- Make AI availability resilient by probing the server proxy instead of assuming a client-side env var is authoritative when it is not provided. 
- Preserve an explicit `VITE_AI_ENABLED=false` as a hard disable for environments that want AI off. 

### Description
- Change `services/geminiService.ts` to treat `VITE_AI_ENABLED` as a tri-state and add `fetchAiHealth` and `refreshAiEnabled` to query `/api/health` on the API gateway. 
- Cache health checks in `aiEnabledCache` and serialize in-flight checks via `aiEnabledPromise` to avoid duplicate requests. 
- Make `isAiEnabled` and `isVoiceGuideEnabled` reflect the dynamic health state and gate `analyzeImage` with `refreshAiEnabled`. 
- Update `components/AddItemModal.tsx` to call `refreshAiEnabled` before starting single-image or batch analysis and import the new function. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569d6d187c832088884dd658d78ddc)