### PR TITLE
Add /api/health and /api/gemini/analyze; dynamic AI health check

### DIFF
--- a/api/gemini/analyze.js
+++ b/api/gemini/analyze.js
@@ -1,0 +1,81 @@
+import { GoogleGenAI, Type } from '@google/genai';
+
+const mapFieldTypeToSchemaType = (type) => {
+  switch (type) {
+    case 'number':
+      return Type.NUMBER;
+    case 'boolean':
+      return Type.BOOLEAN;
+    case 'text':
+    case 'long_text':
+    case 'select':
+    case 'date':
+    default:
+      return Type.STRING;
+  }
+};
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    return res.status(503).json({ error: 'GEMINI_API_KEY is not configured' });
+  }
+
+  const { imageBase64, fields } = req.body || {};
+  if (!imageBase64 || !Array.isArray(fields)) {
+    return res.status(400).json({ error: 'Missing imageBase64 or fields' });
+  }
+
+  const properties = {
+    title: { type: Type.STRING, description: 'A short, descriptive title for the item.' },
+    notes: { type: Type.STRING, description: 'A brief summary of visual observations about the item.' },
+  };
+
+  fields.forEach((field) => {
+    properties[field.id] = {
+      type: mapFieldTypeToSchemaType(field.type),
+      description: `Value for ${field.label}.`,
+    };
+    if (field.type === 'select' && field.options) {
+      properties[field.id].description += ` Must be one of: ${field.options.join(', ')}`;
+    }
+  });
+
+  try {
+    const ai = new GoogleGenAI({ apiKey });
+    const response = await ai.models.generateContent({
+      model: 'gemini-3-flash-preview',
+      contents: {
+        parts: [
+          { inlineData: { mimeType: 'image/jpeg', data: imageBase64 } },
+          {
+            text: 'Analyze this image of a collectible item. Extract metadata based on the provided schema. Be precise. If a field cannot be determined, leave it null.',
+          },
+        ],
+      },
+      config: {
+        responseMimeType: 'application/json',
+        responseSchema: {
+          type: Type.OBJECT,
+          properties,
+        },
+      },
+    });
+
+    const result = JSON.parse(response.text || '{}');
+    const { title, notes, ...data } = result || {};
+    return res.status(200).json({
+      title: title || 'New Item',
+      notes: notes || '',
+      data: data || {},
+    });
+  } catch (error) {
+    console.error('AI Analysis Failed:', error);
+    return res.status(500).json({ error: 'AI analysis failed' });
+  }
+}

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,4 @@
+export default function handler(_req, res) {
+  const geminiConfigured = Boolean(process.env.GEMINI_API_KEY);
+  res.status(200).json({ ok: true, geminiConfigured });
+}

--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -3,7 +3,7 @@ import React, { useState, useRef, useEffect, useMemo } from 'react';
 // Added Plus icon to the lucide-react imports
 import { Camera, Upload, X, Loader2, Sparkles, Check, Zap, ArrowRight, Trash2, Plus } from 'lucide-react';
 import { UserCollection, CollectionItem } from '../types';
-import { analyzeImage, isAiEnabled } from '../services/geminiService';
+import { analyzeImage, refreshAiEnabled } from '../services/geminiService';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
@@ -123,7 +123,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
     });
 
     const analyzeBatchImages = async (images: string[]) => {
-      if (!isAiEnabled()) {
+      const aiEnabled = await refreshAiEnabled();
+      if (!aiEnabled) {
         setError(t('aiUnavailableManual'));
         return images.map(image => createBatchItem(image));
       }
@@ -186,7 +187,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
     const runId = ++analysisRunId.current;
     setError(null);
     setFormData(createEmptyForm());
-    if (!isAiEnabled()) {
+    const aiEnabled = await refreshAiEnabled();
+    if (!aiEnabled) {
       setError(t('aiUnavailableManual'));
       setStep('verify');
       return;

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,9 +1,12 @@
 import { FieldDefinition, UserCollection } from "../types";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
-const AI_ENABLED = import.meta.env.VITE_AI_ENABLED === 'true';
+const AI_ENABLED_ENV = import.meta.env.VITE_AI_ENABLED;
+const AI_ENABLED = AI_ENABLED_ENV === undefined ? null : AI_ENABLED_ENV === 'true';
 const VOICE_GUIDE_ENABLED = import.meta.env.VITE_VOICE_GUIDE_ENABLED === 'true';
 const REQUEST_TIMEOUT_MS = 30000;
+let aiEnabledCache: boolean | null = AI_ENABLED;
+let aiEnabledPromise: Promise<boolean> | null = null;
 
 const postJson = async <T>(path: string, body: unknown): Promise<T> => {
   const controller = new AbortController();
@@ -26,14 +29,39 @@ const postJson = async <T>(path: string, body: unknown): Promise<T> => {
   }
 };
 
-export const isAiEnabled = () => AI_ENABLED;
-export const isVoiceGuideEnabled = () => AI_ENABLED && VOICE_GUIDE_ENABLED;
+const fetchAiHealth = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/health`);
+    if (!response.ok) return false;
+    const payload = await response.json().catch(() => ({}));
+    return Boolean(payload?.geminiConfigured);
+  } catch {
+    return false;
+  }
+};
+
+export const refreshAiEnabled = async (): Promise<boolean> => {
+  if (aiEnabledCache !== null) return aiEnabledCache;
+  if (aiEnabledPromise) return aiEnabledPromise;
+  aiEnabledPromise = fetchAiHealth()
+    .then((enabled) => {
+      aiEnabledCache = enabled;
+      return enabled;
+    })
+    .finally(() => {
+      aiEnabledPromise = null;
+    });
+  return aiEnabledPromise;
+};
+
+export const isAiEnabled = () => aiEnabledCache === true;
+export const isVoiceGuideEnabled = () => isAiEnabled() && VOICE_GUIDE_ENABLED;
 
 export const analyzeImage = async (
   base64Image: string,
   fields: FieldDefinition[]
 ): Promise<{ title: string; data: Record<string, any>; notes: string }> => {
-  if (!AI_ENABLED) {
+  if (!(await refreshAiEnabled())) {
     throw new Error('AI is disabled');
   }
   return postJson('/api/gemini/analyze', { imageBase64: base64Image, fields });


### PR DESCRIPTION
### Motivation
- Fix the 404 observed when the client tried to call `/api/health` by adding a server route that reports Gemini configuration.
- Run image analysis server-side using `GEMINI_API_KEY` so the client does not rely solely on a local `VITE_AI_ENABLED` env var.
- Make AI availability resilient by letting the client probe the API gateway instead of assuming the client-side env var when it is unset.
- Return clear statuses when the key is missing to avoid opaque client failures during analysis.

### Description
- Add `api/health.js` which returns `{ ok: true, geminiConfigured }` based on `process.env.GEMINI_API_KEY`.
- Add `api/gemini/analyze.js` which accepts `POST` requests with `imageBase64` and `fields` and calls `@google/genai` to generate a JSON response conforming to a mapped schema.
- Update `services/geminiService.ts` to treat `VITE_AI_ENABLED` as a tri-state, add `fetchAiHealth` and `refreshAiEnabled` with caching and serialized in-flight checks, and gate `analyzeImage` behind `refreshAiEnabled`.
- Update `components/AddItemModal.tsx` to call `refreshAiEnabled` before single-image and batch analyses and import the new function.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569d6d187c832088884dd658d78ddc)