### PR TITLE
Fix export preview aspect ratio sizing

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -62,7 +62,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     return (
       <div 
         id="card-preview"
-        className={`shadow-2xl transition-all duration-300 overflow-hidden relative group select-none h-full w-auto mx-auto print:h-auto print:w-[100mm]`}
+        className={`shadow-2xl transition-all duration-300 overflow-hidden relative group select-none w-full max-w-[420px] sm:max-w-[520px] h-auto mx-auto print:h-auto print:w-[100mm]`}
         style={{ aspectRatio: aspectRatio.replace(':', ' / ') }}
       >
         <div className={`w-full h-full ${containerStyles[style]} transition-all duration-300`}>


### PR DESCRIPTION
### Motivation
- The export card preview was stretching to fill available height so changing `aspectRatio` had no visible effect. 
- The rendered preview looked excessively tall and visually incorrect for non-square ratios. 
- Constrain the preview container so the CSS `aspect-ratio` can determine the rendered dimensions. 

### Description
- Updated the preview container in `components/ExportModal.tsx` to use `w-full max-w-[420px] sm:max-w-[520px] h-auto` instead of `h-full w-auto`. 
- The component still applies the selected `aspectRatio` via `style={{ aspectRatio: aspectRatio.replace(':', ' / ') }}` so aspect changes now control size. 
- Kept existing print sizing (`print:w-[100mm]`) and other preview internals unchanged. 

### Testing
- Launched the dev server with `npm run dev` and Vite started successfully. 
- Ran a Playwright script that opened the app, triggered the export modal, and produced a screenshot at `artifacts/export-modal-aspect-ratio.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a8478ddc832091714e16ba066fa9)