### PR TITLE
Preserve user intent across auth and add fallback sample collections

### DIFF
--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -9,9 +9,10 @@ import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses 
 interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onAuthSuccess?: () => void;
 }
 
-export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
+export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onAuthSuccess }) => {
   const { t } = useTranslation();
   const { theme } = useTheme();
   const [mode, setMode] = useState<'signin' | 'signup'>('signin');
@@ -63,6 +64,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
     setError(null);
     try {
       await (mode === 'signin' ? signInWithEmail(email, password) : signUpWithEmail(email, password));
+      onAuthSuccess?.();
       onClose();
     } catch (err: any) {
       setError(err.message || "Authentication failed");


### PR DESCRIPTION
### Motivation
- Keep the first-run experience intact by showing sample collections when no cloud or local data exists. 
- Preserve and resume the user’s intended action (add item or create collection) after they authenticate. 
- Ensure collection creation is gated by authentication and avoid leaving stale pending actions. 
- Improve onboarding continuity when Supabase is unavailable or there are no user collections. 

### Description
- Add `fallbackSampleCollections` derived from `INITIAL_COLLECTIONS` and use it when both `cloudCollections` and `localCollections` are empty. 
- Introduce state to capture intent with `pendingAuthAction` and `authActionQueue` and resume actions via `handleAuthSuccess` after sign-in. 
- Add `handleCreateCollectionAction` and update `handleAddAction` to set `pendingAuthAction` and open the auth modal when unauthenticated, and enforce auth inside `handleCreateCollection`. 
- Wire `AuthModal` with a new `onAuthSuccess` prop and call it on successful sign-in, and clear pending intent on auth modal close via `handleAuthClose`. 

### Testing
- No automated tests were run for this change. 
- Manual verification steps were not executed as part of this PR. 
- No test failures reported. 
- Behavior validated via code inspection during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956fe915ba48320aef6e1b22ff65492)