### PR TITLE
Tighten collection list spacing on small screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -728,8 +728,8 @@ const AppContent: React.FC = () => {
             <div
               className={`${
                 viewMode === 'grid'
-                  ? 'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8'
-                  : 'columns-2 md:columns-3 lg:columns-4 [column-gap:2rem]'
+                  ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 sm:gap-8'
+                  : 'columns-1 sm:columns-2 md:columns-3 lg:columns-4 [column-gap:1.5rem] sm:[column-gap:2rem]'
               } w-full`}
             >
                 {filteredItems.map(item => (


### PR DESCRIPTION
### Motivation
- Reduce excessive spacing on the smallest breakpoints so collection items feel more balanced on mobile. 
- Keep responsive parity between the grid and masonry layouts so they scale similarly across breakpoints. 
- Preserve existing `ItemCard` layout switching while adjusting only list spacing. 

### Description
- Updated the collection list classes in `App.tsx` to use `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 sm:gap-8` when `viewMode === 'grid'`. 
- Updated the masonry variant to `columns-1 sm:columns-2 md:columns-3 lg:columns-4 [column-gap:1.5rem] sm:[column-gap:2rem]` for tighter mobile column gaps. 
- Left the `ItemCard` prop logic as `layout={viewMode === 'grid' ? 'grid' : 'masonry'}` so rendering behavior is unchanged. 

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, indicating no build-time errors. 
- Ran a Playwright script that launched Chromium, navigated to the app, and produced a screenshot artifact (`collection-grid.png`) successfully. 
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695704044c7483209c1e793fc4c4c338)