### PR TITLE
Viewport-height fallback and small-screen photo-action visibility

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -829,7 +829,7 @@ const AppContent: React.FC = () => {
 
                   {!isReadOnly && (
                     <>
-                      <div className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${hasPhoto ? 'opacity-0 group-hover:opacity-100' : 'opacity-100'}`}>
+                      <div className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ${hasPhoto ? 'opacity-100 sm:opacity-0 sm:group-hover:opacity-100' : 'opacity-100'}`}>
                           <button disabled={isProcessing} onClick={() => fileInputRef.current?.click()} className="bg-white/90 hover:bg-white text-stone-900 px-6 sm:px-8 py-2 sm:py-3 rounded-full font-bold shadow-2xl backdrop-blur-md transition-all hover:scale-105 flex items-center gap-2 sm:gap-3 disabled:opacity-50 text-xs sm:text-sm">
                             {isProcessing ? <Loader2 size={16} className="animate-spin" /> : <Camera size={16} />}
                             {t('updatePhoto')}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -60,7 +60,7 @@ export const Layout: React.FC<LayoutProps> = ({ children, onOpenAuth, onSignOut,
       : 'from-stone-50 via-stone-50 to-transparent';
 
   return (
-    <div className={`min-h-screen font-sans selection:bg-amber-200 transition-colors ${shellClass}`}>
+    <div className={`min-h-screen min-h-[100dvh] font-sans selection:bg-amber-200 transition-colors ${shellClass}`}>
       <header className={`sticky top-0 z-20 backdrop-blur-md border-b pt-[env(safe-area-inset-top,0px)] ${headerSurface}`}>
         <div className="max-w-4xl mx-auto px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
           <Link to="/" className="flex items-center gap-2 group">


### PR DESCRIPTION
### Motivation
- Use dynamic viewport height to avoid mobile browser chrome causing layout jumps or clipped content.
- Provide a broad fallback for environments that do not support dynamic `dvh` units.
- Ensure the photo update action is accessible on small touch devices where hover is not available.
- Improve cross-device UX for small screens.

### Description
- In `components/Layout.tsx` add a fallback by prepending `min-h-screen` before `min-h-[100dvh]` to cover browsers without `dvh` support.
- In `App.tsx` change the photo-action classes from `opacity-0 group-hover:opacity-100` to `opacity-100 sm:opacity-0 sm:group-hover:opacity-100` so the update button is visible by default on small screens and uses hover on larger screens.
- Modified files: `components/Layout.tsx` and `App.tsx`.
- Kept the file input hidden and wired to the visible button to preserve the existing photo upload behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957030d8ec48320bff3a1de3360a84b)