### PR TITLE
Add PWA manifest, icons, and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#f5f5f4" />
     <title>Curio - Personal Museum</title>
+    <link rel="manifest" href="/manifest.webmanifest" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.tsx
+++ b/index.tsx
@@ -13,3 +13,11 @@ root.render(
     <App />
   </React.StrictMode>
 );
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((error) => {
+      console.error('Service worker registration failed', error);
+    });
+  });
+}

--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192" role="img" aria-label="Curio icon">
+  <rect width="192" height="192" rx="40" fill="#111827" />
+  <circle cx="96" cy="96" r="64" fill="#f5f5f4" />
+  <text x="96" y="112" text-anchor="middle" font-family="'Inter', sans-serif" font-size="64" fill="#111827">C</text>
+</svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="Curio icon">
+  <rect width="512" height="512" rx="96" fill="#111827" />
+  <circle cx="256" cy="256" r="176" fill="#f5f5f4" />
+  <text x="256" y="300" text-anchor="middle" font-family="'Inter', sans-serif" font-size="180" fill="#111827">C</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "Curio - Personal Museum",
+  "short_name": "Curio",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f5f5f4",
+  "theme_color": "#f5f5f4",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,50 @@
+const CACHE_NAME = 'curio-shell-v1';
+const SHELL_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/icon-192.svg',
+  '/icon-512.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(SHELL_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => cachedResponse);
+    })
+  );
+});


### PR DESCRIPTION
### Motivation
- Enable basic PWA functionality and offline app-shell launch by adding a web manifest, icons, and a service worker.
- Improve mobile UX by enabling full-bleed layouts with `viewport-fit=cover` and setting the browser `theme-color`.
- Provide app identity assets in `public/` so installs and homescreen icons render correctly.
- Keep the service worker minimal to provide safe, cache-first app-shell support.

### Description
- Add `public/manifest.webmanifest` with `name`, `short_name`, `start_url`, `display`, `background_color`, `theme_color`, and `icons` entries.
- Add SVG icons at `public/icon-192.svg` and `public/icon-512.svg` and reference them from the manifest.
- Add a minimal service worker at `public/sw.js` that caches the app shell (`/`, `/index.html`, the manifest, and icons) and serves cached responses when available.
- Update `index.html` to include `viewport-fit=cover`, a `<meta name="theme-color">`, and a `<link rel="manifest" href="/manifest.webmanifest">`, and update `index.tsx` to register the service worker on load.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69571177a6c083208bd338ec41d2cc5c)