### PR TITLE
Add “Take Photo” button and enable rear-camera capture in AddItemModal

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -319,6 +319,9 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
             <p className={`text-sm sm:text-base ${mutedText} max-w-xs mx-auto`}>{t('geminiExtracting')}</p>
         </div>
         <div className="flex flex-col gap-2 sm:gap-3">
+            <Button variant="secondary" onClick={() => fileInputRef.current?.click()} size="lg" icon={<Camera size={18} />}>
+                {t('takePhoto')}
+            </Button>
             <Button onClick={() => fileInputRef.current?.click()} size="lg" icon={<Upload size={18} />}>
                 {imagePreview ? t('changePhoto') : t('uploadPhoto')}
             </Button>
@@ -327,7 +330,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
             </Button>
             <button onClick={switchToManual} className="text-xs sm:text-sm font-medium text-stone-400 hover:text-stone-600">{t('skipManual')}</button>
         </div>
-        <input type="file" ref={fileInputRef} className="hidden" accept="image/*" onChange={handleFileChange} />
+        <input type="file" ref={fileInputRef} className="hidden" accept="image/*" capture="environment" onChange={handleFileChange} />
         <input type="file" ref={batchInputRef} className="hidden" accept="image/*" multiple onChange={handleBatchFileChange} />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Make capturing photos on mobile open the rear camera by default for a better capture experience.
- Provide an explicit, discoverable control to trigger camera capture labeled “Take Photo”.
- Preserve the existing upload and batch workflows as fallbacks for desktop and multi-file import.

### Description
- Add a dedicated `Take Photo` button that calls the primary file input (`fileInputRef.current?.click()`).
- Set the main image input to use `capture="environment"` to prefer the rear camera on mobile devices.
- Keep the existing `Upload` and `Batch` buttons and the multiple-file `batchInputRef` behavior intact.
- Changes are limited to `components/AddItemModal.tsx` to implement the UI and input attribute.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, indicating the app served successfully. (succeeded)
- Ran a Playwright script that opened the app, opened the Add Item modal, and captured a screenshot of the modal to verify the new button is present. (succeeded)
- No unit or integration test suite was executed as part of this change. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957129c76a88320866a8154db08f50d)