### PR TITLE
Enhance card tappable affordance with persistent rings and shadows

### DIFF
--- a/components/CollectionCard.tsx
+++ b/components/CollectionCard.tsx
@@ -28,13 +28,17 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({ collection, onCl
   const badgeSurface = theme === 'vault'
     ? 'bg-white/10 text-white border border-white/10'
     : 'bg-white/80 text-stone-700 border border-white/60';
+  const tapRing = theme === 'vault' ? 'ring-1 ring-white/10' : 'ring-1 ring-black/5';
+  const tapShadow = theme === 'vault'
+    ? 'shadow-[0_12px_30px_rgba(0,0,0,0.35)] hover:shadow-[0_18px_40px_rgba(0,0,0,0.45)]'
+    : 'shadow-[0_6px_18px_rgba(15,23,42,0.08)] hover:shadow-[0_12px_26px_rgba(15,23,42,0.14)]';
   
   const displayIcon = collection.icon || template.icon;
 
   return (
     <div 
       onClick={onClick}
-      className={`group relative p-8 rounded-[2.5rem] border ${baseSurface} ${accentBorder[template.accentColor] || accentBorder['stone']} transition-all duration-500 cursor-pointer shadow-sm hover:shadow-xl flex flex-col justify-between h-52 overflow-hidden motion-card`}
+      className={`group relative p-8 rounded-[2.5rem] border ${baseSurface} ${accentBorder[template.accentColor] || accentBorder['stone']} transition-all duration-500 cursor-pointer ${tapShadow} ${tapRing} flex flex-col justify-between h-52 overflow-hidden motion-card`}
     >
       <div className="absolute top-0 right-0 p-8 opacity-10 text-7xl select-none group-hover:scale-110 group-hover:rotate-12 transition-transform duration-700 pointer-events-none">
         {displayIcon}
@@ -60,7 +64,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({ collection, onCl
         <span className={`inline-flex items-center px-4 py-1.5 rounded-full text-sm font-semibold backdrop-blur-sm shadow-sm ${badgeSurface}`}>
           {t(itemCount === 1 ? 'itemCount' : 'itemsCount', { n: itemCount })}
         </span>
-        <div className={`w-10 h-10 rounded-full flex items-center justify-center transition-all shadow-sm group-hover:shadow-md ${theme === 'vault' ? 'bg-white/10 text-white group-hover:bg-white/20' : 'bg-white text-stone-400 group-hover:text-stone-900 group-hover:bg-white'}`}>
+        <div className={`w-10 h-10 rounded-full flex items-center justify-center transition-all shadow-sm group-hover:shadow-md border ${theme === 'vault' ? 'bg-white/10 text-white/80 border-white/20 group-hover:bg-white/20 group-hover:text-white' : 'bg-white text-stone-500 border-stone-200/70 group-hover:text-stone-900 group-hover:bg-white'}`}>
           <ChevronRight size={20} />
         </div>
       </div>

--- a/components/ItemCard.tsx
+++ b/components/ItemCard.tsx
@@ -26,8 +26,9 @@ export const ItemCard: React.FC<ItemCardProps> = ({ item, fields, displayFields,
     : 'bg-stone-100 text-stone-600';
   const ratingSurface = theme === 'vault' ? 'bg-stone-900/80 text-white' : 'bg-white/90 text-stone-700';
   const cardShadow = theme === 'vault'
-    ? 'shadow-[0_10px_30px_rgba(0,0,0,0.35)] hover:shadow-[0_16px_40px_rgba(0,0,0,0.45)]'
-    : 'shadow-sm hover:shadow-md';
+    ? 'shadow-[0_12px_30px_rgba(0,0,0,0.35)] hover:shadow-[0_16px_40px_rgba(0,0,0,0.45)]'
+    : 'shadow-[0_6px_18px_rgba(15,23,42,0.08)] hover:shadow-[0_10px_24px_rgba(15,23,42,0.12)]';
+  const tapRing = theme === 'vault' ? 'ring-1 ring-white/10' : 'ring-1 ring-black/5';
   
   const getValue = (fieldId: string) => {
     const val = item.data[fieldId];
@@ -52,7 +53,7 @@ export const ItemCard: React.FC<ItemCardProps> = ({ item, fields, displayFields,
   return (
     <div 
       onClick={onClick}
-      className={`group rounded-2xl transition-all duration-300 overflow-hidden border cursor-pointer flex flex-col ${layout === 'grid' ? 'h-full' : ''} motion-card ${cardSurface} ${cardShadow}`}
+      className={`group rounded-2xl transition-all duration-300 overflow-hidden border cursor-pointer flex flex-col ${layout === 'grid' ? 'h-full' : ''} motion-card ${cardSurface} ${cardShadow} ${tapRing}`}
     >
       <div className={`${layout === 'grid' ? 'aspect-[4/3]' : ''} ${theme === 'vault' ? 'bg-stone-800' : 'bg-stone-100'} overflow-hidden relative`}>
         <ItemImage 


### PR DESCRIPTION
### Motivation
- Provide persistent visual tap cues (borders, micro-shadows) so cards read as tappable even on touch devices without hover.  
- Ensure hover-only effects have a sensible default state on mobile by exposing subtle ring/shadow styles.  
- Improve discoverability of the chevron action indicator by making it visible without hover.  

### Description
- Add `tapRing` and richer `tapShadow` utility strings and apply them to the `CollectionCard` wrapper to provide a persistent ring and base shadow.  
- Make the collection chevron container a bordered element with default visible colors so the chevron is visible without hover.  
- Tweak `ItemCard` shadow values and add the `tapRing` class to the item wrapper so item cards also show a persistent ring/shadow affordance.  
- All changes are applied via Tailwind utility class strings in `components/CollectionCard.tsx` and `components/ItemCard.tsx` for theme-aware visual treatments.  

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which launched `vite` successfully.  
- Ran a Playwright screenshot script that opened the app and produced `artifacts/cards-tap-cues.png`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695712a8dbe08320ba726049ed4ad39a)