### PR TITLE
Add safe-area padding to overlay wrappers

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -496,7 +496,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({ isOpen, onClose, col
   );
 
   return (
-    <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 ${overlayClass} backdrop-blur-sm`}>
+    <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-[calc(1rem+env(safe-area-inset-bottom,0px))] pl-[calc(1rem+env(safe-area-inset-left,0px))] pr-[calc(1rem+env(safe-area-inset-right,0px))] ${overlayClass} backdrop-blur-sm`}>
       <div className={`${surfaceClass} rounded-2xl sm:rounded-3xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-hidden flex flex-col motion-panel`}>
         <div className={`flex items-center justify-between p-4 sm:p-6 border-b ${borderClass}`}>
           <h2 className={`font-serif font-bold text-lg sm:text-xl ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}>{t('addItem')}</h2>

--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -32,7 +32,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onAuthSuc
 
   if (!supabaseActive) {
     return (
-      <div className={`fixed inset-0 z-[100] flex items-center justify-center p-4 ${overlayClass} backdrop-blur-md`}>
+      <div className={`fixed inset-0 z-[100] flex items-center justify-center p-4 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-[calc(1rem+env(safe-area-inset-bottom,0px))] pl-[calc(1rem+env(safe-area-inset-left,0px))] pr-[calc(1rem+env(safe-area-inset-right,0px))] ${overlayClass} backdrop-blur-md`}>
         <div className={`${surfaceClass} rounded-[2.5rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col border motion-panel`}>
           <div className={`flex items-center justify-between p-8 border-b ${dividerBorder}`}>
             <div>
@@ -74,7 +74,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onAuthSuc
   };
 
   return (
-    <div className={`fixed inset-0 z-[100] flex items-center justify-center p-4 ${overlayClass} backdrop-blur-md`}>
+    <div className={`fixed inset-0 z-[100] flex items-center justify-center p-4 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-[calc(1rem+env(safe-area-inset-bottom,0px))] pl-[calc(1rem+env(safe-area-inset-left,0px))] pr-[calc(1rem+env(safe-area-inset-right,0px))] ${overlayClass} backdrop-blur-md`}>
       <div className={`${surfaceClass} rounded-[2.5rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col border motion-panel`}>
         <div className={`flex items-center justify-between p-8 border-b ${dividerBorder}`}>
           <div>

--- a/components/CreateCollectionModal.tsx
+++ b/components/CreateCollectionModal.tsx
@@ -50,7 +50,7 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({ is
   };
 
   return (
-    <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 ${overlayClass} backdrop-blur-sm`}>
+    <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-[calc(1rem+env(safe-area-inset-bottom,0px))] pl-[calc(1rem+env(safe-area-inset-left,0px))] pr-[calc(1rem+env(safe-area-inset-right,0px))] ${overlayClass} backdrop-blur-sm`}>
       <div className={`${surfaceClass} rounded-2xl shadow-xl w-full max-w-md overflow-hidden flex flex-col motion-panel border`}>
         <div className={`flex items-center justify-between p-4 border-b ${dividerBorder}`}>
           <h2 className={`font-serif font-bold text-lg ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}>{t('newArchive')}</h2>

--- a/components/ExhibitionView.tsx
+++ b/components/ExhibitionView.tsx
@@ -22,7 +22,7 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({ collection, init
   const prev = () => setIndex((i) => (i - 1 + collection.items.length) % collection.items.length);
 
   return (
-    <div className="fixed inset-0 z-[70] bg-stone-950 text-white flex flex-col animate-in fade-in duration-500 overflow-y-auto sm:overflow-hidden">
+    <div className="fixed inset-0 z-[70] bg-stone-950 text-white flex flex-col animate-in fade-in duration-500 overflow-y-auto sm:overflow-hidden pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]">
       <header className="p-6 sm:p-8 flex justify-between items-center bg-gradient-to-b from-stone-950/80 to-transparent sticky top-0 z-10">
         <div>
           <h2 className="text-[10px] font-mono tracking-[0.2em] uppercase opacity-40 mb-0.5">{collection.name}</h2>

--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -128,7 +128,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
 
   return (
     <div
-      className={`fixed inset-0 z-50 bg-stone-950/90 backdrop-blur-md animate-in fade-in duration-200 print:bg-white print:static print:block flex flex-col md:block md:[--sheet-height:0px] ${isExpanded ? '[--sheet-height:85dvh]' : '[--sheet-height:55dvh]'}`}
+      className={`fixed inset-0 z-50 bg-stone-950/90 backdrop-blur-md animate-in fade-in duration-200 print:bg-white print:static print:block flex flex-col md:block md:[--sheet-height:0px] pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)] ${isExpanded ? '[--sheet-height:85dvh]' : '[--sheet-height:55dvh]'}`}
     >
       <div className="flex-1 min-h-0 flex flex-col items-center justify-center px-6 pt-6 pb-6 md:absolute md:inset-0 md:pb-6 md:pr-96 md:pt-6 overflow-hidden print:static">
          <div className="h-full w-full flex items-center justify-center print:block">{renderCardPreview()}</div>

--- a/components/FilterModal.tsx
+++ b/components/FilterModal.tsx
@@ -46,7 +46,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({ isOpen, onClose, field
   const activeCount = Object.values(localFilters).filter(Boolean).length;
 
   return (
-    <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 ${overlayClass} backdrop-blur-sm`}>
+    <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 pt-[calc(1rem+env(safe-area-inset-top,0px))] pb-[calc(1rem+env(safe-area-inset-bottom,0px))] pl-[calc(1rem+env(safe-area-inset-left,0px))] pr-[calc(1rem+env(safe-area-inset-right,0px))] ${overlayClass} backdrop-blur-sm`}>
       <div className={`${surfaceClass} rounded-[1.75rem] shadow-2xl w-full max-w-lg overflow-hidden flex flex-col max-h-[85vh] motion-panel border`}>
         <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">

--- a/components/MuseumGuide.tsx
+++ b/components/MuseumGuide.tsx
@@ -128,7 +128,7 @@ export const MuseumGuide: React.FC<MuseumGuideProps> = ({ collection, isOpen, on
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center p-6 bg-stone-950/80 backdrop-blur-xl animate-in fade-in duration-300">
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-6 pt-[calc(1.5rem+env(safe-area-inset-top,0px))] pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))] pl-[calc(1.5rem+env(safe-area-inset-left,0px))] pr-[calc(1.5rem+env(safe-area-inset-right,0px))] bg-stone-950/80 backdrop-blur-xl animate-in fade-in duration-300">
       <div className="bg-white rounded-[3rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col items-center p-12 text-center relative">
         <button onClick={onClose} className="absolute top-8 right-8 p-2 hover:bg-stone-100 rounded-full text-stone-400 transition-colors">
           <X size={24} />


### PR DESCRIPTION
### Motivation
- Ensure modal controls and close buttons are not obscured by device notches or home indicators on iOS-style devices.
- Apply consistent safe-area handling to modal and full-screen overlay containers so UI chrome remains accessible.

### Description
- Add safe-area inset padding to modal wrapper containers in `components/AuthModal.tsx`, `CreateCollectionModal.tsx`, `AddItemModal.tsx`, and `FilterModal.tsx` using `pt/pb/pl/pr` with `calc(...env(safe-area-inset-*,0px))`.
- Apply the same safe-area pattern to full-screen overlays in `components/ExhibitionView.tsx` and `components/ExportModal.tsx` using `env(safe-area-inset-*)` on the root wrapper.
- Update the `components/MuseumGuide.tsx` overlay wrapper to include `pt/pb/pl/pr` safe-area padding (using slightly larger base spacing) so its close control stays visible.

### Testing
- Started the dev server with `npm run dev` and it reported Vite ready successfully (served at `http://localhost:4173/`).
- Ran a Playwright script that navigated to the app, attempted to open an example modal, and captured a screenshot `artifacts/modal-safe-area.png`, which completed successfully and produced the artifact.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957140a24f88320a0160e81a1f804da)