### PR TITLE
Prepare Gemini proxy for external hosting and fix API base handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY=...
 
 # AI gateway
 VITE_AI_ENABLED=true
-VITE_API_BASE_URL=http://localhost:8787
+VITE_API_BASE_URL=http://localhost:8787/api
 VITE_VOICE_GUIDE_ENABLED=false
 
 # Timestamp-based conflict resolution (requires columns in supabase/1_schema.sql)
@@ -50,6 +50,14 @@ The Gemini proxy expects:
 
 ```
 GEMINI_API_KEY=...
+```
+
+### Production API base
+
+When deploying behind a reverse proxy (e.g., Vercel rewrites), set:
+
+```
+VITE_API_BASE_URL=/api
 ```
 
 ## Supabase Setup

--- a/server/geminiProxy.js
+++ b/server/geminiProxy.js
@@ -26,8 +26,11 @@ const loadEnvFile = (filePath) => {
   });
 };
 
-// Load .env.local for the proxy since Node doesn't read Vite env files automatically.
-ENV_FILES.forEach((file) => loadEnvFile(path.join(ROOT_DIR, file)));
+const shouldLoadEnvFiles = process.env.NODE_ENV !== 'production';
+if (shouldLoadEnvFiles) {
+  // Load .env.local for the proxy since Node doesn't read Vite env files automatically.
+  ENV_FILES.forEach((file) => loadEnvFile(path.join(ROOT_DIR, file)));
+}
 
 const app = express();
 const port = process.env.PORT || 8787;
@@ -119,6 +122,11 @@ app.post('/api/gemini/analyze', async (req, res) => {
   }
 });
 
-app.listen(port, () => {
-  console.log(`Gemini proxy listening on :${port}`);
-});
+const isDirectRun = process.argv[1] === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  app.listen(port, () => {
+    console.log(`Gemini proxy listening on :${port}`);
+  });
+}
+
+export default app;

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -31,7 +31,7 @@ const postJson = async <T>(path: string, body: unknown): Promise<T> => {
 
 const fetchAiHealth = async (): Promise<boolean> => {
   try {
-    const response = await fetch(`${API_BASE_URL}/api/health`);
+    const response = await fetch(`${API_BASE_URL}/health`);
     if (!response.ok) return false;
     const payload = await response.json().catch(() => ({}));
     return Boolean(payload?.geminiConfigured);
@@ -64,7 +64,7 @@ export const analyzeImage = async (
   if (!(await refreshAiEnabled())) {
     throw new Error('AI is disabled');
   }
-  return postJson('/api/gemini/analyze', { imageBase64: base64Image, fields });
+  return postJson('/gemini/analyze', { imageBase64: base64Image, fields });
 };
 
 export const connectMuseumGuide = async (_col: UserCollection, _cb: any, _inst?: string) => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://gemini-proxy-xyz.a.run.app/api/:path*"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Prevent duplicate `/api` prefixes when the client builds requests using `VITE_API_BASE_URL` and relative paths. 
- Make the Gemini proxy safe to import for external hosting and testing by avoiding unconditional process-level side effects. 
- Stop loading local env files in production so runtime environment variables are authoritative. 
- Provide a Vercel rewrites configuration and document the correct production `VITE_API_BASE_URL` value.

### Description
- Updated `services/geminiService.ts` to call the health endpoint at `${API_BASE_URL}/health` and to post analyze requests to `/gemini/analyze` so the `/api` prefix is only applied via `VITE_API_BASE_URL` when desired. 
- Modified `server/geminiProxy.js` to skip loading `.env`/`.env.local` when `NODE_ENV === 'production'`, only call `app.listen` when the file is run directly, and `export default app` for importability. 
- Added `vercel.json` with rewrites forwarding `/api/:path*` to the external Cloud Run proxy URL and routing other requests to `/index.html`. 
- Updated `README.md` to show a local `VITE_API_BASE_URL` and document the recommended production setting `VITE_API_BASE_URL=/api`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957922667788320bf0a48f37133b73e)