### PR TITLE
Drop photo_path fallback in item sync

### DIFF
--- a/services/db.ts
+++ b/services/db.ts
@@ -154,7 +154,7 @@ const mapCloudCollections = (cols: any[], items: any[]): UserCollection[] => {
       .map(i => ({
         id: i.id,
         collectionId: i.collection_id,
-        photoUrl: i.photo_path,
+        photoUrl: i.photo_display_path,
         title: i.title,
         rating: i.rating,
         data: i.data,
@@ -288,7 +288,8 @@ export const saveCollection = async (collection: UserCollection): Promise<void> 
             notes: item.notes,
             rating: item.rating,
             data: item.data,
-            photo_path: photoPath,
+            photo_display_path: photoPath,
+            photo_original_path: item.photoUrl === 'asset' ? photoPath : null,
             seed_key: item.seedKey
           };
           if (SUPABASE_SYNC_TIMESTAMPS) {

--- a/supabase/1_schema.sql
+++ b/supabase/1_schema.sql
@@ -83,6 +83,8 @@ create table if not exists public.items (
   rating int not null default 0 check (rating >= 0 and rating <= 5),
   data jsonb not null default '{}'::jsonb,
   photo_path text,
+  photo_original_path text,
+  photo_display_path text,
   seed_key text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
@@ -106,6 +108,8 @@ alter table public.items add column if not exists seed_key text;
 alter table public.items add column if not exists created_at timestamptz default now();
 alter table public.items add column if not exists updated_at timestamptz default now();
 alter table public.items alter column data set default '{}'::jsonb;
+alter table public.items add column if not exists photo_original_path text;
+alter table public.items add column if not exists photo_display_path text;
 
 create index if not exists collections_user_id_idx on public.collections(user_id, created_at desc);
 create index if not exists items_collection_id_idx on public.items(collection_id, created_at desc);


### PR DESCRIPTION
### Motivation
- Stop relying on legacy `photo_path` fallback and exclusively use `photo_display_path` since the database is empty and backfill is unnecessary.
- Preserve the original master asset location in a dedicated `photo_original_path` column for items stored as local assets.
- Simplify sync logic by removing writing of legacy `photo_path` to the database.

### Description
- Read item URLs from `photo_display_path` in `services/db.ts` (`mapCloudCollections`) instead of `photo_path`.
- On upsert (`saveCollection`) stop sending `photo_path` and instead write `photo_display_path` and set `photo_original_path` to the computed asset when `item.photoUrl === 'asset'`.
- Add `photo_original_path` and `photo_display_path` columns to `supabase/1_schema.sql` and remove the legacy backfill `UPDATE` statement that copied `photo_path` into `photo_display_path`.
- Other sync payload fields and timestamp handling remain unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e5491e4883209ae4f657d8ad07d9)