### PR TITLE
Prefer cloud collections when signed in

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -202,7 +202,9 @@ const AppContent: React.FC = () => {
         await saveAllCollections(cloudCollections);
       }
 
-      if (cloudCollections.length === 0 && localCollections.length === 0) {
+      if (user) {
+        setCollections(cloudCollections);
+      } else if (cloudCollections.length === 0 && localCollections.length === 0) {
         setCollections(fallbackSampleCollections);
       } else {
         setCollections(cloudCollections.length > 0 ? cloudCollections : localCollections);


### PR DESCRIPTION
### Motivation
- Prevent signed-in users from seeing stale local-only collections that may be out of sync with the cloud after deletions or edits.  
- Follow the cloud-first design where Supabase is the source of truth and IndexedDB is only a cache.  
- Reduce confusion caused by local cache showing items that no longer exist in the server-side database.  

### Description
- Update `App.tsx` `refreshCollections` logic to prefer server results when a user is signed in by calling `setCollections(cloudCollections)` when `user` is present.  
- Preserve existing behavior of saving cloud results to local cache via `saveAllCollections` when appropriate.  
- Keep the signed-out fallback behavior to show `fallbackSampleCollections` or local collections when no cloud data is available.  

### Testing
- No automated tests were run against this change.  
- The change is a small logical update in `refreshCollections` in `App.tsx` and does not add new runtime dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585c77d4ac8320a32c9dbf62a24512)