### PR TITLE
Refresh collections after auth is ready to avoid perpetual loading

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -386,6 +386,13 @@ const AppContent: React.FC = () => {
   }, [isSupabaseReady]);
 
   useEffect(() => {
+    if (!isSupabaseReady || !authReady) {
+      return;
+    }
+    refreshCollections();
+  }, [authReady, isSupabaseReady, refreshCollections]);
+
+  useEffect(() => {
     if (!user && collections.some((c) => c.isPublic)) {
       setAllowPublicBrowse(true);
     }


### PR DESCRIPTION
### Motivation
- Users could see the "Restoring the archives..." message indefinitely because the initial collection refresh wasn’t triggered after authentication finished.
- The Home and Explore screens can remain in the `isLoading` state if `refreshCollections` is not called once auth initialization completes.
- The change ensures the initial data load happens only after Supabase is configured and auth setup is done.
- This improves UX by avoiding a stuck spinner and showing sample or public collections promptly.

### Description
- Added a `useEffect` in `App.tsx` that calls `refreshCollections()` when both `isSupabaseReady` and `authReady` are true.
- The effect returns early if either `isSupabaseReady` or `authReady` is false to prevent premature fetches.
- The implementation reuses the existing `refreshCollections` logic and does not add new network flows.
- Only `App.tsx` was modified to add this effect.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594f3c1eac8320b5d007ee3fa32216)