### PR TITLE
Phase 2: DB integration test suites (merge + dual-write + cleanup)

### DIFF
--- a/docs/TESTING_PROGRESS.md
+++ b/docs/TESTING_PROGRESS.md
@@ -12,9 +12,9 @@ This checklist tracks test coverage implementation progress against `docs/TESTIN
 
 ## Phase 2: Critical Services — Integration (Week 2)
 
-- [ ] **2.1 `services/db.ts` — Merge Logic** (`tests/services/db.merge.test.ts`)
-- [ ] **2.2 `services/db.ts` — Dual-Write Operations** (`tests/services/db.operations.test.ts`)
-- [ ] **2.3 `services/db.ts` — Cleanup & Utilities** (`tests/services/db.cleanup.test.ts`)
+- [x] **2.1 `services/db.ts` — Merge Logic** (`tests/services/db.merge.test.ts`)
+- [x] **2.2 `services/db.ts` — Dual-Write Operations** (`tests/services/db.operations.test.ts`)
+- [x] **2.3 `services/db.ts` — Cleanup & Utilities** (`tests/services/db.cleanup.test.ts`)
 
 ## Phase 3: AI & Hooks Integration (Week 3)
 

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -44,7 +44,7 @@
   - Test cases: legacy `photo_path` migration, modern paths, missing paths
   - Edge cases: null/undefined items, partial path data
 
-**Deliverable:** `tests/services/db.pure.test.ts`
+**Deliverable:** `tests/unit/services/db.pure.test.ts`
 
 ---
 
@@ -76,7 +76,7 @@
 npm install --save-dev canvas  # for Node.js Canvas API
 ```
 
-**Deliverable:** `tests/services/imageProcessor.test.ts`
+**Deliverable:** `tests/unit/services/imageProcessor.test.ts`
 
 ---
 
@@ -106,7 +106,7 @@ npm install --save-dev canvas  # for Node.js Canvas API
 // Return controlled responses for auth methods
 ```
 
-**Deliverable:** `tests/services/supabase.test.ts`
+**Deliverable:** `tests/unit/services/supabase.test.ts`
 
 ---
 

--- a/docs/TESTING_SETUP_SUMMARY.md
+++ b/docs/TESTING_SETUP_SUMMARY.md
@@ -69,7 +69,9 @@ tests/
 │   ├── canvas-mock.ts           # Canvas API utilities
 │   └── fixtures/
 │       └── collections.ts       # Mock data factories
-├── services/                     # Phase 1 & 2
+├── unit/                         # Unit-level tests (pure/isolated)
+│   └── services/                # Phase 1
+├── services/                     # Integration-level tests (Phase 2)
 ├── hooks/                        # Phase 3
 ├── components/                   # Phase 4
 │   └── ui/

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,7 +53,9 @@ tests/
 │   ├── canvas-mock.ts           # Canvas API utilities
 │   └── fixtures/
 │       └── collections.ts       # Mock collections and items
-├── services/                     # Phase 1 & 2 - Service tests
+├── unit/                         # Unit-level tests (pure/isolated)
+│   └── services/                # Phase 1 - Pure/isolated service tests
+├── services/                     # Integration-level service tests (IndexedDB/Supabase/etc.)
 ├── hooks/                        # Phase 3 - React hooks tests
 ├── components/                   # Phase 4 - Component tests
 └── e2e/                         # Phase 5 - End-to-end tests
@@ -77,9 +79,9 @@ All testing infrastructure is ready:
 
 **Ready to implement:**
 
-- `tests/services/db.pure.test.ts` - compareTimestamps, normalizePhotoPaths
-- `tests/services/imageProcessor.test.ts` - Image processing validation
-- `tests/services/supabase.test.ts` - Auth function tests
+- `tests/unit/services/db.pure.test.ts` - compareTimestamps, normalizePhotoPaths
+- `tests/unit/services/imageProcessor.test.ts` - Image processing validation
+- `tests/unit/services/supabase.test.ts` - Auth function tests
 
 ### 📋 Phase 2: Critical Services - Integration
 
@@ -208,6 +210,11 @@ MSW handlers are stubs. Expand them in Phase 2/3 as needed:
 - Add realistic error responses
 - Implement RLS policy simulation
 - Add request validation
+
+### IndexedDB + Parallel Test Execution
+
+`services/db.ts` uses a fixed IndexedDB database name (`CurioDatabase`). Running IndexedDB-heavy integration suites in parallel can cause open/delete blocking.
+For determinism, the test runner is configured to run with a single worker.
 
 ## Next Steps
 

--- a/tests/services/db.cleanup.test.ts
+++ b/tests/services/db.cleanup.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Phase 2.3: `services/db.ts` — Cleanup & Utilities (Integration)
+ *
+ * Focus: `cleanupOrphanedAssets(collections)`
+ * - Removes orphaned blobs from IndexedDB asset stores
+ * - Handles large cleanup batches
+ *
+ * IMPORTANT: TDD only — do not modify production implementations in these tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import type { UserCollection } from '@/types';
+
+let openDb: IDBDatabase | null = null;
+
+/**
+ * IMPORTANT:
+ * These tests manipulate IndexedDB state and can conflict with other test files if run in parallel.
+ * We remap the hardcoded production DB name to a per-file unique name to avoid cross-file blocking.
+ */
+const BASE_DB_NAME = 'CurioDatabase';
+const TEST_DB_NAME = `${BASE_DB_NAME}__vitest_${Math.random().toString(16).slice(2)}`;
+const originalOpen = indexedDB.open.bind(indexedDB);
+const originalDeleteDatabase = indexedDB.deleteDatabase.bind(indexedDB);
+
+Object.defineProperty(indexedDB, 'open', {
+  configurable: true,
+  value: ((name: string, version?: number) =>
+    originalOpen(name === BASE_DB_NAME ? TEST_DB_NAME : name, version)) as any,
+});
+Object.defineProperty(indexedDB, 'deleteDatabase', {
+  configurable: true,
+  value: ((name: string) =>
+    originalDeleteDatabase(name === BASE_DB_NAME ? TEST_DB_NAME : name)) as any,
+});
+
+afterAll(() => {
+  Object.defineProperty(indexedDB, 'open', { configurable: true, value: originalOpen as any });
+  Object.defineProperty(indexedDB, 'deleteDatabase', {
+    configurable: true,
+    value: originalDeleteDatabase as any,
+  });
+});
+
+function deleteDatabase(name: string) {
+  return new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase(name);
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+    req.onblocked = () => resolve();
+  });
+}
+
+async function listKeys(db: IDBDatabase, storeName: string): Promise<string[]> {
+  return await new Promise((resolve) => {
+    const tx = db.transaction(storeName, 'readonly');
+    const req = tx.objectStore(storeName).getAllKeys();
+    req.onsuccess = () => resolve((req.result || []).map((k) => String(k)));
+    req.onerror = () => resolve([]);
+  });
+}
+
+async function putBlobs(
+  db: IDBDatabase,
+  entries: Array<{ store: 'assets' | 'display'; key: string; value: Blob }>,
+) {
+  return await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(['assets', 'display'], 'readwrite');
+    const assets = tx.objectStore('assets');
+    const display = tx.objectStore('display');
+
+    for (const e of entries) {
+      (e.store === 'assets' ? assets : display).put(e.value, e.key);
+    }
+
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function importDbModuleFresh() {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  // Keep Supabase disabled for these tests.
+  vi.stubEnv('VITE_SUPABASE_URL', '');
+  vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY', '');
+  return await import('@/services/db');
+}
+
+describe('Phase 2.3 — services/db.ts cleanup utilities', () => {
+  beforeEach(async () => {
+    if (openDb) {
+      openDb.close();
+      openDb = null;
+    }
+    await deleteDatabase('CurioDatabase');
+  });
+
+  afterEach(() => {
+    if (openDb) {
+      openDb.close();
+      openDb = null;
+    }
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('cleanupOrphanedAssets: deletes blobs whose keys do not map to any item id', async () => {
+    /**
+     * Scenario: an item was deleted but its blobs remain in IndexedDB.
+     * Expected: orphaned keys are removed from both `assets` and `display` stores.
+     */
+    const dbMod = await importDbModuleFresh();
+    const db = await dbMod.initDB();
+    openDb = db;
+
+    await putBlobs(db, [
+      { store: 'assets', key: 'keep-1', value: new Blob(['a']) },
+      { store: 'display', key: 'keep-1', value: new Blob(['d']) },
+      { store: 'assets', key: 'orphan-1', value: new Blob(['a']) },
+      { store: 'display', key: 'orphan-1', value: new Blob(['d']) },
+    ]);
+
+    const collections: UserCollection[] = [
+      {
+        id: 'col-1',
+        templateId: 'vinyl',
+        name: 'Col',
+        customFields: [],
+        items: [
+          {
+            id: 'keep-1',
+            collectionId: 'col-1',
+            photoUrl: 'asset',
+            title: 'Kept',
+            rating: 0,
+            data: {},
+            createdAt: new Date().toISOString(),
+            notes: '',
+          },
+        ],
+        settings: { displayFields: [], badgeFields: [] },
+      },
+    ];
+
+    await expect(dbMod.cleanupOrphanedAssets(collections)).resolves.toBeUndefined();
+
+    const assetKeys = await listKeys(db, 'assets');
+    const displayKeys = await listKeys(db, 'display');
+
+    expect(assetKeys).toContain('keep-1');
+    expect(displayKeys).toContain('keep-1');
+    expect(assetKeys).not.toContain('orphan-1');
+    expect(displayKeys).not.toContain('orphan-1');
+  });
+
+  it('cleanupOrphanedAssets: with empty collections input, removes all asset keys (safe cleanup)', async () => {
+    /**
+     * Edge case: if no collections are valid, all asset keys are considered orphaned
+     * and should be removed.
+     */
+    const dbMod = await importDbModuleFresh();
+    const db = await dbMod.initDB();
+    openDb = db;
+
+    await putBlobs(db, [
+      { store: 'assets', key: 'a1', value: new Blob(['a']) },
+      { store: 'display', key: 'a1', value: new Blob(['d']) },
+      { store: 'assets', key: 'a2', value: new Blob(['a']) },
+      { store: 'display', key: 'a2', value: new Blob(['d']) },
+    ]);
+
+    await dbMod.cleanupOrphanedAssets([]);
+
+    expect(await listKeys(db, 'assets')).toEqual([]);
+    expect(await listKeys(db, 'display')).toEqual([]);
+  });
+
+  it('cleanupOrphanedAssets: handles large cleanup batches (100+ items) efficiently', async () => {
+    /**
+     * Performance/boundary: ensure large datasets are handled correctly.
+     * We assert correctness (orphan keys removed) rather than timing.
+     */
+    const dbMod = await importDbModuleFresh();
+    const db = await dbMod.initDB();
+    openDb = db;
+
+    const validCount = 120;
+    const orphanCount = 30;
+
+    const entries: Array<{ store: 'assets' | 'display'; key: string; value: Blob }> = [];
+    for (let i = 0; i < validCount; i++) {
+      entries.push({ store: 'assets', key: `valid-${i}`, value: new Blob(['a']) });
+      entries.push({ store: 'display', key: `valid-${i}`, value: new Blob(['d']) });
+    }
+    for (let i = 0; i < orphanCount; i++) {
+      entries.push({ store: 'assets', key: `orphan-${i}`, value: new Blob(['a']) });
+      entries.push({ store: 'display', key: `orphan-${i}`, value: new Blob(['d']) });
+    }
+    await putBlobs(db, entries);
+
+    const collections: UserCollection[] = [
+      {
+        id: 'col-batch',
+        templateId: 'vinyl',
+        name: 'Batch',
+        customFields: [],
+        items: Array.from({ length: validCount }, (_, i) => ({
+          id: `valid-${i}`,
+          collectionId: 'col-batch',
+          photoUrl: 'asset',
+          title: `Item ${i}`,
+          rating: 0,
+          data: {},
+          createdAt: new Date().toISOString(),
+          notes: '',
+        })),
+        settings: { displayFields: [], badgeFields: [] },
+      },
+    ];
+
+    await dbMod.cleanupOrphanedAssets(collections);
+
+    const assetKeys = await listKeys(db, 'assets');
+    const displayKeys = await listKeys(db, 'display');
+    expect(assetKeys.filter((k) => k.startsWith('orphan-'))).toHaveLength(0);
+    expect(displayKeys.filter((k) => k.startsWith('orphan-'))).toHaveLength(0);
+    expect(assetKeys.filter((k) => k.startsWith('valid-'))).toHaveLength(validCount);
+    expect(displayKeys.filter((k) => k.startsWith('valid-'))).toHaveLength(validCount);
+  });
+
+  it('cleanupOrphanedAssets: rejects/throws on invalid input (null/undefined) rather than silently succeeding', async () => {
+    /**
+     * Error case: invalid inputs should fail fast; this prevents tests from masking bugs.
+     */
+    const dbMod = await importDbModuleFresh();
+    await expect((dbMod as any).cleanupOrphanedAssets(null)).rejects.toBeTruthy();
+    await expect((dbMod as any).cleanupOrphanedAssets(undefined)).rejects.toBeTruthy();
+  });
+});
+
+

--- a/tests/services/db.merge.test.ts
+++ b/tests/services/db.merge.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Phase 2.1: `services/db.ts` — Merge Logic (Integration Contract)
+ *
+ * This suite is intentionally written TDD-first based on `docs/TESTING_ROADMAP.md`.
+ * Some tests will FAIL until the roadmap-specified APIs are exported/implemented.
+ *
+ * Success criteria (roadmap):
+ * - Merge logic passes all conflict resolution scenarios
+ * - No data loss in 100 randomized sync scenarios
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+async function importDbModuleFresh(env: { supabaseUrl?: string; supabaseKey?: string } = {}) {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+
+  // Keep Supabase disabled by default for merge logic tests.
+  vi.stubEnv('VITE_SUPABASE_URL', env.supabaseUrl ?? '');
+  vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY', env.supabaseKey ?? '');
+
+  return await import('@/services/db');
+}
+
+function isoAt(hoursFromEpoch: number) {
+  return new Date(hoursFromEpoch * 60 * 60 * 1000).toISOString();
+}
+
+describe('Phase 2.1 — services/db.ts merge logic (roadmap contract)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('exports mergeCollections(localCollections, cloudCollections, cloudDeletedIds?) as a function', async () => {
+    /**
+     * Verifies the roadmap API exists. This SHOULD FAIL until `mergeCollections`
+     * is exported from `services/db.ts`.
+     */
+    const mod = await importDbModuleFresh();
+    expect(typeof (mod as any).mergeCollections).toBe('function');
+  });
+
+  it('exports mergeItems(localItems, cloudItems, cloudDeletedIds?) as a function', async () => {
+    /**
+     * Verifies the roadmap API exists. This SHOULD FAIL until `mergeItems`
+     * is exported from `services/db.ts`.
+     */
+    const mod = await importDbModuleFresh();
+    expect(typeof (mod as any).mergeItems).toBe('function');
+  });
+
+  it('Scenario: cloud newer -> cloud wins for conflicting collection metadata', async () => {
+    /**
+     * If the same collection exists locally and in cloud, and cloud has a newer `updatedAt`,
+     * the merged result should prefer cloud metadata (name/icon/template/settings, etc.).
+     */
+    const mod = await importDbModuleFresh();
+    const mergeCollections = (mod as any).mergeCollections as undefined | ((a: any, b: any) => any);
+    if (typeof mergeCollections !== 'function') {
+      throw new Error('mergeCollections is not implemented/exported yet (TDD).');
+    }
+
+    const local = [
+      {
+        id: 'col-1',
+        templateId: 'vinyl',
+        name: 'Local Name',
+        icon: '🎵',
+        customFields: [],
+        items: [],
+        settings: { displayFields: [], badgeFields: [] },
+        updatedAt: isoAt(1),
+      },
+    ];
+
+    const cloud = [
+      {
+        id: 'col-1',
+        templateId: 'vinyl',
+        name: 'Cloud Name',
+        icon: '☁️',
+        customFields: [],
+        items: [],
+        settings: { displayFields: [], badgeFields: [] },
+        updatedAt: isoAt(2),
+      },
+    ];
+
+    const merged = mergeCollections(local, cloud);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].name).toBe('Cloud Name');
+    expect(merged[0].icon).toBe('☁️');
+  });
+
+  it('Scenario: local newer -> local wins for conflicting item fields (same item id)', async () => {
+    /**
+     * When an item exists both locally and in cloud, `updatedAt` (or fallback timestamp)
+     * should decide the winner. If local is newer, merged should use local item data.
+     */
+    const mod = await importDbModuleFresh();
+    const mergeItems = (mod as any).mergeItems as undefined | ((a: any, b: any) => any);
+    if (typeof mergeItems !== 'function') {
+      throw new Error('mergeItems is not implemented/exported yet (TDD).');
+    }
+
+    const localItems = [
+      {
+        id: 'item-1',
+        collectionId: 'col-1',
+        photoUrl: 'local.jpg',
+        title: 'Local Title',
+        rating: 5,
+        data: {},
+        createdAt: isoAt(0),
+        updatedAt: isoAt(10),
+        notes: '',
+      },
+    ];
+    const cloudItems = [
+      {
+        id: 'item-1',
+        collectionId: 'col-1',
+        photoUrl: 'cloud.jpg',
+        title: 'Cloud Title',
+        rating: 1,
+        data: {},
+        createdAt: isoAt(0),
+        updatedAt: isoAt(2),
+        notes: '',
+      },
+    ];
+
+    const merged = mergeItems(localItems, cloudItems);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].title).toBe('Local Title');
+    expect(merged[0].photoUrl).toBe('local.jpg');
+    expect(merged[0].rating).toBe(5);
+  });
+
+  it('Scenario: cloud deletion list removes local entities (collections/items) and prevents resurrection', async () => {
+    /**
+     * Roadmap specifies a `cloudDeletedIds?` parameter to ensure deleted records do not
+     * reappear from local cache.
+     */
+    const mod = await importDbModuleFresh();
+    const mergeCollections = (mod as any).mergeCollections as
+      | undefined
+      | ((local: any[], cloud: any[], cloudDeletedIds?: string[]) => any[]);
+
+    if (typeof mergeCollections !== 'function') {
+      throw new Error('mergeCollections is not implemented/exported yet (TDD).');
+    }
+
+    const local = [
+      {
+        id: 'deleted-col',
+        templateId: 'vinyl',
+        name: 'Local Deleted',
+        icon: '🗑️',
+        customFields: [],
+        items: [
+          {
+            id: 'deleted-item',
+            collectionId: 'deleted-col',
+            photoUrl: 'local.jpg',
+            title: 'Should be deleted',
+            rating: 0,
+            data: {},
+            createdAt: isoAt(0),
+            notes: '',
+          },
+        ],
+        settings: { displayFields: [], badgeFields: [] },
+        updatedAt: isoAt(1),
+      },
+    ];
+
+    const cloud: any[] = []; // Cloud no longer has it
+    const merged = mergeCollections(local, cloud, ['deleted-col', 'deleted-item']);
+
+    expect(merged.find((c) => c.id === 'deleted-col')).toBeUndefined();
+  });
+
+  it('Edge case: empty inputs return empty outputs (no exceptions)', async () => {
+    /**
+     * Merge helpers should be safe for empty arrays, returning empty arrays.
+     */
+    const mod = await importDbModuleFresh();
+    const mergeCollections = (mod as any).mergeCollections as undefined | ((a: any[], b: any[]) => any[]);
+    const mergeItems = (mod as any).mergeItems as undefined | ((a: any[], b: any[]) => any[]);
+    if (typeof mergeCollections !== 'function' || typeof mergeItems !== 'function') {
+      throw new Error('mergeCollections/mergeItems are not implemented/exported yet (TDD).');
+    }
+
+    expect(mergeCollections([], [])).toEqual([]);
+    expect(mergeItems([], [])).toEqual([]);
+  });
+
+  it('Property test: 100 randomized scenarios never lose local-only records unless cloud deleted', async () => {
+    /**
+     * Roadmap success criteria: “No data loss in 100 randomized sync scenarios”.
+     *
+     * Contract: any local-only collection/item IDs (not present in cloud) should remain
+     * present after merge, unless explicitly present in `cloudDeletedIds`.
+     */
+    const mod = await importDbModuleFresh();
+    const mergeCollections = (mod as any).mergeCollections as
+      | undefined
+      | ((local: any[], cloud: any[], cloudDeletedIds?: string[]) => any[]);
+    if (typeof mergeCollections !== 'function') {
+      throw new Error('mergeCollections is not implemented/exported yet (TDD).');
+    }
+
+    const rand = (seed: number) => {
+      // Deterministic linear congruential generator for reproducible tests
+      let s = seed >>> 0;
+      return () => {
+        s = (1664525 * s + 1013904223) >>> 0;
+        return s / 2 ** 32;
+      };
+    };
+
+    const r = rand(42);
+    for (let i = 0; i < 100; i++) {
+      const localOnlyCount = 1 + Math.floor(r() * 5);
+      const sharedCount = 1 + Math.floor(r() * 5);
+
+      const localOnly = Array.from({ length: localOnlyCount }, (_, idx) => ({
+        id: `local-only-${i}-${idx}`,
+        templateId: 'vinyl',
+        name: `Local Only ${idx}`,
+        customFields: [],
+        items: [],
+        settings: { displayFields: [], badgeFields: [] },
+        updatedAt: isoAt(1),
+      }));
+
+      const sharedLocal = Array.from({ length: sharedCount }, (_, idx) => ({
+        id: `shared-${i}-${idx}`,
+        templateId: 'vinyl',
+        name: `Shared Local ${idx}`,
+        customFields: [],
+        items: [],
+        settings: { displayFields: [], badgeFields: [] },
+        updatedAt: isoAt(2 + Math.floor(r() * 3)),
+      }));
+
+      const sharedCloud = sharedLocal.map((c) => ({
+        ...c,
+        name: `Shared Cloud ${c.id}`,
+        updatedAt: isoAt(2 + Math.floor(r() * 3)),
+      }));
+
+      const merged = mergeCollections([...localOnly, ...sharedLocal], sharedCloud, []);
+      for (const col of localOnly) {
+        expect(merged.some((m: any) => m.id === col.id)).toBe(true);
+      }
+    }
+  });
+});
+
+

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Phase 2.2: `services/db.ts` — Dual-Write Operations (Integration)
+ *
+ * These tests validate that DB operations write to IndexedDB and attempt to sync to Supabase
+ * when configured, with correct rollback / eventual consistency behavior.
+ *
+ * IMPORTANT: TDD only — do not modify production implementations in these tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+import type { UserCollection, CollectionItem } from '@/types';
+
+let openDb: IDBDatabase | null = null;
+
+/**
+ * IMPORTANT:
+ * `services/db.ts` uses a fixed database name ("CurioDatabase").
+ * Vitest runs test files in parallel by default, so IndexedDB tests that delete/reset the same DB
+ * can block each other and cause timeouts.
+ *
+ * To make these tests deterministic, we map "CurioDatabase" -> a per-file unique DB name.
+ */
+const BASE_DB_NAME = 'CurioDatabase';
+const TEST_DB_NAME = `${BASE_DB_NAME}__vitest_${Math.random().toString(16).slice(2)}`;
+const originalOpen = indexedDB.open.bind(indexedDB);
+const originalDeleteDatabase = indexedDB.deleteDatabase.bind(indexedDB);
+
+Object.defineProperty(indexedDB, 'open', {
+  configurable: true,
+  value: ((name: string, version?: number) =>
+    originalOpen(name === BASE_DB_NAME ? TEST_DB_NAME : name, version)) as any,
+});
+Object.defineProperty(indexedDB, 'deleteDatabase', {
+  configurable: true,
+  value: ((name: string) =>
+    originalDeleteDatabase(name === BASE_DB_NAME ? TEST_DB_NAME : name)) as any,
+});
+
+afterAll(() => {
+  Object.defineProperty(indexedDB, 'open', { configurable: true, value: originalOpen as any });
+  Object.defineProperty(indexedDB, 'deleteDatabase', {
+    configurable: true,
+    value: originalDeleteDatabase as any,
+  });
+});
+
+async function readFromStore<T>(db: IDBDatabase, storeName: string, key: IDBValidKey): Promise<T | null> {
+  return await new Promise((resolve) => {
+    const tx = db.transaction(storeName, 'readonly');
+    const req = tx.objectStore(storeName).get(key);
+    req.onsuccess = () => resolve((req.result as T) ?? null);
+    req.onerror = () => resolve(null);
+  });
+}
+
+async function clearStores(db: IDBDatabase, storeNames: string[]) {
+  return await new Promise<void>((resolve) => {
+    const tx = db.transaction(storeNames, 'readwrite');
+    storeNames.forEach((name) => tx.objectStore(name).clear());
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+    tx.onabort = () => resolve();
+  });
+}
+
+function createSupabaseMock() {
+  const collectionsUpsert = vi.fn().mockResolvedValue({ error: null });
+  const itemsUpsert = vi.fn().mockResolvedValue({ error: null });
+  const upload = vi.fn().mockResolvedValue({ data: { path: 'ok' }, error: null });
+
+  const from = vi.fn((table: string) => {
+    return {
+      upsert: table === 'collections' ? collectionsUpsert : itemsUpsert,
+      // present for completeness; not used directly by these tests
+      select: vi.fn().mockReturnThis(),
+      or: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+    };
+  });
+
+  return {
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'test-user-id' } }, error: null }),
+      },
+      from,
+      storage: {
+        from: vi.fn(() => ({ upload })),
+      },
+    },
+    collectionsUpsert,
+    itemsUpsert,
+    upload,
+    from,
+  };
+}
+
+async function importDbModuleFreshWithSupabaseMock(supabaseMock: any, env?: { syncTimestamps?: 'true' | 'false' }) {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+
+  vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+  vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY', 'test-key');
+  vi.stubEnv('VITE_SUPABASE_SYNC_TIMESTAMPS', env?.syncTimestamps ?? 'true');
+
+  // Ensure the Supabase client created inside `services/supabase.ts` is our controlled mock.
+  vi.doMock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(() => supabaseMock),
+  }));
+
+  return await import('@/services/db');
+}
+
+describe('Phase 2.2 — services/db.ts dual-write operations', () => {
+  beforeEach(async () => {
+    if (openDb) {
+      openDb.close();
+      openDb = null;
+    }
+  });
+
+  afterEach(() => {
+    if (openDb) {
+      openDb.close();
+      openDb = null;
+    }
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('saveCollection: happy path writes to IndexedDB and upserts to Supabase (collections + items)', async () => {
+    /**
+     * Verifies the dual-write contract for collections:
+     * - Local persistence always happens (IndexedDB)
+     * - Cloud upserts are attempted when Supabase is configured + user exists
+     */
+    const { supabase, collectionsUpsert, itemsUpsert, from } = createSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    // Ensure a clean local DB baseline without relying on deleteDatabase (which can block).
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const item: CollectionItem = {
+      id: 'item-1',
+      collectionId: 'col-1',
+      photoUrl: 'asset',
+      title: 'Offline item',
+      rating: 3,
+      data: { a: 1 },
+      createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+      updatedAt: new Date('2024-01-02T00:00:00Z').toISOString(),
+      notes: 'notes',
+    };
+
+    const collection: UserCollection = {
+      id: 'col-1',
+      templateId: 'vinyl',
+      name: 'My Collection',
+      icon: '🎵',
+      customFields: [],
+      items: [item],
+      ownerId: 'test-user-id',
+      settings: { displayFields: [], badgeFields: [] },
+      updatedAt: new Date('2024-01-03T00:00:00Z').toISOString(),
+    };
+
+    await expect(dbMod.saveCollection(collection)).resolves.toBeUndefined();
+
+    // Local persistence: collection exists in IndexedDB.
+    const saved = await readFromStore<UserCollection>(db, 'collections', 'col-1');
+    expect(saved?.id).toBe('col-1');
+    expect(saved?.items?.[0]?.id).toBe('item-1');
+
+    // Cloud sync: correct tables targeted
+    expect(from).toHaveBeenCalledWith('collections');
+    expect(from).toHaveBeenCalledWith('items');
+    expect(collectionsUpsert).toHaveBeenCalledTimes(1);
+    expect(itemsUpsert).toHaveBeenCalledTimes(1);
+
+    // Cloud payload includes normalized fields and timestamp mapping when enabled.
+    const [collectionPayload] = collectionsUpsert.mock.calls[0];
+    expect(collectionPayload).toMatchObject({
+      id: 'col-1',
+      user_id: 'test-user-id',
+      template_id: 'vinyl',
+      name: 'My Collection',
+      icon: '🎵',
+      is_public: false,
+    });
+    expect(collectionPayload.updated_at).toBeDefined();
+
+    const [itemsPayload] = itemsUpsert.mock.calls[0];
+    expect(Array.isArray(itemsPayload)).toBe(true);
+    expect(itemsPayload[0]).toMatchObject({
+      id: 'item-1',
+      user_id: 'test-user-id',
+      collection_id: 'col-1',
+      title: 'Offline item',
+      photo_original_path: 'test-user-id/collections/col-1/item-1/original.jpg',
+      photo_display_path: 'test-user-id/collections/col-1/item-1/display.jpg',
+    });
+    expect(itemsPayload[0].created_at).toBeDefined();
+    expect(itemsPayload[0].updated_at).toBeDefined();
+  });
+
+  it('saveCollection: cloud failure does not rollback local save (eventual consistency)', async () => {
+    /**
+     * Roadmap expectation: if cloud fails, local succeeds; callers get eventual consistency.
+     * Current implementation swallows cloud errors and logs instead of throwing.
+     */
+    const { supabase, collectionsUpsert } = createSupabaseMock();
+    collectionsUpsert.mockRejectedValueOnce(new Error('network timeout'));
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const collection: UserCollection = {
+      id: 'col-2',
+      templateId: 'vinyl',
+      name: 'Local Only',
+      icon: '📦',
+      customFields: [],
+      items: [],
+      ownerId: 'test-user-id',
+      settings: { displayFields: [], badgeFields: [] },
+      updatedAt: new Date('2024-01-03T00:00:00Z').toISOString(),
+    };
+
+    await expect(dbMod.saveCollection(collection)).resolves.toBeUndefined();
+
+    const saved = await readFromStore<UserCollection>(db, 'collections', 'col-2');
+    expect(saved?.name).toBe('Local Only');
+
+    consoleError.mockRestore();
+  });
+
+  it('saveCollection: invalid collection object (missing id) rejects and does not attempt cloud writes', async () => {
+    /**
+     * Error case: IndexedDB keyPath is `id`; objects without `id` should fail local persistence,
+     * and cloud sync should not run.
+     */
+    const { supabase, collectionsUpsert, from } = createSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const invalid: any = {
+      templateId: 'vinyl',
+      name: 'Missing id',
+      customFields: [],
+      items: [],
+      settings: { displayFields: [], badgeFields: [] },
+    };
+
+    await expect(dbMod.saveCollection(invalid)).rejects.toBeTruthy();
+    expect(from).not.toHaveBeenCalled();
+    expect(collectionsUpsert).not.toHaveBeenCalled();
+  });
+
+  it('saveAsset: happy path writes original+display blobs to IndexedDB and uploads both to Supabase Storage', async () => {
+    /**
+     * Verifies the dual-write contract for assets:
+     * - Local writes are atomic across `assets` + `display` stores
+     * - Cloud uploads are attempted in parallel when configured
+     */
+    const { supabase, upload } = createSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const original = new Blob(['orig'], { type: 'image/jpeg' });
+    const display = new Blob(['disp'], { type: 'image/jpeg' });
+
+    await expect(dbMod.saveAsset('col-1', 'item-asset-1', original, display)).resolves.toBeUndefined();
+
+    const savedOriginal = await readFromStore<Blob>(db, 'assets', 'item-asset-1');
+    const savedDisplay = await readFromStore<Blob>(db, 'display', 'item-asset-1');
+    // In happy-dom/fake-indexeddb, returned values may be Blob-like rather than a real `Blob` instance.
+    expect(savedOriginal).toBeTruthy();
+    expect(savedDisplay).toBeTruthy();
+    expect((savedOriginal as any).type).toBe('image/jpeg');
+    expect((savedDisplay as any).type).toBe('image/jpeg');
+
+    // Cloud upload called twice: original + display
+    expect(upload).toHaveBeenCalledTimes(2);
+    const calledPaths = upload.mock.calls.map((c) => c[0]);
+    expect(calledPaths).toContain('test-user-id/collections/col-1/item-asset-1/original.jpg');
+    expect(calledPaths).toContain('test-user-id/collections/col-1/item-asset-1/display.jpg');
+  });
+
+  it('saveAsset: cloud upload failure should trigger retry logic (roadmap requirement)', async () => {
+    /**
+     * Roadmap calls out “Upload retries”. This test defines a retry contract:
+     * - If an upload fails transiently, the operation should retry at least once.
+     *
+     * This SHOULD FAIL until retry logic is implemented.
+     */
+    const { supabase, upload } = createSupabaseMock();
+
+    // Fail first, succeed second.
+    upload.mockRejectedValueOnce(new Error('transient'));
+    upload.mockResolvedValueOnce({ data: { path: 'ok' }, error: null });
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const original = new Blob(['orig'], { type: 'image/jpeg' });
+    const display = new Blob(['disp'], { type: 'image/jpeg' });
+
+    await dbMod.saveAsset('col-1', 'retry-asset', original, display);
+
+    // Contract: there must be more than 2 calls if retries occur (2 uploads baseline: original+display).
+    expect(upload.mock.calls.length).toBeGreaterThan(2);
+
+    warn.mockRestore();
+  });
+
+  it('exports saveItem(item, session) as a function (roadmap API)', async () => {
+    /**
+     * Roadmap requires `saveItem(item, session)` for dual-write item persistence.
+     * This SHOULD FAIL until `saveItem` exists/exports from `services/db.ts`.
+     */
+    const { supabase } = createSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+    expect(typeof (dbMod as any).saveItem).toBe('function');
+  });
+});
+
+

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
     environment: 'happy-dom',
     setupFiles: './tests/setup.ts',
     include: ['tests/**/*.test.{ts,tsx}'],
+    // IndexedDB-heavy integration tests (Phase 2) use a fixed DB name in production code.
+    // Running test files in parallel can cause delete/open blocking across suites.
+    // Keep the suite deterministic by running with a single worker.
+    maxWorkers: 1,
+    sequence: {
+      concurrent: false,
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
**Summary**

- Adds Phase 2 integration test suites for services/db.ts:
  - tests/services/db.merge.test.ts
  - tests/services/db.operations.test.ts
  - tests/services/db.cleanup.test.ts
- Updates testing docs to reflect the current folder conventions and completed Phase 2 testing checklist.
- Makes the Vitest runner deterministic for IndexedDB-heavy suites by running with a single worker.

**What’s covered**

- Merge logic contract tests (cloud vs local timestamps, deletion lists, local-only preservation, randomized scenarios).
- Dual-write behavior for saveCollection / saveAsset:
  - Local IndexedDB persistence
  - Supabase + Storage sync attempts
  - Eventual consistency on cloud failure
  - Defines roadmap-required retry contract (currently failing until implemented)
- Cleanup utilities:
  - cleanupOrphanedAssets removes orphan keys in assets/display, including large batches.

**TDD status / expected failures**

This PR is test-first. Current failures indicate missing roadmap contracts:
- mergeCollections / mergeItems are not exported/available
- saveItem API is missing
- saveAsset retry behavior not implemented

**Notes**

- Docs updated: docs/TESTING_PROGRESS.md, docs/TESTING_ROADMAP.md, docs/TESTING_SETUP_SUMMARY.md, tests/README.md
- Runner config: vitest.config.ts set to maxWorkers: 1 to avoid IndexedDB cross-test blocking.
