### PR TITLE
test(auth): Phase 1.3 expect signInWithEmail to return user (document…

### DIFF
--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -93,7 +93,8 @@ npm install --save-dev canvas  # for Node.js Canvas API
   - Success case: Returns user object
   - Error cases: Duplicate email, weak password, network failure
 - `signInWithEmail(email, password)`
-  - Success case: Returns session
+  - Success case: Returns user (current implementation)
+  - Note: If we later need tokens (access/refresh) for advanced flows, consider returning `session` (or `{ user, session }`)
   - Error cases: Invalid credentials, unconfirmed email
 - `signOutUser()`
   - Success case: Clears session

--- a/tests/unit/services/supabase.test.ts
+++ b/tests/unit/services/supabase.test.ts
@@ -184,12 +184,14 @@ describe('services/supabase.ts - Auth Helpers (Phase 1.3)', () => {
   });
 
   describe('signInWithEmail(email, password)', () => {
-    it('returns a session on success (roadmap requirement)', async () => {
+    it('returns a user on success (Option A: keep implementation simple)', async () => {
       /**
-       * Happy path (roadmap): sign-in should return a session object so callers can
-       * access tokens if needed.
+       * Happy path: the current implementation returns `data.user` from Supabase.
        *
-       * Note: This test is intentionally strict to enforce the roadmap contract.
+       * Note: This intentionally chooses "Option A" (return user, not session) to keep
+       * auth usage simple while the app is changing rapidly. If we later need access/refresh
+       * tokens for server-side calls or advanced flows, we can switch the helper to return
+       * `data.session` (or `{ user, session }`) and update tests accordingly.
        */
       const mod = await importSupabaseModuleFresh({
         url: 'https://test.supabase.co',
@@ -206,7 +208,7 @@ describe('services/supabase.ts - Auth Helpers (Phase 1.3)', () => {
       });
 
       const result = await mod.signInWithEmail('signedin@example.com', 'StrongPassword!123');
-      expect(result).toMatchObject(session);
+      expect(result).toMatchObject({ id: 'signed-in-user', email: 'signedin@example.com' });
     });
 
     it('throws on invalid credentials (e.g., wrong email/password)', async () => {


### PR DESCRIPTION
Test updated: tests/unit/services/supabase.test.ts

- The “sign in success” test now expects a user ({ id, email }) instead of a session.
- The test docstring explains why (Option A) and what we’d do later if tokens are needed.

Documentation note added: docs/TESTING_ROADMAP.md

- Phase 1.3 signInWithEmail now says returns user (current implementation).
- Adds a note: if we later need tokens, we may switch to returning session or { user, session }.