### PR TITLE
test(phase3): add AI + hooks integration tests

### DIFF
--- a/docs/TESTING_PROGRESS.md
+++ b/docs/TESTING_PROGRESS.md
@@ -18,9 +18,9 @@ This checklist tracks test coverage implementation progress against `docs/TESTIN
 
 ## Phase 3: AI & Hooks Integration (Week 3)
 
-- [ ] **3.1 `services/geminiService.ts` — AI Analysis** (`tests/services/geminiService.test.ts`)
-- [ ] **3.2 `hooks/useAuthState.ts` — Auth State Management** (`tests/hooks/useAuthState.test.ts`)
-- [ ] **3.3 `hooks/useCollections.ts` — Collection Management** (`tests/hooks/useCollections.test.ts`)
+- [x] **3.1 `services/geminiService.ts` — AI Analysis** (`tests/services/geminiService.test.ts`)
+- [x] **3.2 `hooks/useAuthState.ts` — Auth State Management** (`tests/hooks/useAuthState.test.ts`)
+- [x] **3.3 `hooks/useCollections.ts` — Collection Management** (`tests/hooks/useCollections.test.ts`)
 
 ## Phase 4: Components (Week 4)
 
@@ -31,5 +31,3 @@ This checklist tracks test coverage implementation progress against `docs/TESTIN
 ## Phase 5: End-to-End Tests (Week 5)
 
 - [ ] **5.1 Critical User Flows** (`tests/e2e/critical-flows.spec.ts`)
-
-

--- a/tests/hooks/useAuthState.test.ts
+++ b/tests/hooks/useAuthState.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase 3.2: hooks/useAuthState.ts — Auth State Management Tests
+ *
+ * Success criteria (from docs/TESTING_ROADMAP.md Phase 3):
+ * - Hooks maintain correct state through auth lifecycle
+ * - Initial loading state, auth state change updates, sign out clears user
+ * - Edge case: rapid sign-in/out cycles
+ *
+ * IMPORTANT (TDD): Do not modify production implementations while writing these tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { mockSupabaseClient, resetSupabaseMocks } from '@/tests/mocks/supabase';
+
+// Provide a controlled Supabase client for the hook under test.
+vi.mock('@/services/supabase', () => {
+  return {
+    supabase: mockSupabaseClient,
+  };
+});
+
+describe('hooks/useAuthState.ts (Phase 3.2)', () => {
+  beforeEach(() => {
+    resetSupabaseMocks();
+    // Default profiles query for tests that don't care about isAdmin:
+    // return non-admin and avoid noisy console warnings.
+    mockSupabaseClient.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { is_admin: false }, error: null }),
+    } as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initial state: user is null and authReady is false until getSession resolves', async () => {
+    /**
+     * Verifies the initial "loading" behavior:
+     * - Immediately after mount, the hook should indicate auth is not ready yet.
+     * - user should be null until Supabase session initialization completes.
+     */
+    let resolveSession: (value: any) => void;
+    const pending = new Promise((r) => (resolveSession = r));
+    mockSupabaseClient.auth.getSession.mockReturnValueOnce(pending as any);
+
+    const { useAuthState } = await import('@/hooks/useAuthState');
+    const { result } = renderHook(() => useAuthState(true));
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.authReady).toBe(false);
+
+    resolveSession!({ data: { session: null } });
+    await waitFor(() => expect(result.current.authReady).toBe(true));
+    expect(result.current.user).toBeNull();
+  });
+
+  it('auth state changes: onAuthStateChange updates user (sign-in and sign-out)', async () => {
+    /**
+     * Verifies that Supabase auth events update React state.
+     * - SIGNED_IN should set user
+     * - SIGNED_OUT should clear user
+     */
+    const unsubscribe = vi.fn();
+    let handler: ((event: string, session: any) => void) | null = null;
+    mockSupabaseClient.auth.onAuthStateChange.mockImplementationOnce((cb: any) => {
+      handler = cb;
+      return { data: { subscription: { unsubscribe } } };
+    });
+    mockSupabaseClient.auth.getSession.mockResolvedValueOnce({ data: { session: null } });
+
+    const { useAuthState } = await import('@/hooks/useAuthState');
+    const { result, unmount } = renderHook(() => useAuthState(true));
+
+    await waitFor(() => expect(result.current.authReady).toBe(true));
+
+    await act(async () => {
+      handler?.('SIGNED_IN', { user: { id: 'u1', email: 'u1@example.com' } });
+    });
+    expect(result.current.user).toMatchObject({ id: 'u1', email: 'u1@example.com' });
+
+    await act(async () => {
+      handler?.('SIGNED_OUT', null);
+    });
+    expect(result.current.user).toBeNull();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('admin status: when a user is present, loads profiles.is_admin; clears isAdmin when user becomes null', async () => {
+    /**
+     * Verifies admin lookup behavior:
+     * - With a user, queries profiles table for is_admin
+     * - If user becomes null, isAdmin resets to false
+     */
+    const unsubscribe = vi.fn();
+    let handler: ((event: string, session: any) => void) | null = null;
+    mockSupabaseClient.auth.onAuthStateChange.mockImplementationOnce((cb: any) => {
+      handler = cb;
+      return { data: { subscription: { unsubscribe } } };
+    });
+
+    mockSupabaseClient.auth.getSession.mockResolvedValueOnce({
+      data: { session: { user: { id: 'u1', email: 'u1@example.com' } } },
+    });
+
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { is_admin: true }, error: null }),
+    };
+    mockSupabaseClient.from.mockReturnValueOnce(query as any);
+
+    const { useAuthState } = await import('@/hooks/useAuthState');
+    const { result } = renderHook(() => useAuthState(true));
+
+    await waitFor(() => expect(result.current.authReady).toBe(true));
+    await waitFor(() => expect(result.current.isAdmin).toBe(true));
+
+    await act(async () => {
+      handler?.('SIGNED_OUT', null);
+    });
+    await waitFor(() => expect(result.current.isAdmin).toBe(false));
+  });
+
+  it('edge case: handles rapid sign-in/out cycles and ends in the latest state', async () => {
+    /**
+     * Verifies resilience to quick successive auth events (e.g., flaky network / multiple tabs).
+     * The hook should converge to the state from the last event it receives.
+     */
+    let handler: ((event: string, session: any) => void) | null = null;
+    mockSupabaseClient.auth.onAuthStateChange.mockImplementationOnce((cb: any) => {
+      handler = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+    mockSupabaseClient.auth.getSession.mockResolvedValueOnce({ data: { session: null } });
+
+    const { useAuthState } = await import('@/hooks/useAuthState');
+    const { result } = renderHook(() => useAuthState(true));
+    await waitFor(() => expect(result.current.authReady).toBe(true));
+
+    await act(async () => {
+      handler?.('SIGNED_IN', { user: { id: 'u1' } });
+      handler?.('SIGNED_OUT', null);
+      handler?.('SIGNED_IN', { user: { id: 'u2' } });
+    });
+
+    // Assert within waitFor to ensure any follow-on effects are also wrapped in act().
+    await waitFor(() => expect(result.current.user).toMatchObject({ id: 'u2' }));
+  });
+});
+
+

--- a/tests/hooks/useCollections.test.ts
+++ b/tests/hooks/useCollections.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Phase 3.3: hooks/useCollections.ts — Collection Management Tests
+ *
+ * Success criteria (from docs/TESTING_ROADMAP.md Phase 3):
+ * - Collection fetching handles offline/online transitions
+ * - First-time admin seeding behavior works
+ * - Offline mode falls back to local cache
+ *
+ * IMPORTANT (TDD): Do not modify production implementations while writing these tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { UserCollection } from '@/types';
+import { CURRENT_SEED_VERSION, INITIAL_COLLECTIONS } from '@/services/seedCollections';
+
+const dbMocks = {
+  fetchCloudCollections: vi.fn(),
+  getLocalCollections: vi.fn(),
+  hasLocalOnlyData: vi.fn(),
+  requestPersistence: vi.fn(),
+  saveAllCollections: vi.fn(),
+  saveCollection: vi.fn(),
+  getSeedVersion: vi.fn(),
+  setSeedVersion: vi.fn(),
+};
+
+vi.mock('@/services/db', () => dbMocks);
+
+function minimalCollection(overrides: Partial<UserCollection> = {}): UserCollection {
+  return {
+    id: 'c1',
+    templateId: 'vinyl',
+    name: 'Test Collection',
+    icon: '🎷',
+    customFields: [],
+    items: [],
+    updatedAt: new Date().toISOString(),
+    settings: { displayFields: [], badgeFields: [] },
+    ...overrides,
+  } as UserCollection;
+}
+
+describe('hooks/useCollections.ts (Phase 3.3)', () => {
+  const t = (key: string) => key;
+  const showStatus = vi.fn();
+  const fallbackSampleCollections: UserCollection[] = [minimalCollection({ id: 'sample' })];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.requestPersistence.mockResolvedValue(undefined);
+    dbMocks.getLocalCollections.mockResolvedValue([]);
+    dbMocks.fetchCloudCollections.mockResolvedValue([]);
+    dbMocks.hasLocalOnlyData.mockReturnValue(false);
+    dbMocks.saveAllCollections.mockResolvedValue(undefined);
+    dbMocks.saveCollection.mockResolvedValue(undefined);
+    dbMocks.getSeedVersion.mockResolvedValue(CURRENT_SEED_VERSION);
+    dbMocks.setSeedVersion.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    showStatus.mockClear();
+  });
+
+  it('offline: when cloud fetch fails, falls back to local collections and exposes a sync-paused error', async () => {
+    /**
+     * Verifies offline behavior:
+     * - Cloud fetch failure does not blank the UI
+     * - Local IndexedDB cache is used
+     * - loadError is set and showStatus is called with an error tone
+     */
+    const local = [minimalCollection({ id: 'local' })];
+    dbMocks.getLocalCollections.mockResolvedValueOnce(local);
+    dbMocks.fetchCloudCollections.mockRejectedValueOnce(new Error('Network down'));
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'u1' } as any,
+        isAdmin: false,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.collections).toEqual(local);
+    expect(result.current.loadError).toContain('Unable to sync with Supabase');
+    expect(showStatus).toHaveBeenCalledWith('statusSyncPaused', 'error');
+  });
+
+  it('happy path: with a user, uses cloud collections, persists them locally, and reports synced', async () => {
+    /**
+     * Verifies standard online behavior:
+     * - Loads local cache
+     * - Fetches cloud collections
+     * - When there is no local-only data, saves cloud collections to local storage
+     * - Reports "synced" status
+     */
+    const local = [minimalCollection({ id: 'local' })];
+    const cloud = [minimalCollection({ id: 'cloud' })];
+    dbMocks.getLocalCollections.mockResolvedValueOnce(local);
+    dbMocks.fetchCloudCollections.mockResolvedValueOnce(cloud);
+    dbMocks.hasLocalOnlyData.mockReturnValueOnce(false);
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'u1' } as any,
+        isAdmin: false,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.collections).toEqual(cloud);
+    expect(result.current.loadError).toBeNull();
+    expect(result.current.hasLocalImport).toBe(false);
+    expect(dbMocks.saveAllCollections).toHaveBeenCalledWith(cloud);
+    expect(showStatus).toHaveBeenCalledWith('statusSynced', 'success');
+  });
+
+  it('first-time admin: when local+cloud are empty and seed version is outdated, seeds INITIAL_COLLECTIONS and sets seed version', async () => {
+    /**
+     * Verifies first-time/admin seeding path:
+     * - When both local and cloud are empty AND user is admin
+     * - If local seed version < CURRENT_SEED_VERSION
+     * - The hook saves each initial seed collection and updates seed version
+     */
+    dbMocks.getLocalCollections.mockResolvedValueOnce([]);
+    dbMocks.fetchCloudCollections.mockResolvedValueOnce([]);
+    dbMocks.hasLocalOnlyData.mockReturnValueOnce(false);
+    dbMocks.getSeedVersion.mockResolvedValueOnce(0);
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'admin-1' } as any,
+        isAdmin: true,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(dbMocks.saveCollection).toHaveBeenCalledTimes(INITIAL_COLLECTIONS.length);
+    const firstCallArg = dbMocks.saveCollection.mock.calls[0]?.[0];
+    expect(firstCallArg).toMatchObject({ ownerId: 'admin-1', isPublic: true });
+
+    expect(dbMocks.setSeedVersion).toHaveBeenCalledWith(CURRENT_SEED_VERSION);
+    expect(result.current.collections).toHaveLength(INITIAL_COLLECTIONS.length);
+  });
+
+  it('edge case: when Supabase is not ready, returns an empty collection list and does not error', async () => {
+    /**
+     * Verifies a boundary condition:
+     * - If Supabase is not ready, the hook should stop loading and return empty collections.
+     */
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: null,
+        isAdmin: false,
+        isSupabaseReady: false,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.collections).toEqual([]);
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it('edge case: signed-out user with no data uses fallback sample collections', async () => {
+    /**
+     * Verifies unauthenticated first-use behavior:
+     * - If there is no cloud data and no local cache, show sample/fallback collections.
+     */
+    dbMocks.getLocalCollections.mockResolvedValueOnce([]);
+    dbMocks.fetchCloudCollections.mockResolvedValueOnce([]);
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: null,
+        isAdmin: false,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.collections).toEqual(fallbackSampleCollections);
+  });
+});
+
+

--- a/tests/services/geminiService.test.ts
+++ b/tests/services/geminiService.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Phase 3.1: services/geminiService.ts — AI Analysis Tests
+ *
+ * Success criteria (from docs/TESTING_ROADMAP.md Phase 3):
+ * - AI service degrades gracefully on all failure modes (non-blocking)
+ * - Schema validation: response matches expected shape
+ * - Timeout handling: user can proceed without AI (timeout returns null)
+ *
+ * IMPORTANT (TDD): Do not modify production implementations while writing these tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { FieldDefinition } from '@/types';
+
+async function importGeminiServiceFresh(env: { aiEnabled?: string; apiBaseUrl?: string } = {}) {
+  vi.resetModules();
+  if (env.aiEnabled !== undefined) vi.stubEnv('VITE_AI_ENABLED', env.aiEnabled);
+  if (env.apiBaseUrl !== undefined) vi.stubEnv('VITE_API_BASE_URL', env.apiBaseUrl);
+  return await import('@/services/geminiService');
+}
+
+function createOkJsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('services/geminiService.ts - analyzeImage (Phase 3.1)', () => {
+  const fields: FieldDefinition[] = [
+    { id: 'artist', label: 'Artist', type: 'text' } as FieldDefinition,
+  ];
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:8787');
+    vi.stubEnv('VITE_AI_ENABLED', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('happy path: posts image + field schema to /api/gemini/analyze and returns {title, notes, data}', async () => {
+    /**
+     * Verifies the typical AI analysis request:
+     * - Uses the correct API route (the proxy/server exposes /api/gemini/analyze)
+     * - Sends { imageBase64, fields } in the JSON body
+     * - Returns the expected response shape for downstream UI usage
+     */
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (!url.endsWith('/api/gemini/analyze')) {
+        throw new Error(`Unexpected endpoint: ${url}`);
+      }
+      expect(init?.method).toBe('POST');
+      const body = JSON.parse(String(init?.body ?? 'null'));
+      expect(body).toMatchObject({ imageBase64: 'BASE64', fields });
+      return createOkJsonResponse({
+        title: 'Analyzed Item',
+        notes: 'AI notes',
+        data: { artist: 'Miles Davis' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const mod = await importGeminiServiceFresh();
+    const result = await mod.analyzeImage('BASE64', fields);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      title: 'Analyzed Item',
+      notes: 'AI notes',
+      data: { artist: 'Miles Davis' },
+    });
+  });
+
+  it('edge case: rejects invalid inputs (empty base64 or non-array fields) with a clear error', async () => {
+    /**
+     * Verifies input validation for boundary/empty inputs.
+     * The AI layer should fail fast with a helpful error instead of sending bad requests.
+     */
+    vi.stubGlobal('fetch', vi.fn());
+    const mod = await importGeminiServiceFresh();
+
+    // Empty base64 string
+    // Expectation: should throw (or otherwise clearly reject) due to invalid input.
+    await expect(mod.analyzeImage('', fields)).rejects.toThrow();
+
+    // Fields must be an array
+    await expect(mod.analyzeImage('BASE64', null as any)).rejects.toThrow();
+  });
+
+  it('timeout: returns null after ~30s when the request does not complete (non-blocking)', async () => {
+    /**
+     * Verifies non-blocking timeout behavior:
+     * - If the fetch never resolves, the request is aborted around 30 seconds
+     * - The function should resolve to null (caller can continue manually)
+     *
+     * NOTE: Uses fake timers to avoid waiting 30 real seconds.
+     */
+    vi.useFakeTimers();
+
+    const hangingFetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (signal) {
+          signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), {
+            once: true,
+          });
+        }
+      });
+    });
+    vi.stubGlobal('fetch', hangingFetch);
+
+    const mod = await importGeminiServiceFresh();
+
+    const promise = mod.analyzeImage('BASE64', fields) as unknown as Promise<any>;
+
+    // Attach handlers BEFORE advancing timers so AbortError never becomes "temporarily unhandled".
+    let resolvedValue: unknown;
+    let rejectedError: unknown;
+    const settled = promise.then((v) => (resolvedValue = v)).catch((e) => (rejectedError = e));
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await settled;
+
+    expect(rejectedError).toBeUndefined();
+    expect(resolvedValue).toBeNull();
+  });
+
+  it('error cases: network failures / 401 / 429 return null (graceful degradation)', async () => {
+    /**
+     * Verifies that common failure modes do not hard-block the UI:
+     * - transport/network error
+     * - invalid API key (401)
+     * - rate limiting (429)
+     *
+     * Expected behavior: return null so callers can fall back to manual entry.
+     */
+    const mod = await importGeminiServiceFresh();
+
+    // Network failure (fetch throws)
+    vi.stubGlobal('fetch', vi.fn(async () => Promise.reject(new Error('Network down'))));
+    {
+      const p = mod.analyzeImage('BASE64', fields);
+      let value: unknown;
+      let err: unknown;
+      await p.then((v) => (value = v)).catch((e) => (err = e));
+      expect(err).toBeUndefined();
+      expect(value).toBeNull();
+    }
+
+    // 401
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ error: 'Invalid API key' }), { status: 401 })),
+    );
+    {
+      const p = mod.analyzeImage('BASE64', fields);
+      let value: unknown;
+      let err: unknown;
+      await p.then((v) => (value = v)).catch((e) => (err = e));
+      expect(err).toBeUndefined();
+      expect(value).toBeNull();
+    }
+
+    // 429
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ error: 'Rate limit' }), { status: 429 })),
+    );
+    {
+      const p = mod.analyzeImage('BASE64', fields);
+      let value: unknown;
+      let err: unknown;
+      await p.then((v) => (value = v)).catch((e) => (err = e));
+      expect(err).toBeUndefined();
+      expect(value).toBeNull();
+    }
+  });
+
+  it('malformed JSON / schema mismatch: returns null (does not throw)', async () => {
+    /**
+     * Verifies robustness to unexpected server responses:
+     * - response.json() throws (malformed JSON)
+     * - missing required keys (schema mismatch)
+     *
+     * Expected behavior: return null and allow manual flow.
+     */
+    const mod = await importGeminiServiceFresh();
+
+    // Malformed JSON: response.json throws
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const res = createOkJsonResponse({ ok: true });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (res as any).json = () => Promise.reject(new Error('Invalid JSON'));
+        return res;
+      }),
+    );
+    {
+      const p = mod.analyzeImage('BASE64', fields);
+      let value: unknown;
+      let err: unknown;
+      await p.then((v) => (value = v)).catch((e) => (err = e));
+      expect(err).toBeUndefined();
+      expect(value).toBeNull();
+    }
+
+    // Schema mismatch: missing title/notes/data
+    vi.stubGlobal('fetch', vi.fn(async () => createOkJsonResponse({ title: 123 })));
+    {
+      const p = mod.analyzeImage('BASE64', fields);
+      let value: unknown;
+      let err: unknown;
+      await p.then((v) => (value = v)).catch((e) => (err = e));
+      expect(err).toBeUndefined();
+      expect(value).toBeNull();
+    }
+  });
+});
+
+


### PR DESCRIPTION
**Summary**

- Adds Phase 3 tests from docs/TESTING_ROADMAP.md covering:
  - 3.1 AI analysis (services/geminiService.ts)
  - 3.2 Auth lifecycle state (hooks/useAuthState.ts)
  - 3.3 Collections loading/seeding/offline (hooks/useCollections.ts)
- Also updates docs/TESTING_PROGRESS.md to mark Phase 3 complete.

**What changed**

- New tests
  - tests/services/geminiService.test.ts
  - tests/hooks/useAuthState.test.ts
  - tests/hooks/useCollections.test.ts
- Docs
  - docs/TESTING_PROGRESS.md updated (Phase 3 checked)

**Test results (current)**

- npm test currently reports Phase 3 hook suites passing, and Phase 3 AI suite failing as expected under TDD because production behavior doesn’t yet satisfy roadmap success criteria.

**Key failing expectations (Phase 3.1)**
These failures are intentional TDD signals (no production changes in this PR):
- Endpoint mismatch: geminiService.analyzeImage calls .../gemini/analyze but tests expect .../api/gemini/analyze.
- Graceful degradation: on timeout/network/HTTP errors/malformed JSON/schema mismatch, tests expect analyzeImage to return null (non-blocking), but it currently rejects/throws.

**Notes**
No production code was modified; this PR only adds tests + progress checklist updates.