### PR TITLE
Fix auth modal hook order crash

### DIFF
--- a/components/AuthModal.tsx
+++ b/components/AuthModal.tsx
@@ -32,15 +32,15 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onAuthSuc
       ? 'bg-white/5 border border-white/10 text-white placeholder:text-stone-400'
       : 'bg-stone-50 border border-stone-200 text-stone-900';
 
-  if (!isOpen) return null;
-
   // Basic modal a11y: Escape-to-close, focus trap, and focus restore.
   React.useEffect(() => {
+    if (!isOpen) return;
     lastFocusedElementRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
-  }, []);
+  }, [isOpen]);
 
   React.useEffect(() => {
+    if (!isOpen) return;
     const dialog = dialogRef.current;
 
     requestAnimationFrame(() => {
@@ -93,7 +93,9 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onAuthSuc
       document.removeEventListener('keydown', onKeyDown);
       lastFocusedElementRef.current?.focus?.();
     };
-  }, [onClose]);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
 
   if (!supabaseActive) {
     return (


### PR DESCRIPTION
### Motivation
- Opening the Sign In modal could make the app go blank because the modal component executed hooks conditionally, breaking React's hook order contract.
- Focus management and escape/Tab handling were running even when the modal was closed, which risked accessing DOM refs out of lifecycle.

### Description
- Guarded the modal accessibility effects with `isOpen` so they only run while the modal is visible by adding `if (!isOpen) return;` checks and adding `isOpen` to effect dependency arrays in `components/AuthModal.tsx`.
- Moved the early `if (!isOpen) return null;` to after the effects so hooks are always registered in the same order.
- Ensured focus restore and key handlers are cleaned up only when the modal was actually active.

### Testing
- No automated tests were run against this change.
- Existing component tests referencing `AuthModal` remain in the test suite (e.g. `tests/components/AuthModal.test.tsx`) but were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc4cb0c2483208c46a979ffcb3af2)