### PR TITLE
Prioritize viewport-based sizing for export preview

### DIFF
--- a/components/ExportModal.tsx
+++ b/components/ExportModal.tsx
@@ -102,13 +102,20 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     const titleSize = aspectRatio === '1:1' ? 'text-xl' : 'text-3xl';
     const metaSize = aspectRatio === '1:1' ? 'text-[8px]' : 'text-[10px]';
     const [ratioW, ratioH] = aspectRatio.split(':').map(Number);
-    const previewWidth = `min(80vw, 520px, calc((100dvh - var(--sheet-height)) * ${ratioW} / ${ratioH}))`;
+    const previewWidth = 'max(260px, min(85vw, 560px))';
+    const previewMaxWidth = 'min(85vw, 560px)';
+    const previewMaxHeight = 'min(80dvh, 720px)';
 
     return (
       <div
         id="card-preview"
         className={`shadow-2xl transition-all duration-300 overflow-hidden relative group select-none h-auto mx-auto print:h-auto print:!w-[100mm]`}
-        style={{ aspectRatio: `${ratioW} / ${ratioH}`, width: previewWidth }}
+        style={{
+          aspectRatio: `${ratioW} / ${ratioH}`,
+          width: previewWidth,
+          maxWidth: previewMaxWidth,
+          maxHeight: previewMaxHeight,
+        }}
       >
         <div className={`w-full h-full ${containerStyles[style]} transition-all duration-300`}>
           {style === 'minimal' && (


### PR DESCRIPTION
### Motivation
- Replace the previous height-coupled sizing that used `var(--sheet-height)` so the preview prioritizes viewport dimensions.
- Ensure the export card remains visually dominant with a safe minimum size and capped maximums.
- Avoid clipping and preserve the selected `aspectRatio` when resizing the preview.
- Prefer using `max-width`/`max-height` constraints on the preview container instead of tying width directly to sheet height.

### Description
- Updated `components/ExportModal.tsx` to replace the `previewWidth` calc that referenced `var(--sheet-height)` with `previewWidth = 'max(260px, min(85vw, 560px))'`.
- Added `previewMaxWidth = 'min(85vw, 560px)'` and `previewMaxHeight = 'min(80dvh, 720px)'` and applied them via inline styles (`width`, `maxWidth`, `maxHeight`) on `#card-preview`.
- Kept the `aspectRatio` style applied (`aspectRatio: "${ratioW} / ${ratioH}"`) so the preview respects the chosen aspect ratio without clipping.
- Change is localized to the preview sizing logic and does not alter visual templates or image handling.

### Testing
- Started the Vite dev server (`npm run dev`) successfully and the app served at the local URL.
- Ran a Playwright script to load the app and capture a screenshot of the export modal, which completed and produced `artifacts/export-modal.png`.
- No unit or integration test suite was run as part of this change.
- No automated test failures were encountered during the above runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec5c1c45883209e2f8fadd1e92f66)