### PR TITLE
chore: add issue drafts and link backlog items

### DIFF
--- a/docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md
+++ b/docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md
@@ -117,6 +117,8 @@ Rather than introducing new themes, we enhance the three existing themes with re
 
 ## Part 3: Photo Enhancement Tools
 
+**Tracking:** Enhance (client-side) is tracked in [#80](https://github.com/Akkkkkkki/curio/issues/80). Image edit proxy endpoint is tracked in [#78](https://github.com/Akkkkkkki/curio/issues/78). “Remove Background” / “Fix Blur” UI actions are tracked in [#81](https://github.com/Akkkkkkki/curio/issues/81). Photo variants storage/model work is tracked in [#82](https://github.com/Akkkkkkki/curio/issues/82).
+
 ### Design Principle: Invisible Intelligence
 
 Present features by their **outcome**, not their underlying technology. Users should see "Enhance" and "Remove Background" - not "AI-powered" or "Gemini Vision".
@@ -370,17 +372,17 @@ app.post('/api/gemini/edit-image', async (req, res) => {
 
 ### Phase 1: Client-Side Enhancement
 
-1. Create `services/imageEnhancer.ts` with CLAHE, vibrance, unsharp mask, white balance
-2. Add "Enhance" button to photo review step in AddItemModal
-3. Implement before/after preview UI
-4. Store enhanced variant alongside original
+1. Create `services/imageEnhancer.ts` with CLAHE, vibrance, unsharp mask, white balance (tracked in [#80](https://github.com/Akkkkkkki/curio/issues/80))
+2. Add "Enhance" button to photo review step in AddItemModal (tracked in [#80](https://github.com/Akkkkkkki/curio/issues/80))
+3. Implement before/after preview UI (tracked in [#80](https://github.com/Akkkkkkki/curio/issues/80))
+4. Store enhanced variant alongside original (tracked in [#82](https://github.com/Akkkkkkki/curio/issues/82))
 
 ### Phase 2: Gemini-Based Tools
 
-1. Add `/api/gemini/edit-image` endpoint to proxy server
-2. Implement "Remove Background" with universal prompt
-3. Implement "Fix Blur" with universal prompt
-4. Add these options to verify step as secondary actions
+1. Add `/api/gemini/edit-image` endpoint to proxy server (tracked in [#78](https://github.com/Akkkkkkki/curio/issues/78))
+2. Implement "Remove Background" with universal prompt (tracked in [#81](https://github.com/Akkkkkkki/curio/issues/81))
+3. Implement "Fix Blur" with universal prompt (tracked in [#81](https://github.com/Akkkkkkki/curio/issues/81))
+4. Add these options to verify step as secondary actions (tracked in [#81](https://github.com/Akkkkkkki/curio/issues/81))
 
 ### Phase 3: Theme Refinements
 

--- a/docs/INDEXEDDB_RELIABILITY.md
+++ b/docs/INDEXEDDB_RELIABILITY.md
@@ -115,7 +115,7 @@ App Load ← IndexedDB (cache) ←──────── Supabase (source of t
 
 **Note:** The `mergeCollections` function exists but isn't used in `loadCollections()`.
 
-**Status:** Not implemented in this PR. Could be addressed in a future update.
+**Status:** Not implemented in this PR. Could be addressed in a future update. (Tracked in [#84](https://github.com/Akkkkkkki/curio/issues/84))
 
 ---
 
@@ -123,7 +123,7 @@ App Load ← IndexedDB (cache) ←──────── Supabase (source of t
 
 **Problem:** If cloud upload fails, asset is stuck local-only with no retry mechanism.
 
-**Status:** Not implemented in this PR. Similar queue mechanism could be added for assets.
+**Status:** Not implemented in this PR. Similar queue mechanism could be added for assets. (Tracked in [#85](https://github.com/Akkkkkkki/curio/issues/85))
 
 ---
 
@@ -131,7 +131,7 @@ App Load ← IndexedDB (cache) ←──────── Supabase (source of t
 
 **Problem:** Large collections could hit IndexedDB quota limits without warning.
 
-**Status:** Not implemented in this PR. Low priority.
+**Status:** Not implemented in this PR. Low priority. (Tracked in [#83](https://github.com/Akkkkkkki/curio/issues/83))
 
 ---
 
@@ -143,9 +143,9 @@ After implementing fixes, verify:
 - [x] Sync errors display in status bar (P0 #2)
 - [x] Offline changes sync when back online (P1 #1)
 - [x] Concurrent saves don't corrupt data (P1 #2)
-- [ ] Local-only items survive cloud fetch (P2 - not implemented)
-- [ ] Failed asset uploads retry on reconnection (P2 - not implemented)
-- [ ] Large collections warn about storage limits (P3 - not implemented)
+- [ ] Local-only items survive cloud fetch (P2 - not implemented; tracked in [#84](https://github.com/Akkkkkkki/curio/issues/84))
+- [ ] Failed asset uploads retry on reconnection (P2 - not implemented; tracked in [#85](https://github.com/Akkkkkkki/curio/issues/85))
+- [ ] Large collections warn about storage limits (P3 - not implemented; tracked in [#83](https://github.com/Akkkkkkki/curio/issues/83))
 
 ---
 

--- a/docs/MVP_CHECKLIST.md
+++ b/docs/MVP_CHECKLIST.md
@@ -34,7 +34,7 @@ Purpose: Turn the MVP UX and aesthetic goals into an ordered, buildable plan wit
 
 ## P2 - Nice-to-Have MVP Extensions
 
-- [ ] Add inline field hints for custom templates; Tech design: display a short helper text per field in `ItemDetailScreen` and Add Item verify flow, using optional metadata in `TEMPLATES`.
-- [ ] Create a first-run empty state guide; Tech design: add a small "Getting Started" card on Home when `collections.length === 0` with 2-3 actions (create, sample, import) in `App.tsx`.
-- [ ] Provide lightweight accessibility polish; Tech design: add focus trap and ESC handling in modal components, plus `aria-label` on icon-only buttons in `components/Layout.tsx` and `components/ItemCard.tsx`.
-- [ ] Add a compact public sample update guide for admins; Tech design: document steps in `README.md` or a new `ADMIN_NOTES.md` and link from the access gate when `isAdmin` is true.
+- [ ] Add inline field hints for custom templates; Tech design: display a short helper text per field in `ItemDetailScreen` and Add Item verify flow, using optional metadata in `TEMPLATES`. (Tracked in [#76](https://github.com/Akkkkkkki/curio/issues/76))
+- [ ] Create a first-run empty state guide; Tech design: add a small "Getting Started" card on Home when `collections.length === 0` with 2-3 actions (create, sample, import) in `App.tsx`. (Tracked in [#77](https://github.com/Akkkkkkki/curio/issues/77))
+- [ ] Provide lightweight accessibility polish; Tech design: add focus trap and ESC handling in modal components, plus `aria-label` on icon-only buttons in `components/Layout.tsx` and `components/ItemCard.tsx`. (Tracked in [#79](https://github.com/Akkkkkkki/curio/issues/79))
+- [ ] Add a compact public sample update guide for admins; Tech design: document steps in `README.md` or a new `ADMIN_NOTES.md` and link from the access gate when `isAdmin` is true. (Tracked in [#86](https://github.com/Akkkkkkki/curio/issues/86))

--- a/docs/PRODUCT_DESIGN.md
+++ b/docs/PRODUCT_DESIGN.md
@@ -40,7 +40,7 @@ Curio is a digital sanctuary for physical collectors. Unlike marketplace-driven 
 3.  **Global Aesthetic Curation**:
     - **Dynamic Global Themes**: Users select from _The Gallery_ (Light/Airy), _The Vault_ (Moody/Dark), or _The Atelier_ (Artisanal/Warm).
 4.  **Security for High-Value Collections**:
-    - **Vault Lock**: Optional biometric-style lock for specific collections.
+    - **Vault Lock**: Optional biometric-style lock for specific collections. (Tracked in [#87](https://github.com/Akkkkkkki/curio/issues/87))
 
 ## 3. Design Language
 

--- a/docs/issue-drafts/2026-01-13/admin-sample-update-guide.md
+++ b/docs/issue-drafts/2026-01-13/admin-sample-update-guide.md
@@ -1,0 +1,39 @@
+## Title
+
+Document and surface an admin-only guide for updating the public sample gallery
+
+## Labels
+
+- type:enhancement
+- area:auth
+- severity:p3
+
+## Problem
+
+Admins need a lightweight, repeatable way to update the curated public sample gallery without guessing the workflow. Right now, the “how to update sample content” process isn’t clearly documented or discoverable in-product.
+
+## Steps to Reproduce
+
+N/A (enhancement)
+
+## Expected
+
+- A short admin guide exists in the repo (e.g. `ADMIN_NOTES.md` or `README.md` section) describing how to update sample collections/items safely.
+- If the user is an admin, the app provides a small link/entry point to that guide (or inline checklist) near the access gate/sample entry.
+
+## Actual
+
+No clear admin-facing sample update guide is documented/discoverable.
+
+## Acceptance Criteria
+
+- Add a concise admin guide documenting:
+  - where sample data is defined/seeded
+  - how to update images/metadata
+  - how to validate read-only behavior for non-admins
+  - how to ship updates safely
+- Add an admin-only UI link to the guide (or a minimal in-app note) when `isAdmin` is true.
+
+## Notes (optional)
+
+- Source: `docs/MVP_CHECKLIST.md` (P2 “public sample update guide for admins”).

--- a/docs/issue-drafts/2026-01-13/field-level-hints-for-templates.md
+++ b/docs/issue-drafts/2026-01-13/field-level-hints-for-templates.md
@@ -1,0 +1,41 @@
+## Title
+
+Add optional field-level hints for templates (show inline help in Add Item and Item Detail)
+
+## Labels
+
+- type:ux
+- area:forms
+- severity:p3
+
+## Problem
+
+Some template fields are not self-explanatory (especially for new collectors). We currently have template-level descriptions, but no per-field helper text. Inline hints can improve completion quality without adding clutter if implemented subtly.
+
+## Steps to Reproduce
+
+1. Create a collection using any template.
+2. Add an item and review the extracted fields.
+3. Notice there is no inline guidance for what to enter in each field.
+
+## Expected
+
+Templates can optionally provide short field hints (1 line), and the UI can display them under the label (or as a subtle “?” tooltip) in:
+
+- Add Item verify flow
+- Item Detail edit view
+
+## Actual
+
+`FieldDefinition` has no hint/help metadata, so the UI can’t display per-field guidance.
+
+## Acceptance Criteria
+
+- Extend `FieldDefinition` with an optional `hint` (or `helpText`) field.
+- Update templates to include a few high-value hints (keep it minimal).
+- Render hints in Add Item and Item Detail in a subtle, theme-aware way.
+- Ensure i18n works (either translate hints, or constrain to short English-only hints with a clear plan).
+
+## Notes (optional)
+
+- Source: `docs/MVP_CHECKLIST.md` (P2 inline field hints).

--- a/docs/issue-drafts/2026-01-13/first-run-getting-started-card-on-empty-home.md
+++ b/docs/issue-drafts/2026-01-13/first-run-getting-started-card-on-empty-home.md
@@ -1,0 +1,41 @@
+## Title
+
+Add a “Getting Started” guide card on empty Home screen (create / sample / import)
+
+## Labels
+
+- type:ux
+- area:auth
+- severity:p2
+
+## Problem
+
+We have a strong first-run access gate CTA set, but once a user gets to Home with no personal collections, we should provide a lightweight “Getting Started” guide card to reduce confusion and offer clear next actions.
+
+## Steps to Reproduce
+
+1. Run Curio with no user-created collections (fresh account or cleared state).
+2. Navigate to Home.
+
+## Expected
+
+Home shows a small “Getting Started” card with 2–3 clear actions:
+
+- Create/add first item
+- Explore sample
+- Import local data (if available)
+
+## Actual
+
+No dedicated “Getting Started” guide card exists on the empty Home state.
+
+## Acceptance Criteria
+
+- When the user has no editable collections, show a compact guide card on Home.
+- Keep the “single-path first run” constraint: one primary action, one secondary action, optional tertiary link.
+- Copy is short and value-focused; uses existing translations or adds new ones (EN + ZH).
+- Add a simple test (unit or e2e) verifying the card appears only in empty state.
+
+## Notes (optional)
+
+- Source: `docs/MVP_CHECKLIST.md` (P2 first-run empty state guide).

--- a/docs/issue-drafts/2026-01-13/gemini-image-edit-proxy-endpoint.md
+++ b/docs/issue-drafts/2026-01-13/gemini-image-edit-proxy-endpoint.md
@@ -1,0 +1,37 @@
+## Title
+
+Add `/api/gemini/edit-image` proxy endpoint for image background removal and deblur tools
+
+## Labels
+
+- type:enhancement
+- area:forms
+- severity:p2
+
+## Problem
+
+We want to offer simple, outcome-driven photo tools like “Remove Background” and “Fix Blur”. These require a server-side proxy endpoint to keep API keys off the client and to return image results.
+
+## Steps to Reproduce
+
+N/A (enhancement)
+
+## Expected
+
+The Gemini proxy server exposes a safe endpoint that accepts `{ image, prompt }` and returns a generated image result (base64), suitable for client-side tooling.
+
+## Actual
+
+No `/api/gemini/edit-image` endpoint exists in `server/geminiProxy.js`, and the client has no production implementation for these tools.
+
+## Acceptance Criteria
+
+- Add `POST /api/gemini/edit-image` to the proxy server (with basic validation and error handling).
+- Ensure response is consistent and includes the returned image data (base64).
+- Add a corresponding client helper in `services/geminiService.ts` (or a small dedicated module) for calling this endpoint.
+- Handle failure cases gracefully (timeout / model errors) without blocking item creation.
+- Add tests (unit-level) for request/response shape and error handling.
+
+## Notes (optional)
+
+- Source: `docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md` (Phase 2).

--- a/docs/issue-drafts/2026-01-13/modal-accessibility-standardize-focus-trap-escape-aria.md
+++ b/docs/issue-drafts/2026-01-13/modal-accessibility-standardize-focus-trap-escape-aria.md
@@ -1,0 +1,46 @@
+## Title
+
+Standardize modal accessibility across remaining modals (Escape, focus trap, aria labels, dialog semantics)
+
+## Labels
+
+- type:ux
+- area:forms
+- severity:p2
+
+## Problem
+
+Some modals implement good accessibility patterns (Escape-to-close, focus trap, focus restore, `role="dialog"`, `aria-modal`, close button `aria-label`). Others still miss parts of this, causing keyboard navigation issues and inconsistent UX.
+
+## Steps to Reproduce
+
+1. Open a modal that lacks focus trapping.
+2. Press Tab repeatedly and observe focus escaping behind the modal.
+3. Press Escape and observe inconsistent close behavior.
+
+## Expected
+
+All modals follow a consistent baseline:
+
+- Escape closes (unless explicitly unsafe)
+- Focus is trapped within the modal
+- Focus restores to the previous element on close
+- Dialog semantics are present (`role="dialog"`, `aria-modal`, `aria-labelledby`)
+- Icon-only buttons have `aria-label`
+
+## Actual
+
+Accessibility patterns are inconsistently implemented across modal components.
+
+## Acceptance Criteria
+
+- Audit all modal components and bring them to the same baseline behavior.
+- At minimum, address gaps in:
+  - `components/FilterModal.tsx`
+  - `components/ExportModal.tsx`
+  - `components/CreateCollectionModal.tsx` (if missing focus trap/escape semantics)
+- Add tests (or e2e coverage) verifying Escape closes and focus remains within the dialog.
+
+## Notes (optional)
+
+- Source: `docs/MVP_CHECKLIST.md` (P2 accessibility polish).

--- a/docs/issue-drafts/2026-01-13/photo-enhance-client-side-in-add-item-flow.md
+++ b/docs/issue-drafts/2026-01-13/photo-enhance-client-side-in-add-item-flow.md
@@ -1,0 +1,38 @@
+## Title
+
+Add a one-tap client-side “Enhance” photo tool in Add Item flow (before/after preview, non-destructive)
+
+## Labels
+
+- type:enhancement
+- area:forms
+- severity:p2
+
+## Problem
+
+Many capture photos are slightly dull/underexposed. Users want a quick improvement without becoming photo editors. We already have a guided capture flow; adding a single outcome-based enhancement (“Enhance”) can improve perceived quality and delight without adding complexity.
+
+## Steps to Reproduce
+
+N/A (enhancement)
+
+## Expected
+
+Users can tap **Enhance** during photo review to see a before/after comparison and choose which version to keep.
+
+## Actual
+
+No photo enhancement tools exist in the capture/review flow.
+
+## Acceptance Criteria
+
+- Add a new client-side enhancer (e.g. `services/imageEnhancer.ts`) implementing lightweight adjustments (contrast/vibrance/sharpen/WB) with fast performance.
+- Add an **Enhance** action in `components/AddItemModal.tsx` during the review/verify step.
+- Show a simple before/after preview with clear CTAs: “Use Enhanced” / “Keep Original”.
+- Non-destructive: original always remains available.
+- Store the chosen variant so it persists across app restarts (local cache at minimum).
+- Keep time-to-first-item under 5 minutes; enhancement must be optional and not block save.
+
+## Notes (optional)
+
+- Source: `docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md` (Phase 1).

--- a/docs/issue-drafts/2026-01-13/photo-remove-background-and-fix-blur-actions.md
+++ b/docs/issue-drafts/2026-01-13/photo-remove-background-and-fix-blur-actions.md
@@ -1,0 +1,44 @@
+## Title
+
+Add “Remove Background” and “Fix Blur” actions in photo review (optional, recoverable AI)
+
+## Labels
+
+- type:enhancement
+- area:forms
+- severity:p2
+
+## Problem
+
+After capture, users often want quick outcomes like isolating an object for a clean catalog look (background removal) or improving a slightly blurry photo. These tools should feel optional and “invisible AI”, and must never block completing an item.
+
+## Steps to Reproduce
+
+N/A (enhancement)
+
+## Expected
+
+In the photo review/verify step, users can optionally run:
+
+- **Remove Background**
+- **Fix Blur**
+
+They can preview results and choose which variant to keep, or revert to original.
+
+## Actual
+
+No UI actions exist for these tools.
+
+## Acceptance Criteria
+
+- Add “Remove Background” and “Fix Blur” buttons in `components/AddItemModal.tsx` (verify step).
+- Use a universal prompt approach (no prompt engineering UI).
+- Show progress state and allow cancel/back without losing the item draft.
+- Results are previewable with clear CTAs: “Use Result” / “Keep Original”.
+- Failures show a friendly message and return user to manual flow; no hard blockers.
+- Ensure variants persist (at least locally) once selected.
+
+## Notes (optional)
+
+- Depends on: `/api/gemini/edit-image` proxy endpoint.
+- Source: `docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md` (Phase 2).

--- a/docs/issue-drafts/2026-01-13/photo-variants-storage-and-active-variant.md
+++ b/docs/issue-drafts/2026-01-13/photo-variants-storage-and-active-variant.md
@@ -1,0 +1,42 @@
+## Title
+
+Support multiple photo variants per item (enhanced / background-removed) with an active display variant
+
+## Labels
+
+- type:enhancement
+- area:sync
+- severity:p2
+
+## Problem
+
+To keep photo editing non-destructive and trustworthy, Curio needs to store multiple photo variants and allow choosing which one is displayed/exported, while still backing up variants to cloud storage.
+
+## Steps to Reproduce
+
+N/A (enhancement)
+
+## Expected
+
+Items can store and switch between multiple variants:
+
+- original (existing)
+- display (existing)
+- enhanced (new)
+- no-background (new, PNG)
+
+## Actual
+
+Only original/display variants are supported today; no first-class model/storage for additional variants exists.
+
+## Acceptance Criteria
+
+- Extend the item model to track optional variant paths and an `activePhotoVariant` (or equivalent).
+- Add IndexedDB storage support for new variant blobs (new stores or keyed variants).
+- Add Supabase Storage paths/policies for new variants (e.g. `_enhanced.jpg`, `_nobg.png`).
+- Ensure export/view uses the active variant (fallback to display/original).
+- Add migration/backwards compatibility strategy for existing items.
+
+## Notes (optional)
+
+- Source: `docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md` (Data model + storage structure section).

--- a/docs/issue-drafts/2026-01-13/sync-handle-indexeddb-quota-exhaustion.md
+++ b/docs/issue-drafts/2026-01-13/sync-handle-indexeddb-quota-exhaustion.md
@@ -1,0 +1,41 @@
+## Title
+
+Warn users on IndexedDB quota exhaustion and handle QuotaExceededError gracefully
+
+## Labels
+
+- type:ux
+- area:sync
+- severity:p3
+
+## Problem
+
+Large collections or large image blobs can hit browser storage limits. Today, quota exhaustion can surface as IndexedDB write failures without clear user guidance, creating confusion and risk of perceived data loss.
+
+## Steps to Reproduce
+
+1. Add many high-resolution photos (or very large blobs) until the browser’s storage quota is reached.
+2. Attempt to add another item/photo.
+
+## Expected
+
+The app should detect “low storage” conditions and/or handle quota errors by:
+
+- Showing a clear toast/inline message explaining what happened
+- Offering actionable guidance (e.g. delete items/photos, reduce image size, or export/back up)
+- Avoiding silent failure states
+
+## Actual
+
+Quota-related failures are not surfaced clearly to users.
+
+## Acceptance Criteria
+
+- Detect storage pressure using `navigator.storage.estimate()` when available.
+- Catch quota errors on IndexedDB writes (e.g. QuotaExceededError / DOMException) and surface a user-visible message.
+- Add a small “storage health” note in relevant flows (photo save / import) when at risk.
+- Add tests for quota exhaustion scenarios (mocked) to ensure UX feedback appears and app remains usable.
+
+## Notes (optional)
+
+- Mentioned as a remaining item in `docs/INDEXEDDB_RELIABILITY.md` (“No Storage Quota Checks”).

--- a/docs/issue-drafts/2026-01-13/sync-merge-preserve-local-on-cloud-refresh.md
+++ b/docs/issue-drafts/2026-01-13/sync-merge-preserve-local-on-cloud-refresh.md
@@ -1,0 +1,44 @@
+## Title
+
+Prevent cloud refresh from overwriting unsynced local collections (use merge logic in `loadCollections`)
+
+## Labels
+
+- type:bug
+- area:sync
+- severity:p1
+
+## Problem
+
+`services/db.ts` `loadCollections()` currently fetches cloud collections and then **blindly overwrites** IndexedDB with the cloud result (`saveAllCollections(cloudCollections)`), returning cloud data.
+
+This can effectively **delete or hide local-only / not-yet-synced collections/items** (e.g. created offline or during transient auth/network issues), violating the “local cache as resilience” promise and creating data loss risk.
+
+## Steps to Reproduce
+
+1. Create or modify a collection while offline (or while cloud sync is failing).
+2. Ensure local changes exist but are not in Supabase yet.
+3. Restore connectivity and trigger a refresh (app load or manual refresh that calls `loadCollections()`).
+
+## Expected
+
+Local-only changes should **survive** a cloud refresh and be merged with cloud state, while still respecting cloud deletions and conflict resolution rules.
+
+## Actual
+
+Cloud refresh overwrites local IndexedDB collections with the cloud snapshot, potentially removing local-only data.
+
+## Acceptance Criteria
+
+- `loadCollections()` uses `mergeCollections(local, cloud)` (and `mergeItems` as needed) instead of overwriting local with cloud.
+- Local-only collections/items remain visible after a cloud refresh.
+- Cloud deletions are still respected (do not resurrect deleted cloud entities).
+- Conflicts are resolved deterministically (timestamps when enabled, otherwise current merge rules).
+- Add/update tests covering at least:
+  - local-only items survive cloud fetch
+  - cloud deletion removes locally cached items
+  - timestamp conflict resolution behavior
+
+## Notes (optional)
+
+- Documented as a remaining gap in `docs/INDEXEDDB_RELIABILITY.md` (“`loadCollections` Ignores Merge Logic”).

--- a/docs/issue-drafts/2026-01-13/sync-retry-failed-asset-uploads.md
+++ b/docs/issue-drafts/2026-01-13/sync-retry-failed-asset-uploads.md
@@ -1,0 +1,42 @@
+## Title
+
+Retry failed Supabase Storage asset uploads (queue + online retry) to avoid local-only image orphans
+
+## Labels
+
+- type:bug
+- area:sync
+- severity:p2
+
+## Problem
+
+`services/db.ts` `saveAsset()` uploads original/display images to Supabase Storage but on failure it only logs a warning and does not retry.
+
+This leaves assets **stuck local-only** (and potentially inconsistent with item metadata in the cloud), which can degrade cross-device usage and undermine trust in sync.
+
+## Steps to Reproduce
+
+1. Add an item with a photo while offline or with flaky connectivity.
+2. Ensure the item record is created locally (and may sync later).
+3. Trigger `saveAsset()` while the network/storage upload fails.
+4. Restore connectivity.
+
+## Expected
+
+Failed asset uploads are **queued** and automatically retried when the app is online (and/or on startup), with user-visible status when appropriate.
+
+## Actual
+
+Asset uploads fail silently (aside from console warnings) and are never retried.
+
+## Acceptance Criteria
+
+- Introduce a persistent pending-asset-upload queue (likely in IndexedDB `settings` store, similar to pending collection sync).
+- Queue entries include enough information to retry (collectionId, itemId, variant(s), remote paths if needed).
+- On `online` event and on app startup, retry queued uploads until success; remove from queue on success.
+- Provide minimal user feedback (e.g. “Will sync photos” / “Photos synced”) aligned with existing sync status patterns.
+- Add/update tests that simulate upload failures and verify retry + eventual success.
+
+## Notes (optional)
+
+- Documented as a remaining gap in `docs/INDEXEDDB_RELIABILITY.md` (“Asset Sync Failures Leave Orphans”).

--- a/docs/issue-drafts/2026-01-13/vault-lock-for-collections.md
+++ b/docs/issue-drafts/2026-01-13/vault-lock-for-collections.md
@@ -1,0 +1,37 @@
+## Title
+
+Add “Vault Lock” to protect selected collections (lock/unlock UX + gated access)
+
+## Labels
+
+- type:enhancement
+- area:auth
+- severity:p3
+
+## Problem
+
+Some users maintain high-value collections and want an extra privacy layer. The product doc proposes “Vault Lock” to gate access to specific collections. We currently have an `isLocked` field in the type model but no end-to-end lock UX or enforcement.
+
+## Steps to Reproduce
+
+N/A (enhancement)
+
+## Expected
+
+Users can mark a collection as locked, and unlocking is required before viewing/editing its items.
+
+## Actual
+
+Lock is not fully implemented (no reliable UX or gating).
+
+## Acceptance Criteria
+
+- Add a lock/unlock control for eligible collections (settings/menu).
+- Enforce locked state in routing/views (collection screen + item detail) with a clear unlock prompt.
+- Define an MVP unlock mechanism (e.g. device-level gate or simple passcode) that works cross-platform.
+- Ensure public/sample collections remain read-only and are not lockable.
+- Add tests ensuring locked collections cannot be accessed without unlock.
+
+## Notes (optional)
+
+- Source: `docs/PRODUCT_DESIGN.md` (“Vault Lock”).


### PR DESCRIPTION
Adds a dated batch of issue drafts and updates design/reliability docs to reference the created GitHub issues for tracking.