### PR TITLE
Add sync feedback and retry actions to status toasts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -54,6 +54,9 @@ import {
   getSeedVersion,
   setSeedVersion,
   initDB,
+  setSyncStatusCallback,
+  syncPendingChanges,
+  type SyncStatus,
 } from './services/db';
 import { processImage } from './services/imageProcessor';
 import { ItemImage } from './components/ItemImage';
@@ -100,7 +103,11 @@ const AppContent: React.FC = () => {
   const [status, setStatus] = useState<{
     message: string;
     tone: StatusTone;
+    actionLabel?: string;
+    onAction?: () => void;
   } | null>(null);
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
+  const [syncError, setSyncError] = useState<string | null>(null);
   const [pendingAuthAction, setPendingAuthAction] = useState<
     'add-item' | 'create-collection' | null
   >(null);
@@ -109,6 +116,7 @@ const AppContent: React.FC = () => {
   );
   const saveTimeoutRef = useRef<Record<string, any>>({});
   const statusTimeoutRef = useRef<number | null>(null);
+  const pendingSyncToastRef = useRef(false);
   const isSupabaseReady = isSupabaseConfigured();
   const fallbackSampleCollections = useMemo(
     () =>
@@ -120,19 +128,85 @@ const AppContent: React.FC = () => {
     [],
   );
 
-  const showStatus = useCallback((message: string, tone: StatusTone = 'info') => {
-    if (statusTimeoutRef.current) {
-      clearTimeout(statusTimeoutRef.current);
+  const showStatus = useCallback(
+    (
+      message: string,
+      tone: StatusTone = 'info',
+      options?: { actionLabel?: string; onAction?: () => void; durationMs?: number },
+    ) => {
+      if (statusTimeoutRef.current) {
+        clearTimeout(statusTimeoutRef.current);
+      }
+      setStatus({
+        message,
+        tone,
+        actionLabel: options?.actionLabel,
+        onAction: options?.onAction,
+      });
+      const durationMs = options?.durationMs ?? (options?.actionLabel ? 6000 : 2400);
+      statusTimeoutRef.current = window.setTimeout(() => setStatus(null), durationMs);
+    },
+    [],
+  );
+
+  const handleRetrySync = useCallback(async () => {
+    try {
+      const synced = await syncPendingChanges();
+      if (synced > 0) {
+        showStatus(t('statusPendingSynced').replace('{count}', String(synced)), 'success');
+      } else {
+        showStatus(t('statusWillSync'), 'warning');
+      }
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : t('statusSyncPaused');
+      showStatus(t('statusSyncError').replace('{error}', errorMessage), 'error', {
+        actionLabel: t('actionRetry'),
+        onAction: () => handleRetrySync(),
+      });
     }
-    setStatus({ message, tone });
-    statusTimeoutRef.current = window.setTimeout(() => setStatus(null), 2400);
-  }, []);
+  }, [showStatus, t]);
 
   useEffect(() => {
     return () => {
       if (statusTimeoutRef.current) clearTimeout(statusTimeoutRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    const handleSyncStatus = (status: SyncStatus, error?: string) => {
+      setSyncStatus(status);
+      setSyncError(error ?? null);
+    };
+    setSyncStatusCallback(handleSyncStatus);
+    return () => setSyncStatusCallback(null);
+  }, []);
+
+  useEffect(() => {
+    if (!pendingSyncToastRef.current) return;
+
+    if (syncStatus === 'synced') {
+      showStatus(t('statusSynced'), 'success');
+      pendingSyncToastRef.current = false;
+    }
+
+    if (syncStatus === 'offline') {
+      showStatus(t('statusWillSync'), 'warning');
+      pendingSyncToastRef.current = false;
+    }
+
+    if (syncStatus === 'error') {
+      const errorMessage = syncError || t('statusSyncPaused');
+      if (!navigator.onLine) {
+        showStatus(t('statusWillSync'), 'warning');
+      } else {
+        showStatus(t('statusSyncError').replace('{error}', errorMessage), 'error', {
+          actionLabel: t('actionRetry'),
+          onAction: () => handleRetrySync(),
+        });
+      }
+      pendingSyncToastRef.current = false;
+    }
+  }, [handleRetrySync, showStatus, syncError, syncStatus, t]);
 
   useEffect(() => {
     if (!isSupabaseReady || !supabase) {
@@ -448,6 +522,8 @@ const AppContent: React.FC = () => {
     itemData: Omit<CollectionItem, 'id' | 'createdAt' | 'updatedAt'>,
   ) => {
     if (!canEditCollection(collectionId)) return;
+    pendingSyncToastRef.current = true;
+    if (!isSupabaseReady) pendingSyncToastRef.current = false;
     const itemId = Math.random().toString(36).substr(2, 9);
     const now = new Date().toISOString();
     let hasPhoto = false;
@@ -513,6 +589,8 @@ const AppContent: React.FC = () => {
       setIsCreateCollectionOpen(false);
       return;
     }
+    pendingSyncToastRef.current = true;
+    if (!isSupabaseReady) pendingSyncToastRef.current = false;
     const template = TEMPLATES.find((t) => t.id === templateId) || TEMPLATES[0];
     const newCol: UserCollection = {
       id: Math.random().toString(36).substr(2, 9),
@@ -1581,6 +1659,8 @@ const AppContent: React.FC = () => {
           <StatusToast
             message={status.message}
             tone={status.tone}
+            actionLabel={status.actionLabel}
+            onAction={status.onAction}
             onDismiss={() => setStatus(null)}
           />
         </div>

--- a/components/StatusToast.tsx
+++ b/components/StatusToast.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { CheckCircle, AlertTriangle, Info } from 'lucide-react';
+import { CheckCircle, AlertTriangle, Info, AlertCircle } from 'lucide-react';
 
-export type StatusTone = 'success' | 'error' | 'info';
+export type StatusTone = 'success' | 'error' | 'info' | 'warning';
 
 interface StatusToastProps {
   message: string;
   tone?: StatusTone;
   onDismiss?: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
 }
 
 const toneStyles: Record<StatusTone, { bg: string; text: string; Icon: React.ComponentType<any> }> =
@@ -26,19 +28,41 @@ const toneStyles: Record<StatusTone, { bg: string; text: string; Icon: React.Com
       text: 'text-stone-700',
       Icon: Info,
     },
+    warning: {
+      bg: 'bg-amber-50 border-amber-100',
+      text: 'text-amber-800',
+      Icon: AlertCircle,
+    },
   };
 
-export const StatusToast: React.FC<StatusToastProps> = ({ message, tone = 'info', onDismiss }) => {
+export const StatusToast: React.FC<StatusToastProps> = ({
+  message,
+  tone = 'info',
+  onDismiss,
+  actionLabel,
+  onAction,
+}) => {
   const { bg, text, Icon } = toneStyles[tone];
   return (
     <div
       data-testid="status-toast"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
       className={`pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-2xl border shadow-lg ${bg} ${text} motion-pop`}
     >
       <Icon size={18} />
       <span className="text-sm font-semibold leading-tight" data-testid="status-toast-message">
         {message}
       </span>
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          className="ml-2 text-xs font-bold uppercase tracking-[0.08em] text-amber-700 hover:text-amber-900"
+        >
+          {actionLabel}
+        </button>
+      )}
       {onDismiss && (
         <button
           onClick={onDismiss}

--- a/i18n.ts
+++ b/i18n.ts
@@ -123,6 +123,7 @@ export const translations = {
     statusSaved: 'Saved to your archive',
     statusSynced: 'Synced',
     statusSyncPaused: 'Sync paused',
+    statusWillSync: 'Will sync / retrying',
     statusImportComplete: 'Imported from local storage',
     statusImportFailed: 'Import failed',
     // IndexedDB Recovery Messages
@@ -135,6 +136,7 @@ export const translations = {
     statusSyncError: 'Sync failed: {error}',
     statusPendingSyncs: '{count} change(s) pending sync',
     statusPendingSynced: '{count} pending change(s) synced',
+    actionRetry: 'Retry',
     // Auth & Cloud
     login: 'Sign In',
     register: 'Create Account',
@@ -326,6 +328,7 @@ export const translations = {
     statusSaved: '已保存到档案',
     statusSynced: '已同步',
     statusSyncPaused: '同步暂停',
+    statusWillSync: '将同步 / 正在重试',
     statusImportComplete: '本地数据已导入',
     statusImportFailed: '导入失败，请重试。',
     // IndexedDB Recovery Messages
@@ -337,6 +340,7 @@ export const translations = {
     statusSyncError: '同步失败：{error}',
     statusPendingSyncs: '{count} 项更改待同步',
     statusPendingSynced: '{count} 项待同步更改已完成',
+    actionRetry: '重试',
     // Auth & Cloud
     login: '登录',
     register: '创建账号',


### PR DESCRIPTION
### Motivation

- Surface reliable save/sync lifecycle feedback to users so local "Saved" state is followed by deterministic cloud sync status updates. 
- Allow users to retry failed syncs directly from the toast to reduce friction during intermittent connectivity. 
- Provide accessible live-region semantics for status updates to improve screen reader behavior.

### Description

- Extend `StatusToast` to support a `warning` tone, optional `actionLabel`/`onAction` callback, and ARIA live-region attributes (`role="status"`, `aria-live="polite"`, `aria-atomic="true"`).
- Add a `warning` style and icon mapping in `components/StatusToast.tsx` and expose the action button when provided.
- Add sync lifecycle strings `statusWillSync` and `actionRetry` to `i18n.ts` for both English and Chinese locales.
- Wire up sync-state handling in `App.tsx` by tracking `pendingSyncToastRef`, subscribing via `setSyncStatusCallback`, and showing retryable toasts that call `syncPendingChanges` when appropriate.

### Testing

- Attempted to run the dev server with `npm run dev`, but startup failed due to a missing dependency (`@vercel/speed-insights/react`) preventing the full app from running. 
- No automated test suite was executed as part of this change due to the dev server failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966df3681348320b4b084395bd377cd)