### PR TITLE
Fix Supabase items photo columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ GEMINI_API_KEY=your_api_key_here
 **Database Schema:**
 
 - `collections` table: id (text), user_id, template_id, name, icon, settings (jsonb), seed_key, is_public, created_at, updated_at
-- `items` table: id (text), collection_id, user_id, title, rating, notes, data (jsonb), photo_path (legacy), photo_original_path, photo_display_path, seed_key, created_at, updated_at
+- `items` table: id (text), collection_id, user_id, title, rating, notes, data (jsonb), photo_original_path, photo_display_path, seed_key, created_at, updated_at
 - `profiles` table: id (uuid), seed_version, is_admin, created_at
 - RLS enforces per-user access, plus public read on `is_public` collections/items and admin-only edits
 - Update trigger (`set_updated_at()`) auto-maintains `updated_at` timestamps for conflict resolution

--- a/docs/TESTING_REVIEW.md
+++ b/docs/TESTING_REVIEW.md
@@ -127,7 +127,7 @@ e2e/                   # Phase 5: End-to-end tests
   - Very old/future dates
 - **normalizePhotoPaths**: Thorough path normalization testing
   - Empty/null handling
-  - Legacy `photo_path` migration
+  - Legacy photo path migration
   - Modern path formats
   - Supabase URL extraction
   - Edge cases (missing fields, partial data)

--- a/docs/TESTING_ROADMAP.md
+++ b/docs/TESTING_ROADMAP.md
@@ -42,7 +42,7 @@
   - Test cases: local newer, cloud newer, equal, undefined handling
   - Edge cases: malformed timestamps, timezone differences
 - `normalizePhotoPaths(item)`
-  - Test cases: legacy `photo_path` migration, modern paths, missing paths
+  - Test cases: legacy photo path migration, modern paths, missing paths
   - Edge cases: null/undefined items, partial path data
 
 **Deliverable:** `tests/unit/services/db.pure.test.ts`

--- a/docs/TESTING_SETUP_SUMMARY.md
+++ b/docs/TESTING_SETUP_SUMMARY.md
@@ -128,7 +128,7 @@ Mock data factories:
 
 - `mockCollection` - Pre-defined collection
 - `mockItem` - Pre-defined item
-- `mockItemWithLegacyPath` - Legacy photo_path migration testing
+- `mockItemWithLegacyPath` - Legacy photo path migration testing
 - `createMockCollection()` - Factory with overrides
 - `createMockItem()` - Factory with overrides
 - `createMockCollections()` - Batch generation

--- a/services/db.ts
+++ b/services/db.ts
@@ -432,7 +432,7 @@ const mapCloudCollections = (cols: any[], items: any[]): UserCollection[] => {
     const colItems: CollectionItem[] = (items || [])
       .filter((i) => i.collection_id === c.id)
       .map((i) => {
-        // Prefer new explicit columns; avoid relying on legacy `photo_path`.
+        // Use explicit columns for storage paths.
         const photoPath = i.photo_display_path || i.photo_original_path || '';
         return {
           id: i.id,

--- a/supabase/1_schema.sql
+++ b/supabase/1_schema.sql
@@ -82,7 +82,6 @@ create table if not exists public.items (
   notes text,
   rating int not null default 0 check (rating >= 0 and rating <= 5),
   data jsonb not null default '{}'::jsonb,
-  photo_path text,
   photo_original_path text,
   photo_display_path text,
   seed_key text,

--- a/tests/utils/fixtures/collections.ts
+++ b/tests/utils/fixtures/collections.ts
@@ -62,9 +62,8 @@ export const mockItem: CollectionItem = {
 export const mockItemWithLegacyPath: CollectionItem = {
   ...mockItem,
   id: 'test-item-legacy',
-  photo_path: 'legacy/path.jpg',
-  photo_original_path: undefined,
-  photo_display_path: undefined,
+  photo_original_path: 'legacy/path.jpg',
+  photo_display_path: 'legacy/path.jpg',
 };
 
 export const mockCollectionWithItems: UserCollection = {


### PR DESCRIPTION
## Summary
- Remove legacy `photo_path` usage and standardize on `photo_original_path` + `photo_display_path`.
- Align schema docs/tests and `supabase/1_schema.sql` with the new columns to prevent sync 400s.

## Test plan
- [x] `npx vitest run tests/services/db.operations.test.ts --pool=threads`
- [ ] In Supabase: ensure `public.items` has `photo_original_path` + `photo_display_path`, add an item in-app, confirm no sync error toast.

## Notes
- Excluded unrelated untracked file: `docs/PRODUCT_REVIEW_FEEDBACK_20260113.md`.