### PR TITLE
Fix manual entry fallback during AI analysis

### DIFF
--- a/components/AddItemModal.tsx
+++ b/components/AddItemModal.tsx
@@ -311,11 +311,13 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     setError(null);
     setFormData(createEmptyForm());
     const aiEnabled = await refreshAiEnabled();
+    if (analysisRunId.current !== runId) return;
     if (!aiEnabled) {
       setError(t('aiUnavailableManual'));
       setStep('verify');
       return;
     }
+    if (analysisRunId.current !== runId) return;
     setStep('analyzing');
     try {
       const base64Data = base64.split(',')[1];

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -218,6 +218,28 @@ describe('AddItemModal', () => {
         expect(screen.getByText(/enter manually/i)).toBeInTheDocument();
       });
     });
+
+    it('switches to manual entry when "Enter manually" is clicked during analysis', async () => {
+      const user = userEvent.setup();
+      mockAnalyzeImage.mockImplementation(() => new Promise(() => {}));
+
+      renderWithProviders(<AddItemModal {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('add-item-file-input') as HTMLInputElement;
+      const file = new File(['test image content'], 'test.jpg', { type: 'image/jpeg' });
+
+      await waitFor(() => {
+        fireEvent.change(fileInput, { target: { files: [file] } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/enter manually/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText(/enter manually/i));
+
+      expect(screen.getByText(/Add to Collection/i)).toBeInTheDocument();
+    });
   });
 
   describe('AI Failure Handling (Graceful Degradation)', () => {


### PR DESCRIPTION
### Motivation

- Prevent a race where async AI availability/analysis results overwrite a user-triggered manual-entry transition, causing the “Enter manually” fallback to appear unresponsive.

### Description

- Add run-id guards in `analyze` to bail out if the analysis run was superseded before/after `refreshAiEnabled`, preventing late async updates from reverting a manual switch.
- Keep form state reset and error handling but ensure `setStep('verify')` or `setStep('analyzing')` are skipped when the run is stale.
- Add a regression test `switches to manual entry when "Enter manually" is clicked during analysis` in `tests/components/AddItemModal.test.tsx` that simulates a hanging analysis and verifies the manual form appears.

### Testing

- Added a unit test that clicks the in-flight-analysis "Enter manually" button and asserts the verify/manual UI is shown (`tests/components/AddItemModal.test.tsx`).
- No test suite was executed as part of this change (automated test run was not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969762478f08320b77a103688e7f611)