### PR TITLE
Refine mobile collection controls and add mobile development guidelines

### DIFF
--- a/docs/PRODUCT_DESIGN.md
+++ b/docs/PRODUCT_DESIGN.md
@@ -63,6 +63,17 @@ This section captures **current behavior in the codebase** (so docs stay actiona
   - Batch mode is present but not primary (it’s discoverable as an optional link).
 - **AI failures are boring**: show a short “AI unavailable—continue manually” message and keep the user on the same screen.
 
+### Mobile development guidelines (Curio-first, industry-aligned)
+
+- **Mobile-first layout**: design for narrow viewports first, then scale up with responsive breakpoints. If a layout works at 360–430px width, it will scale cleanly. Avoid relying on hover to discover critical actions.
+- **Thumb-friendly actions**: primary actions should be near the top or bottom and have comfortable spacing. Treat **44×44px** as the minimum interactive target size for tap areas.
+- **Content density**: prioritize scannability (short headings, two-line clamp where needed). If content is hidden, provide an obvious path to reveal it without navigation churn.
+- **Input ergonomics**: use appropriate input types (e.g., numeric keyboards for years, decimal for prices) and avoid wide multi-step forms on small screens—keep flows on one page when possible.
+- **Safe-area + fixed UI**: respect safe-area insets for top/bottom fixed elements and ensure floating bars do not cover important content.
+- **Performance perception**: keep first screen fast and provide immediate feedback for save/sync actions. If an operation is async, show status and keep the UI usable.
+- **Accessibility baseline**: maintain readable contrast and font sizes; avoid tiny labels on mobile. Ensure focus states are visible for keyboard and assistive tech.
+- **Testing expectation**: validate changes at common mobile sizes (e.g., 360×740, 390×844) and at least one small Android device size. Include screenshots for perceptible UI changes.
+
 ## 2.1 AI image features (design + cost guardrails)
 
 Curio’s AI image work should be **explicitly optional**, **recoverable**, and **cost-aware**:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1085,85 +1085,89 @@ const AppContent: React.FC = () => {
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-4 flex-wrap">
-            {canAddItems && (
+          <div className="flex flex-col gap-3 w-full lg:w-auto">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 w-full">
+              {canAddItems && (
+                <Button
+                  variant="primary"
+                  onClick={() => setIsAddModalOpen(true)}
+                  icon={<Plus size={16} />}
+                  className="shadow-md w-full sm:w-auto"
+                >
+                  {t('addItem')}
+                </Button>
+              )}
               <Button
                 variant="primary"
-                onClick={() => setIsAddModalOpen(true)}
-                icon={<Plus size={16} />}
-                className="shadow-md"
+                onClick={() => setIsExhibitionOpen(true)}
+                disabled={collection.items.length === 0}
+                icon={<Play size={16} />}
+                className="shadow-md w-full sm:w-auto"
               >
-                {t('addItem')}
+                {t('enterExhibition')}
               </Button>
-            )}
-            <Button
-              variant="primary"
-              onClick={() => setIsExhibitionOpen(true)}
-              disabled={collection.items.length === 0}
-              icon={<Play size={16} />}
-              className="shadow-md"
-            >
-              {t('enterExhibition')}
-            </Button>
-            <Button
-              variant="outline"
-              className={theme === 'vault' ? 'bg-stone-900 text-white border-white/10' : 'bg-white'}
-              onClick={() => {
-                if (isVoiceGuideEnabled) {
-                  setActiveCollectionForGuide(collection);
-                  setIsGuideOpen(true);
-                }
-              }}
-              disabled={!isVoiceGuideEnabled || collection.items.length === 0}
-              icon={<Mic size={16} />}
-              title={isVoiceGuideEnabled ? undefined : 'Coming soon'}
-            >
-              {t('vocalGuide')}
-            </Button>
-            {!isReadOnly && (
-              <button
-                onClick={() => setIsDeleteCollectionModalOpen(true)}
-                className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center rounded-xl transition-colors ${
-                  theme === 'vault'
-                    ? 'bg-stone-900 border border-white/10 text-stone-400 hover:text-red-400 hover:border-red-400/30'
-                    : 'bg-white border border-stone-200 text-stone-400 hover:text-red-500 hover:border-red-200'
-                }`}
-                title={t('deleteCollection')}
-              >
-                <Trash2 size={18} />
-              </button>
-            )}
-            <div
-              className={`flex rounded-xl p-1 ${theme === 'vault' ? 'bg-white/5' : 'bg-stone-200/50'}`}
-            >
-              <button
-                onClick={() => setViewMode('grid')}
-                className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? 'bg-white text-stone-900 shadow-sm' : 'text-stone-400 hover:text-stone-600'}`}
-              >
-                <LayoutGrid size={18} />
-              </button>
-              <button
-                onClick={() => setViewMode('waterfall')}
-                className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? 'bg-white text-stone-900 shadow-sm' : 'text-stone-400 hover:text-stone-600'}`}
-              >
-                <LayoutTemplate size={18} className="rotate-180" />
-              </button>
-            </div>
-            <div className="relative flex gap-2">
-              <input
-                type="text"
-                placeholder="..."
-                value={filter}
-                onChange={(e) => setFilter(e.target.value)}
-                className={`pl-4 pr-4 py-2 rounded-xl border focus:ring-4 focus:ring-amber-500/5 outline-none text-sm w-48 transition-all shadow-sm font-serif italic ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
-              />
               <Button
-                variant={activeFilterCount > 0 ? 'primary' : 'outline'}
-                className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}
-                onClick={() => setIsFilterModalOpen(true)}
+                variant="outline"
+                className={`${theme === 'vault' ? 'bg-stone-900 text-white border-white/10' : 'bg-white'} w-full sm:w-auto`}
+                onClick={() => {
+                  if (isVoiceGuideEnabled) {
+                    setActiveCollectionForGuide(collection);
+                    setIsGuideOpen(true);
+                  }
+                }}
+                disabled={!isVoiceGuideEnabled || collection.items.length === 0}
+                icon={<Mic size={16} />}
+                title={isVoiceGuideEnabled ? undefined : 'Coming soon'}
               >
-                <SlidersHorizontal size={18} />
+                {t('vocalGuide')}
               </Button>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
+              {!isReadOnly && (
+                <button
+                  onClick={() => setIsDeleteCollectionModalOpen(true)}
+                  className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center rounded-xl transition-colors ${
+                    theme === 'vault'
+                      ? 'bg-stone-900 border border-white/10 text-stone-400 hover:text-red-400 hover:border-red-400/30'
+                      : 'bg-white border border-stone-200 text-stone-400 hover:text-red-500 hover:border-red-200'
+                  }`}
+                  title={t('deleteCollection')}
+                >
+                  <Trash2 size={18} />
+                </button>
+              )}
+              <div
+                className={`flex rounded-xl p-1 ${theme === 'vault' ? 'bg-white/5' : 'bg-stone-200/50'}`}
+              >
+                <button
+                  onClick={() => setViewMode('grid')}
+                  className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? 'bg-white text-stone-900 shadow-sm' : 'text-stone-400 hover:text-stone-600'}`}
+                >
+                  <LayoutGrid size={18} />
+                </button>
+                <button
+                  onClick={() => setViewMode('waterfall')}
+                  className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? 'bg-white text-stone-900 shadow-sm' : 'text-stone-400 hover:text-stone-600'}`}
+                >
+                  <LayoutTemplate size={18} className="rotate-180" />
+                </button>
+              </div>
+              <div className="relative flex gap-2 flex-1 min-w-[12rem]">
+                <input
+                  type="text"
+                  placeholder="..."
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  className={`pl-4 pr-4 py-2 rounded-xl border focus:ring-4 focus:ring-amber-500/5 outline-none text-sm w-full transition-all shadow-sm font-serif italic ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
+                />
+                <Button
+                  variant={activeFilterCount > 0 ? 'primary' : 'outline'}
+                  className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}
+                  onClick={() => setIsFilterModalOpen(true)}
+                >
+                  <SlidersHorizontal size={18} />
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -62,9 +62,9 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
       }}
       data-testid="collection-card"
       data-collection-id={collection.id}
-      className={`group relative p-8 rounded-[2.5rem] border ${baseSurface} ${accentBorder[template.accentColor] || accentBorder['stone']} transition-all duration-500 cursor-pointer ${tapShadow} ${tapRing} flex flex-col justify-between h-52 overflow-hidden motion-card`}
+      className={`group relative p-5 sm:p-8 rounded-[2.5rem] border ${baseSurface} ${accentBorder[template.accentColor] || accentBorder['stone']} transition-all duration-500 cursor-pointer ${tapShadow} ${tapRing} flex flex-col justify-between min-h-[11rem] sm:h-52 overflow-hidden motion-card`}
     >
-      <div className="absolute top-0 right-0 p-8 opacity-10 text-7xl select-none group-hover:scale-110 group-hover:rotate-12 transition-transform duration-700 pointer-events-none">
+      <div className="absolute top-0 right-0 p-5 sm:p-8 opacity-10 text-6xl sm:text-7xl select-none group-hover:scale-110 group-hover:rotate-12 transition-transform duration-700 pointer-events-none">
         {displayIcon}
       </div>
 


### PR DESCRIPTION
### Motivation

- Collection action toolbar and controls were cramped on small screens and needed to be more thumb-friendly and readable.
- Search and filter controls should expand to use available width on narrow viewports so they remain usable on mobile.
- Team documentation needed a concise, practical mobile guideline to align future work with industry best practice.

### Description

- Restructured the collection header controls in `src/App.tsx` into stacked primary and secondary rows so primary actions expand full width on small screens.
- Made the search input and filter button flexible by adding `flex-1`/`min-w` constraints and ensuring buttons use `w-full sm:w-auto` for responsive behavior.
- Adjusted `src/components/CollectionCard.tsx` to reduce padding on small screens, set a smaller `min-h` for cards, and scale down the decorative icon for improved mobile density.
- Added a concise "Mobile development guidelines" section to `docs/PRODUCT_DESIGN.md` with practical, Curio-focused rules (mobile-first layout, touch targets, input ergonomics, safe-area handling, performance and accessibility expectations, and testing guidance).

### Testing

- Started the dev server with Vite which reported ready and served the app at the local/network URLs. (succeeded)
- Ran a Playwright script that loaded the app at `http://127.0.0.1:4173/` with a `390×844` viewport and produced a screenshot at `artifacts/mobile-home.png` to verify mobile layout changes (succeeded).
- No unit tests or CI jobs were executed as part of this change. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712a0a46d08320bffa2f292fb44041)