### PR TITLE
Keep access gate visible; add production readiness checklist and issue drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repo intentionally keeps documentation **small, current, and non-duplicativ
 - **Design requirements (new work)**: `docs/DESIGN_REQUIREMENTS_ai_image_features_and_capture_simplification.md`
 - **Design proposals / reviews (legacy pointer)**: `docs/DESIGN_REVIEW_image_enhancement_and_theme_strategy.md`
 - **Testing**: `docs/TESTING.md` (quick how-to) and `tests/README.md` (details)
+- **Production readiness**: `docs/PRODUCTION_READINESS_CHECKLIST.md`
 - **Issue filing**: `docs/GITHUB_ISSUES_PROTOCOL.md`
 - **Historical reviews**: `docs/PRODUCT_REVIEW_FEEDBACK_20260113.md` (reference; tracking happens in GitHub)
 

--- a/docs/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/PRODUCTION_READINESS_CHECKLIST.md
@@ -1,0 +1,57 @@
+# Production Readiness Checklist
+
+This checklist tracks the minimum bar for a full production launch. Items are grouped by area and
+should be verified (or explicitly waived) before launch. Gaps are tracked in GitHub issues.
+
+## Product & UX
+
+- [ ] First-run access gate stays visible until users explicitly choose **Explore sample** or sign in.
+- [ ] Public sample collections are clearly labeled read-only and disable edit actions.
+- [ ] Add-item flow shows staged progress (Upload → Analyzing → Review → Save) with manual fallback.
+- [ ] Save/sync feedback (“Saved / Synced / Will sync / Sync failed”) is surfaced for all critical flows.
+
+## Data Reliability & Offline
+
+- [ ] IndexedDB corruption recovery notifications are visible.
+- [ ] Sync queue retries metadata updates when back online.
+- [ ] Asset upload retry queue exists for failed uploads.
+- [ ] Storage quota checks warn users before IndexedDB fills.
+- [ ] Timestamp-based conflict resolution is enabled in production (`VITE_SUPABASE_SYNC_TIMESTAMPS=true`).
+
+## Security & Access Control
+
+- [ ] Supabase RLS policies enforce per-user isolation and public sample read-only access.
+- [ ] Storage buckets are per-user and enforce access isolation.
+- [ ] AI gateway CORS is restricted to known origins (no wildcard in production).
+- [ ] AI gateway requires auth or signed requests for image analysis/enhancement.
+- [ ] AI gateway rate limiting is enforced.
+
+## Observability & Operations
+
+- [ ] AI gateway metrics (request count, latency, error rate) are exported and monitored.
+- [ ] Sync error rates are visible (client + server monitoring) with actionable alerting.
+- [ ] Quota/rate-limit errors have user-facing recovery messaging.
+
+## Testing & CI
+
+- [ ] `npm test` (unit + component) passes in CI.
+- [ ] `npm run build` passes in CI.
+- [ ] Playwright E2E tests run in CI with a maintained baseline.
+- [ ] Documentation reflects actual test coverage status.
+
+## Performance & Resilience
+
+- [ ] Initial load does not flash through unintended states (auth/sync loading handled predictably).
+- [ ] Large collections do not degrade core browsing performance (pagination/virtualization if needed).
+- [ ] Image processing is time-boxed with fallbacks and failure messaging.
+
+## Deployment & Configuration
+
+- [ ] Production env vars are configured (Supabase, AI gateway, feature flags).
+- [ ] `/api/*` routes point to the intended gateway (same-origin or proxy) in production.
+- [ ] Rollback steps are documented for AI gateway and database schema changes.
+
+## Notes
+
+- Reliability work is tracked in `docs/INDEXEDDB_RELIABILITY.md`.
+- Product expectations and system architecture are defined in `docs/TECHNICAL_DESIGN.md`.

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -206,3 +206,13 @@ Key columns added for the public sample flow:
 
 - **Theming:** `theme.tsx` exposes a `ThemeProvider` / `useTheme` hook that persists the selected theme (Gallery, Vault, Atelier) in IndexedDB and is consumed by modals (`AddItemModal`, `AuthModal`, `CreateCollectionModal`, `FilterModal`) for consistent surfaces.
 - **Feedback:** A lightweight `StatusToast` component in `App.tsx` surfaces save/sync/import success and error states so users see clear outcomes even during transient network issues.
+
+## 9. Production readiness gaps (shortlist)
+
+These are known gaps that should be closed before a full production launch. They are tracked in issues and
+expanded in the production readiness checklist.
+
+- **Asset upload retry queue** and **storage quota warnings** in IndexedDB (see `docs/INDEXEDDB_RELIABILITY.md`).
+- **AI gateway hardening** (CORS restrictions, auth/signed requests, rate limiting).
+- **Operational monitoring** for the AI gateway and sync error rates (metrics + alerting).
+- **Documentation alignment** so testing status reflects actual E2E coverage.

--- a/docs/issue-drafts/2026-01-23/access-gate-stays-visible.md
+++ b/docs/issue-drafts/2026-01-23/access-gate-stays-visible.md
@@ -1,0 +1,36 @@
+## Title
+
+Access gate should remain visible until users choose Explore Sample or sign in
+
+## Labels
+
+- type:ux
+- area:auth
+- severity:p1
+
+## Problem
+
+First-time visitors briefly see the access gate and then are dropped into the home view when public samples load. This hides the intended “browse first” choice and creates a confusing flash of state.
+
+## Steps to Reproduce
+
+1. Open the app in a browser with Supabase configured and public samples available.
+2. Observe the access gate for ~1s, then the home view appears without user intent.
+
+## Expected
+
+The access gate stays visible until the user explicitly chooses **Explore sample** or completes sign-in.
+
+## Actual
+
+The access gate disappears automatically when public sample collections are loaded.
+
+## Acceptance Criteria
+
+- Access gate remains visible for unauthenticated users until they opt into browsing samples or sign in.
+- Clicking **Explore sample** transitions to sample browsing and reveals public collections.
+- No access-gate flicker into home view on first load.
+
+## Notes (optional)
+
+This is part of the “delight before auth” requirement.

--- a/docs/issue-drafts/2026-01-23/ai-gateway-hardening.md
+++ b/docs/issue-drafts/2026-01-23/ai-gateway-hardening.md
@@ -1,0 +1,37 @@
+## Title
+
+Harden AI gateway with restricted CORS, auth, and rate limiting
+
+## Labels
+
+- type:enhancement
+- area:auth
+- severity:p1
+
+## Problem
+
+The AI gateway currently allows wildcard CORS and has no explicit authentication or rate limiting. This increases the risk of abuse, unexpected cost, and security exposure in production.
+
+## Steps to Reproduce
+
+1. Send cross-origin requests to the gateway from any origin.
+2. Observe that requests are accepted without auth or throttling.
+
+## Expected
+
+Only approved origins can call the gateway, and requests are authenticated or signed, with rate limiting to protect quota and availability.
+
+## Actual
+
+Requests are allowed from any origin without auth or rate limiting.
+
+## Acceptance Criteria
+
+- CORS is restricted to known origins in production.
+- Gateway requires auth/signed requests from the frontend.
+- Rate limiting is enforced (configurable thresholds + response messaging).
+- Update documentation for required env/config.
+
+## Notes (optional)
+
+This is a production-readiness requirement.

--- a/docs/issue-drafts/2026-01-23/ai-sync-observability.md
+++ b/docs/issue-drafts/2026-01-23/ai-sync-observability.md
@@ -1,0 +1,37 @@
+## Title
+
+Add monitoring for AI gateway and sync error rates
+
+## Labels
+
+- type:enhancement
+- area:sync
+- severity:p2
+
+## Problem
+
+There is no documented or implemented monitoring for AI gateway latency/error rates or client sync failures, making incidents harder to detect and respond to.
+
+## Steps to Reproduce
+
+1. Introduce AI gateway failures or slow responses.
+2. Observe that no metrics or alerts are triggered.
+
+## Expected
+
+Operational metrics (request counts, latency, error rate) are tracked with alerting, and sync failure rates are visible to operators.
+
+## Actual
+
+Only console logging exists; there are no metrics or alerts.
+
+## Acceptance Criteria
+
+- Gateway metrics are captured and exported (count, latency, error rate).
+- Alerts are configured for elevated error rates or sustained latency.
+- Sync failures are visible in monitoring (client telemetry or server logs).
+- Documentation describes the monitoring setup and owner.
+
+## Notes (optional)
+
+This is part of production readiness.

--- a/docs/issue-drafts/2026-01-23/asset-upload-retry-queue.md
+++ b/docs/issue-drafts/2026-01-23/asset-upload-retry-queue.md
@@ -1,0 +1,36 @@
+## Title
+
+Add retry queue for failed asset uploads
+
+## Labels
+
+- type:enhancement
+- area:sync
+- severity:p2
+
+## Problem
+
+If a Supabase storage upload fails, the asset is left local-only with no retry mechanism, creating a silent failure risk for long-term access.
+
+## Steps to Reproduce
+
+1. Trigger an asset upload while offline or with Supabase storage failing.
+2. Observe that metadata saves but the asset never uploads.
+
+## Expected
+
+Failed asset uploads are queued and retried when back online (or via manual retry).
+
+## Actual
+
+Failed asset uploads are not retried; assets can remain local-only indefinitely.
+
+## Acceptance Criteria
+
+- Failed asset uploads are stored in a retry queue.
+- Retries occur automatically on reconnect and can be manually triggered.
+- User receives status feedback when assets are queued or synced.
+
+## Notes (optional)
+
+See `docs/INDEXEDDB_RELIABILITY.md` (Issue #85 reference).

--- a/docs/issue-drafts/2026-01-23/large-collection-performance.md
+++ b/docs/issue-drafts/2026-01-23/large-collection-performance.md
@@ -1,0 +1,36 @@
+## Title
+
+Plan performance strategy for large collections (pagination or virtualization)
+
+## Labels
+
+- type:enhancement
+- area:exhibition
+- severity:p2
+
+## Problem
+
+Rendering large collections without pagination or virtualization may degrade browsing performance and increase memory usage, impacting the production experience.
+
+## Steps to Reproduce
+
+1. Populate a collection with a large number of items (hundreds or more).
+2. Navigate to the collection view and scroll.
+
+## Expected
+
+Large collections remain responsive, with predictable memory use and smooth scrolling.
+
+## Actual
+
+Performance characteristics are undefined; large collections may degrade the browsing experience.
+
+## Acceptance Criteria
+
+- Define a performance strategy (pagination, infinite scroll with windowing, or virtualization).
+- Implement the chosen strategy and document the approach.
+- Validate with a representative large dataset.
+
+## Notes (optional)
+
+This supports the production readiness checklist performance section.

--- a/docs/issue-drafts/2026-01-23/production-rollback-runbook.md
+++ b/docs/issue-drafts/2026-01-23/production-rollback-runbook.md
@@ -1,0 +1,36 @@
+## Title
+
+Document rollback steps for AI gateway and database schema changes
+
+## Labels
+
+- type:enhancement
+- area:sync
+- severity:p2
+
+## Problem
+
+Production rollbacks for the AI gateway or schema changes are not documented, increasing recovery time and risk during incidents.
+
+## Steps to Reproduce
+
+1. Attempt to find a documented rollback/runbook for AI gateway configuration changes.
+2. Attempt to find a documented rollback procedure for schema changes.
+
+## Expected
+
+Clear rollback/runbook steps exist for AI gateway and database schema changes.
+
+## Actual
+
+No explicit rollback/runbook documentation is present.
+
+## Acceptance Criteria
+
+- Document rollback steps for AI gateway configuration changes (routing, env vars, deployment).
+- Document rollback steps for database schema changes (migrations, triggers, feature flags).
+- Identify owners and required access for the rollback procedures.
+
+## Notes (optional)
+
+This is required for production readiness.

--- a/docs/issue-drafts/2026-01-23/storage-quota-warning.md
+++ b/docs/issue-drafts/2026-01-23/storage-quota-warning.md
@@ -1,0 +1,37 @@
+## Title
+
+Warn users when IndexedDB storage quota is near limits
+
+## Labels
+
+- type:enhancement
+- area:sync
+- severity:p3
+
+## Problem
+
+Large collections can hit IndexedDB quota limits without warning, risking failed saves and confusion.
+
+## Steps to Reproduce
+
+1. Save a large number of high-resolution assets to IndexedDB.
+2. Approach the browser’s storage quota.
+3. Observe that no warning appears before failures.
+
+## Expected
+
+Users receive a warning before IndexedDB quota is exhausted, with guidance on cleanup or sync.
+
+## Actual
+
+No warning is shown; failures can appear without context.
+
+## Acceptance Criteria
+
+- The app checks available quota periodically (or during large saves).
+- A warning toast/modal appears when remaining quota is below a defined threshold.
+- Guidance is provided for resolving the issue (syncing, cleanup, reducing image sizes).
+
+## Notes (optional)
+
+See `docs/INDEXEDDB_RELIABILITY.md` (Issue #83 reference).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -491,12 +491,6 @@ const AppContent: React.FC = () => {
     refreshCollections();
   }, [authReady, isSupabaseReady, refreshCollections]);
 
-  useEffect(() => {
-    if (!user && collections.some((c) => c.isPublic)) {
-      setAllowPublicBrowse(true);
-    }
-  }, [collections, user]);
-
   const handleImportLocal = async () => {
     setImportState('running');
     setImportMessage(null);
@@ -1615,9 +1609,7 @@ const AppContent: React.FC = () => {
 
   const isAuthenticated = Boolean(user);
   const sampleCollection = useMemo(() => collections.find((c) => c.isPublic), [collections]);
-  const hasPublicCollections = useMemo(() => collections.some((c) => c.isPublic), [collections]);
-  const showAccessGate =
-    !isSupabaseReady || (!isAuthenticated && !allowPublicBrowse && !hasPublicCollections);
+  const showAccessGate = !isSupabaseReady || (!isAuthenticated && !allowPublicBrowse);
   const isExploreRoute = location.pathname === '/explore';
   const shouldShowAccessGate = showAccessGate && !isExploreRoute;
   const fallbackSampleCollectionId = fallbackSampleCollections[0]?.id ?? null;

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,7 @@ npm run test:coverage
 
 ## Current Status
 
-**Phase 1-3 Complete:** 179 tests passing, 2 skipped, 2 todo
+**Phase 1-3 Complete:** 179 tests passing, 2 skipped, 2 todo. **Phase 5 (E2E) is in progress.**
 
 | Phase                   | Status         | Tests     |
 | ----------------------- | -------------- | --------- |
@@ -28,7 +28,7 @@ npm run test:coverage
 | Phase 2: Integration    | ✅ Complete    | 21 tests  |
 | Phase 3: AI & Hooks     | ✅ Complete    | 19 tests  |
 | Phase 4: Components     | 📋 Not Started | -         |
-| Phase 5: E2E            | 📋 Not Started | -         |
+| Phase 5: E2E            | 🚧 In Progress | 3 specs   |
 
 ## Infrastructure Setup ✅
 
@@ -117,10 +117,12 @@ tests/
 - `tests/components/AuthModal.test.tsx` - Authentication UI
 - `tests/components/ui/*.test.tsx` - Other UI components
 
-### 📋 Phase 5: End-to-End Tests (Not Started)
+### 🚧 Phase 5: End-to-End Tests (In Progress)
 
-- Install Playwright or Cypress
-- `tests/e2e/critical-flows.spec.ts` - Critical user flows
+- Playwright specs live in `tests/e2e/`
+  - `accessibility.spec.ts`
+  - `first-time-user.spec.ts`
+  - `authenticated-user.spec.ts` (requires credentials to run)
 
 ## Writing Tests
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated users from being auto-routed off the first-run access gate and ensure the gate remains visible until users explicitly choose to explore or sign in. 
- Capture production-readiness gaps (reliability, AI gateway hardening, observability, storage, rollback/runbook, and large-collection performance) as issue drafts so they can be triaged and tracked in GitHub. 

### Description
- UI: Stop auto-enabling public browse for unauthenticated users by removing the effect that set `allowPublicBrowse` in `src/App.tsx` and adjust the `showAccessGate` logic accordingly. 
- Docs: Add `docs/PRODUCTION_READINESS_CHECKLIST.md` and append a short “Production readiness gaps” section to `docs/TECHNICAL_DESIGN.md`. 
- Issues: Add multiple issue drafts under `docs/issue-drafts/2026-01-23/` for `access-gate-stays-visible`, `ai-gateway-hardening`, `ai-sync-observability`, `asset-upload-retry-queue`, `storage-quota-warning`, and two new drafts `production-rollback-runbook.md` and `large-collection-performance.md`. 
- Misc: Link the new checklist from `README.md` and mark Phase 5 (E2E) as in-progress in `tests/README.md`. 

### Testing
- No automated tests were executed for these changes (documentation additions plus a small UI gating change). 
- Recommend running `npm test`, `npm run build`, and the Playwright E2E specs in `tests/e2e/` to validate behavior and regressions before merging. 
- All documentation files and the small UI change were committed successfully to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733fcec19083208a75fea1ea2a59b9)