### PR TITLE
Add asset upload retry backoff and tests

### DIFF
--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -99,7 +99,10 @@ export const useCollections = ({
   }, []);
 
   useEffect(() => {
-    const handleAssetSyncStatus = (status: AssetSyncStatus, details?: { count?: number }) => {
+    const handleAssetSyncStatus = (
+      status: AssetSyncStatus,
+      details?: { count?: number; error?: string },
+    ) => {
       const t = tRef.current;
       const showStatus = showStatusRef.current;
 
@@ -108,6 +111,9 @@ export const useCollections = ({
       } else if (status === 'synced') {
         const count = details?.count ?? 0;
         showStatus(t('statusPhotosSynced').replace('{count}', String(count)), 'success');
+      } else if (status === 'error') {
+        const errorMessage = details?.error || t('statusSyncPaused');
+        showStatus(t('statusPhotosSyncFailed').replace('{error}', errorMessage), 'error');
       }
     };
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -150,6 +150,7 @@ export const translations = {
     statusPendingSynced: '{count} pending change(s) synced',
     statusPhotosWillSync: 'Will sync photos',
     statusPhotosSynced: '{count} photo(s) synced',
+    statusPhotosSyncFailed: 'Photo upload failed. Will retry automatically. ({error})',
     actionRetry: 'Retry',
     // Auth & Cloud
     login: 'Sign In',
@@ -387,6 +388,7 @@ export const translations = {
     statusPendingSynced: '{count} 项待同步更改已完成',
     statusPhotosWillSync: '照片将同步',
     statusPhotosSynced: '已同步 {count} 张照片',
+    statusPhotosSyncFailed: '照片上传失败，将自动重试。({error})',
     actionRetry: '重试',
     // Auth & Cloud
     login: '登录',

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -77,7 +77,13 @@ type PendingAssetUpload = {
   collectionId: string;
   itemId: string;
   createdAt?: string;
+  attemptCount?: number;
+  lastError?: string;
+  nextRetryAt?: string;
 };
+
+const ASSET_UPLOAD_BACKOFF_BASE_MS = 30_000;
+const ASSET_UPLOAD_BACKOFF_MAX_MS = 10 * 60_000;
 
 // Exported for testing
 export const compareTimestamps = (a?: string, b?: string) => {
@@ -346,10 +352,46 @@ const addToPendingAssetUploads = async (collectionId: string, itemId: string): P
     (entry) => entry.collectionId === collectionId && entry.itemId === itemId,
   );
   if (!exists) {
-    pending.push({ collectionId, itemId, createdAt: new Date().toISOString() });
+    pending.push({
+      collectionId,
+      itemId,
+      createdAt: new Date().toISOString(),
+      attemptCount: 0,
+    });
     const tx = db.transaction(SETTINGS_STORE, 'readwrite');
     tx.objectStore(SETTINGS_STORE).put(pending, PENDING_ASSET_UPLOADS_KEY);
   }
+};
+
+const getAssetUploadBackoffMs = (attemptCount: number): number => {
+  if (attemptCount <= 0) return ASSET_UPLOAD_BACKOFF_BASE_MS;
+  const backoff = ASSET_UPLOAD_BACKOFF_BASE_MS * Math.pow(2, attemptCount - 1);
+  return Math.min(backoff, ASSET_UPLOAD_BACKOFF_MAX_MS);
+};
+
+const markPendingAssetUploadFailure = async (
+  collectionId: string,
+  itemId: string,
+  errorMessage?: string,
+): Promise<void> => {
+  const db = await initDB();
+  const pending = await getPendingAssetUploads();
+  const now = Date.now();
+  const updated = pending.map((entry) => {
+    if (entry.collectionId === collectionId && entry.itemId === itemId) {
+      const nextAttempt = (entry.attemptCount ?? 0) + 1;
+      const delayMs = getAssetUploadBackoffMs(nextAttempt);
+      return {
+        ...entry,
+        attemptCount: nextAttempt,
+        lastError: errorMessage || entry.lastError,
+        nextRetryAt: new Date(now + delayMs).toISOString(),
+      };
+    }
+    return entry;
+  });
+  const tx = db.transaction(SETTINGS_STORE, 'readwrite');
+  tx.objectStore(SETTINGS_STORE).put(updated, PENDING_ASSET_UPLOADS_KEY);
 };
 
 const removeFromPendingAssetUploads = async (
@@ -466,8 +508,19 @@ export const syncPendingAssetUploads = async (): Promise<number> => {
   const pendingUploads = await getPendingAssetUploads();
   if (pendingUploads.length === 0) return 0;
 
+  const now = Date.now();
+  const dueUploads = pendingUploads.filter((entry) => {
+    if (!entry.nextRetryAt) return true;
+    const retryAt = new Date(entry.nextRetryAt).getTime();
+    return Number.isNaN(retryAt) || retryAt <= now;
+  });
+  if (dueUploads.length === 0) {
+    return 0;
+  }
+
   let synced = 0;
-  for (const { collectionId, itemId } of pendingUploads) {
+  let lastErrorMessage: string | null = null;
+  for (const { collectionId, itemId } of dueUploads) {
     const [original, display] = await Promise.all([
       readAssetFromStore(ASSETS_STORE, itemId),
       readAssetFromStore(DISPLAY_STORE, itemId),
@@ -484,11 +537,17 @@ export const syncPendingAssetUploads = async (): Promise<number> => {
       synced++;
     } catch (e) {
       console.warn(`Failed to sync pending asset for item ${itemId}:`, e);
+      const errorMessage = e instanceof Error ? e.message : 'Unknown upload error';
+      await markPendingAssetUploadFailure(collectionId, itemId, errorMessage);
+      lastErrorMessage = errorMessage;
     }
   }
 
   if (synced > 0) {
     notifyAssetSyncStatus('synced', { count: synced });
+  }
+  if (lastErrorMessage) {
+    notifyAssetSyncStatus('error', { error: lastErrorMessage });
   }
 
   return synced;
@@ -896,6 +955,8 @@ export const saveAsset = async (
     } catch (e) {
       console.warn('Cloud asset sync failed:', e);
       await addToPendingAssetUploads(collectionId, id);
+      const errorMessage = e instanceof Error ? e.message : 'Unknown upload error';
+      await markPendingAssetUploadFailure(collectionId, id, errorMessage);
       notifyAssetSyncStatus('queued');
     }
   }

--- a/tests/hooks/useCollections.test.ts
+++ b/tests/hooks/useCollections.test.ts
@@ -203,6 +203,31 @@ describe('hooks/useCollections.ts (Phase 3.3)', () => {
     expect(result.current.loadError).toBeNull();
   });
 
+  it('surfaces asset upload failures via status toasts', async () => {
+    let assetStatusCallback: ((status: any, details?: any) => void) | null = null;
+    dbMocks.setAssetSyncStatusCallback.mockImplementation((cb) => {
+      assetStatusCallback = cb;
+    });
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    renderHook(() =>
+      useCollections({
+        user: { id: 'u1' } as any,
+        isAdmin: false,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(dbMocks.setAssetSyncStatusCallback).toHaveBeenCalled());
+    expect(assetStatusCallback).toBeTruthy();
+
+    assetStatusCallback?.('error', { error: 'Upload failed' });
+    expect(showStatus).toHaveBeenCalledWith('statusPhotosSyncFailed', 'error');
+  });
+
   it('edge case: signed-out user with no data uses fallback sample collections', async () => {
     /**
      * Verifies unauthenticated first-use behavior:

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -314,7 +314,7 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     expect(calledPaths).toContain('test-user-id/collections/col-1/item-asset-1/display.jpg');
   });
 
-  it('saveAsset: cloud upload failure queues retry and syncPendingAssetUploads retries successfully', async () => {
+  it('saveAsset: cloud upload failure queues retry and syncPendingAssetUploads retries after backoff', async () => {
     const { supabase, upload } = createSupabaseMock();
     upload
       .mockResolvedValueOnce({ data: null, error: new Error('Upload failed') })
@@ -334,11 +334,36 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
 
     const pendingAfterSave = await readFromStore<any[]>(db, 'settings', 'pending_asset_uploads');
     expect(pendingAfterSave).toEqual([
-      expect.objectContaining({ collectionId: 'col-1', itemId: 'item-asset-2' }),
+      expect.objectContaining({
+        collectionId: 'col-1',
+        itemId: 'item-asset-2',
+        attemptCount: 1,
+        nextRetryAt: expect.any(String),
+      }),
     ]);
 
     upload.mockClear();
     upload.mockResolvedValue({ data: { path: 'ok' }, error: null });
+
+    await expect(dbMod.syncPendingAssetUploads()).resolves.toBe(0);
+    expect(upload).not.toHaveBeenCalled();
+
+    const tx = db.transaction('settings', 'readwrite');
+    const nextRetryAt = new Date(Date.now() - 1000).toISOString();
+    tx.objectStore('settings').put(
+      [
+        {
+          ...pendingAfterSave[0],
+          nextRetryAt,
+        },
+      ],
+      'pending_asset_uploads',
+    );
+    await new Promise((resolve) => {
+      tx.oncomplete = () => resolve(null);
+      tx.onerror = () => resolve(null);
+      tx.onabort = () => resolve(null);
+    });
 
     await expect(dbMod.syncPendingAssetUploads()).resolves.toBe(1);
 


### PR DESCRIPTION
### Motivation
- Ensure failed asset uploads are retried with exponential backoff and that failures are surfaced to users so uploads do not silently disappear. 
- Prevent immediate re-attempts of failed uploads and provide predictable retry scheduling to improve durability and UX.

### Description
- Extend pending asset upload metadata with `attemptCount`, `lastError`, and `nextRetryAt` and add backoff constants `ASSET_UPLOAD_BACKOFF_BASE_MS` and `ASSET_UPLOAD_BACKOFF_MAX_MS` in `src/services/db.ts`.
- Implement `getAssetUploadBackoffMs` and `markPendingAssetUploadFailure` to compute exponential backoff and update pending entries, only attempting uploads when `nextRetryAt` is due in `syncPendingAssetUploads` and emitting `error` status when retries fail.
- Record retry metadata on initial failure from `saveAsset` and surface a queued state via `notifyAssetSyncStatus('queued')`.
- Surface upload-failure toasts in the UI by handling the new `error` asset sync status in `src/hooks/useCollections.ts` and add localized copy key `statusPhotosSyncFailed` (English + Chinese) in `src/i18n.ts`.
- Add/adjust unit tests: update `tests/services/db.operations.test.ts` to validate backoff behavior and due-time filtering, and add `tests/hooks/useCollections.test.ts` coverage for status toast emission.

### Testing
- Ran the targeted test suite with `npm test -- --run tests/services/db.operations.test.ts tests/hooks/useCollections.test.ts` and all tests passed (17 passed, 1 todo).
- The added/modified tests are `tests/services/db.operations.test.ts` (asset backoff/due-time behavior) and `tests/hooks/useCollections.test.ts` (asset sync error toast), and they succeeded during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f49b7af483208bd48325f6d4d412)