### PR TITLE
Add collection tombstones to pending delete flow

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -645,8 +645,7 @@ export const getPendingDeletes = async (): Promise<PendingDelete[]> => {
   return new Promise((resolve) => {
     const tx = db.transaction(SETTINGS_STORE, 'readonly');
     const req = tx.objectStore(SETTINGS_STORE).get(PENDING_DELETE_KEY);
-    req.onsuccess = () =>
-      resolve(normalizePendingDeletes((req.result as PendingDelete[]) || []));
+    req.onsuccess = () => resolve(normalizePendingDeletes((req.result as PendingDelete[]) || []));
     req.onerror = () => resolve([]);
   });
 };
@@ -658,7 +657,8 @@ export const addToPendingDeletes = async (entry: PendingDelete): Promise<void> =
   if (entry.type === 'item') {
     if (
       pending.some(
-        (d) => d.type === 'item' && d.collectionId === entry.collectionId && d.itemId === entry.itemId,
+        (d) =>
+          d.type === 'item' && d.collectionId === entry.collectionId && d.itemId === entry.itemId,
       )
     ) {
       return;
@@ -707,10 +707,7 @@ export const syncPendingDeletes = async (): Promise<number> => {
       if (!user) continue;
 
       if (entry.type === 'collection') {
-        const { error } = await supabase
-          .from('collections')
-          .delete()
-          .eq('id', entry.collectionId);
+        const { error } = await supabase.from('collections').delete().eq('id', entry.collectionId);
 
         if (!error) {
           await removeFromPendingDeletes(entry.collectionId);

--- a/tests/services/db.merge.test.ts
+++ b/tests/services/db.merge.test.ts
@@ -519,9 +519,7 @@ describe('Phase 2.1 — services/db.ts merge logic', () => {
         },
       ];
 
-      const pendingDeletes = [
-        { type: 'collection', collectionId: 'col-1', createdAt: isoAt(3) },
-      ];
+      const pendingDeletes = [{ type: 'collection', collectionId: 'col-1', createdAt: isoAt(3) }];
 
       const merged = mod.mergeCollections(local as any, cloud as any, { pendingDeletes });
       expect(merged).toHaveLength(0);


### PR DESCRIPTION
### Motivation

- Prevent deleted collections from being resurrected during cloud/local merges by treating collection deletes as tombstones in the pending-delete queue. 
- Extend the existing pending-delete mechanism to represent both item-level and collection-level deletes so the sync worker can handle both types. 
- Keep backward compatibility with legacy pending-delete entries stored as `{collectionId,itemId,createdAt}`.

### Description

- Extend the `PendingDelete` type to be a discriminated union for `item` and `collection` tombstones and add a `LegacyPendingDelete` converter to normalize older entries. 
- Update `mergeItems` to ignore pending item tombstones and update `mergeCollections` to filter out cloud collections that have a pending collection tombstone while still passing item tombstones to `mergeItems`. 
- Change pending-delete APIs: `getPendingDeletes` now normalizes legacy entries, `addToPendingDeletes` accepts a `PendingDelete` entry, and `removeFromPendingDeletes` accepts an optional `itemId` so collection tombstones can be removed independently. 
- Make the pending-delete sync worker (`syncPendingDeletes`) handle collection deletes (deleting from `collections`), and enqueue tombstones from `deleteCloudItem` and `deleteCollection`; clear tombstones on successful cloud deletion. 
- Add and update tests in `tests/services/db.merge.test.ts` to use typed pending deletes and to cover filtering of collection tombstones in merges.

### Testing

- Ran `npm test -- tests/services/db.merge.test.ts` which executed the merge tests. 
- All tests in that file passed: `18 tests` passed (test run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697532fa74288320b039f625c0b132ce)