### PR TITLE
Update docs to reflect implemented asset upload retry queue and remove archived issue snapshot

### DIFF
--- a/docs/INDEXEDDB_RELIABILITY.md
+++ b/docs/INDEXEDDB_RELIABILITY.md
@@ -127,7 +127,7 @@ App Load ← IndexedDB (cache) ←──────── Supabase (source of t
 
 **Problem:** If cloud upload fails, asset is stuck local-only with no retry mechanism.
 
-**Status:** Not implemented in this PR. Similar queue mechanism could be added for assets. (Tracked in [#85](https://github.com/Akkkkkkki/curio/issues/85))
+**Status:** Implemented via an IndexedDB-backed pending upload queue with retries on reconnect/startup and exponential backoff (see `services/db.ts`).
 
 ---
 
@@ -148,7 +148,7 @@ After implementing fixes, verify:
 - [x] Offline changes sync when back online (P1 #1)
 - [x] Concurrent saves don't corrupt data (P1 #2)
 - [x] Local-only items survive cloud fetch (P2 #5)
-- [ ] Failed asset uploads retry on reconnection (P2 - not implemented; tracked in [#85](https://github.com/Akkkkkkki/curio/issues/85))
+- [x] Failed asset uploads retry on reconnection (P2 - implemented with IndexedDB pending queue + backoff).
 - [ ] Large collections warn about storage limits (P3 - not implemented; tracked in [#83](https://github.com/Akkkkkkki/curio/issues/83))
 
 ---

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -140,7 +140,7 @@ error
 #### Notes / quirks (today)
 
 - Follow-up “Synced / Will sync / Sync failed” toasts are shown only when the initiating action sets a “pending sync toast” flag (e.g., add-item / create-collection). Debounced edits may sync without showing a toast.
-- Image asset uploads (`saveAsset`) are separate from metadata sync and do not currently participate in the pending-queue / retry UX.
+- Image asset uploads (`saveAsset`) queue failed uploads in IndexedDB and retry automatically on reconnect/startup (see `services/db.ts`).
 
 ## 4.1 Home “On This Day” selection logic
 


### PR DESCRIPTION
### Motivation
- Align the project's reliability and technical-design documentation with the current codebase by removing an archived issue snapshot and documenting the implemented asset upload retry behavior.

### Description
- Delete `docs/issue-131.json` and update `docs/INDEXEDDB_RELIABILITY.md` and `docs/TECHNICAL_DESIGN.md` to state that failed `saveAsset()` uploads are tracked in an IndexedDB-backed pending upload queue and retried on reconnect/startup with backoff, and to reference `services/db.ts` for the implementation.

### Testing
- Documentation-only updates; no automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763fbecd8c8320a29332da4bae52c8)