### PR TITLE
Revise collection creation doc for tag-based suggested-tags flow

### DIFF
--- a/docs/COLLECTION_CREATION_AI_WIREFRAME.md
+++ b/docs/COLLECTION_CREATION_AI_WIREFRAME.md
@@ -1,9 +1,11 @@
 # Collection Creation: Faster Setup With Suggested Tags
 
 ## Background (Why we’re doing this)
+
 Creating a collection should feel effortless and personal. Today, users must pick from a handful of presets, which can feel restrictive and slow for anyone whose collection doesn’t fit a template. The goal is to make the first-time experience feel welcoming and quick—more like “describe what you collect and start” than “fill out a form.”
 
 This effort focuses on:
+
 - **Reducing time-to-first-collection**
 - **Removing jargon and complexity**
 - **Keeping the experience friendly and guided**
@@ -12,6 +14,7 @@ This effort focuses on:
 ---
 
 ## Product Goals (Baseline)
+
 1. **Fast start**: A user should create a collection in under 30 seconds.
 2. **Low effort**: Minimal typing, no technical setup.
 3. **Personal fit**: Fields should reflect the user’s real collection.
@@ -21,6 +24,7 @@ This effort focuses on:
 ---
 
 ## New User Journey (High-Level)
+
 1. **Start** → “Create Collection”
 2. **Describe** → User describes what they collect; we suggest tags
 3. **Pick Tags** → User selects from suggested tags and adds their own
@@ -30,6 +34,7 @@ This effort focuses on:
 ---
 
 ## Tag Model (Simplified)
+
 - **All tags are plain text.**
 - **No tag types** (no numbers, dates, dropdowns, etc.).
 - **One universal long-text field for “Description/Notes.”**
@@ -42,10 +47,12 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 ## Wireframe Sequence (Textual)
 
 > Notes:
+>
 > - The “suggested tags” come from a background model but are framed as **suggestions**, not “AI.”
 > - The template picker remains available as a secondary path.
 
 ### Screen 1 — Create Collection (Entry)
+
 ```
 ┌─────────────────────────────────────────────┐
 │ New Collection                              │
@@ -61,7 +68,9 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 │ [Cancel]                         [Continue] │
 └─────────────────────────────────────────────┘
 ```
+
 **Behavior**
+
 - Default focus: description input (fast path).
 - If user chooses a template, “Suggest tags” can be skipped.
 - “Continue” is enabled when tag suggestions exist or a template is selected.
@@ -69,6 +78,7 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 ---
 
 ### Screen 2 — Suggestions (Loading)
+
 ```
 ┌─────────────────────────────────────────────┐
 │ Creating suggestions…                        │
@@ -77,12 +87,15 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 │ [Cancel]                                    │
 └─────────────────────────────────────────────┘
 ```
+
 **Behavior**
+
 - If suggestions are unavailable, we fallback to **manual tag entry**.
 
 ---
 
 ### Screen 3 — Pick Tags (Suggestion Review)
+
 ```
 ┌─────────────────────────────────────────────┐
 │ Pick tags for your collection               │
@@ -99,7 +112,9 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 │ [Back]                            [Next]    │
 └─────────────────────────────────────────────┘
 ```
+
 **Behavior**
+
 - Users select from suggested tags or add their own.
 - **Hard cap**: 6 tags max.
 - **Minimum**: 3–4 tags to keep cards useful.
@@ -108,6 +123,7 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 ---
 
 ### Screen 4 — Display Preview
+
 ```
 ┌─────────────────────────────────────────────┐
 │ Preview                                     │
@@ -121,12 +137,15 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 │ [Back]                            [Create]  │
 └─────────────────────────────────────────────┘
 ```
+
 **Behavior**
+
 - Shows how tags will appear on cards and item details.
 
 ---
 
 ### Screen 5 — Success
+
 ```
 ┌─────────────────────────────────────────────┐
 │ Collection created                          │
@@ -139,12 +158,15 @@ This keeps the experience simple and future‑proof. More advanced types can be 
 ---
 
 ## Copy Guidelines (User-Friendly Language)
+
 Replace “AI/prompt/schema/field type” language with:
+
 - “Suggestions” instead of “AI”
 - “Tags” instead of “fields”
 - “Pick tags” instead of “configure data types”
 
 Examples:
+
 - “Describe what you collect”
 - “Here are some suggested tags. Pick the ones you want.”
 - “Add more tags”
@@ -152,11 +174,13 @@ Examples:
 ---
 
 ## Suggested Tag Limits (Recommended)
+
 - **Minimum**: 3–4 tags
 - **Maximum**: 6 tags
 - **Tag length**: 24–32 characters
 
 **Why:**
+
 - Ensures item cards remain scannable
 - Keeps tagging simple, not overwhelming
 - Encourages thoughtful metadata without turning into a form
@@ -164,9 +188,11 @@ Examples:
 ---
 
 ## LLM Prompt (Internal Only)
+
 > This is internal. The user-facing UI should never reference “AI.”
 
 ### System Prompt
+
 ```
 You are helping suggest simple tags for a personal collection.
 Favor short, everyday labels. Avoid technical jargon.
@@ -174,6 +200,7 @@ Return 4–6 tags maximum. Use the current app language.
 ```
 
 ### Developer Prompt
+
 ```
 Return JSON with:
 - collectionName: string
@@ -187,6 +214,7 @@ Rules:
 ```
 
 ### User Prompt Template
+
 ```
 User description: "{{collection_description}}"
 App language: "{{locale}}"
@@ -195,6 +223,7 @@ App language: "{{locale}}"
 ---
 
 ## Example LLM Output
+
 ```json
 {
   "collectionName": "Vintage Postcards",
@@ -210,6 +239,7 @@ App language: "{{locale}}"
 ---
 
 ## Decisions (Applied)
+
 1. **Fallback behavior**: If suggestions are unavailable, show manual tag entry. All tags are simple strings, with a length limit. Also include a universal “Description/Notes” field for every collection.
 2. **Regenerate limits**: Allow **one** successful suggestion pass. If it fails, retry automatically once. No user-triggered “regenerate.”
 3. **Field (tag) cap**: Enforce a **hard max of 4–6 tags** (recommended 6 max).
@@ -221,6 +251,7 @@ App language: "{{locale}}"
 ---
 
 ## Technical Notes (Relevant Only)
+
 - Suggested tags are stored as a list of labels/ids.
 - Tag data is saved with the collection so items can reuse it.
 - One **universal Description/Notes field** exists for all collections.
@@ -228,6 +259,7 @@ App language: "{{locale}}"
 ---
 
 ## Success Metrics
+
 - Time to first collection created (median)
 - % of users completing creation without templates
 - Tag selection completion rate


### PR DESCRIPTION
### Motivation
- Incorporate product context and baseline goals so the collection-creation flow reads as a product design decision (faster, friendlier start) rather than a technical spec. 
- Respond to earlier feedback by replacing jargon-heavy schema/field-type guidance with a simpler, user-focused “tags” model and friendlier copy. 
- Apply product/technical decisions requested in feedback such as single-generation limits, hard tag caps, locale-aware suggestions, simple persistence guidance, and a fallback for when suggestions are unavailable.

### Description
- Updated `docs/COLLECTION_CREATION_AI_WIREFRAME.md` to a new tag-focused doc titled "Collection Creation: Faster Setup With Suggested Tags" that adds product background, goals, and a friendly user journey. 
- Reworked wireframes and copy to remove references to “AI/prompt/schema/field type” and instead use user-facing terms like “Suggestions” and “Tags,” plus added copy guidelines for the UI. 
- Replaced the multi-type field schema with a simplified tag model (string-only tags, universal Description/Notes field, tag length limits) and included an internal LLM prompt that is explicitly for internal use only. 
- Applied the requested decisions and constraints in the document: one successful suggestion pass (auto-retry once on failure), hard max of 4–6 tags (recommended 6), minimum around 3–4, locale-aware labels, fallback to manual tag entry, and a persistence note recommending a new column if current storage is insufficient.

### Testing
- No automated tests were run because this is a documentation-only change and does not modify application code or test suites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764ccd958883209643608570fd05a7)