### PR TITLE
test: add coverage for deletion flows and validation

### DIFF
--- a/tests/components/DeleteCollectionModal.test.tsx
+++ b/tests/components/DeleteCollectionModal.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Phase 4: DeleteCollectionModal Component Tests
+ *
+ * Validates modal rendering, warning content, and user actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { DeleteCollectionModal } from '@/components/DeleteCollectionModal';
+import { createMockCollection, createMockItem } from '../utils/fixtures/collections';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+describe('DeleteCollectionModal', () => {
+  const collection = createMockCollection({
+    name: 'Vintage Cameras',
+    items: [createMockItem({ title: 'Polaroid SX-70' }), createMockItem({ title: 'Leica M6' })],
+  });
+  const defaultProps = {
+    isOpen: true,
+    collection,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(<DeleteCollectionModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText(/Delete Collection/i)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when collection is missing', () => {
+    renderWithProviders(<DeleteCollectionModal {...defaultProps} collection={null} />);
+    expect(screen.queryByText(/Delete Collection/i)).not.toBeInTheDocument();
+  });
+
+  it('shows warning message with collection name and item count', () => {
+    renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+    expect(screen.getByText(/Vintage Cameras/)).toBeInTheDocument();
+    expect(screen.getByText(/2 items/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when delete is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /delete collection/i }));
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/DeleteItemModal.test.tsx
+++ b/tests/components/DeleteItemModal.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Phase 4: DeleteItemModal Component Tests
+ *
+ * Validates modal rendering, warning content, and user actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { DeleteItemModal } from '@/components/DeleteItemModal';
+import { createMockItem } from '../utils/fixtures/collections';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+describe('DeleteItemModal', () => {
+  const item = createMockItem({ title: 'Arcade Cabinet' });
+  const defaultProps = {
+    isOpen: true,
+    item,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(<DeleteItemModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText(/Delete Item/i)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when item is missing', () => {
+    renderWithProviders(<DeleteItemModal {...defaultProps} item={null} />);
+    expect(screen.queryByText(/Delete Item/i)).not.toBeInTheDocument();
+  });
+
+  it('shows warning message with item title', () => {
+    renderWithProviders(<DeleteItemModal {...defaultProps} />);
+    expect(screen.getByText(/Arcade Cabinet/)).toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DeleteItemModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when delete is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DeleteItemModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /delete item/i }));
+    expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/StatusToast.test.tsx
+++ b/tests/components/StatusToast.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Phase 4: StatusToast Component Tests
+ *
+ * Validates tone rendering, actions, and accessibility attributes.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../utils/test-utils';
+import { StatusToast } from '@/components/StatusToast';
+
+describe('StatusToast', () => {
+  it('renders message with default info tone', () => {
+    renderWithProviders(<StatusToast message="Saved to archive" />);
+
+    const toast = screen.getByTestId('status-toast');
+    expect(toast).toHaveAttribute('role', 'status');
+    expect(toast).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByTestId('status-toast-message')).toHaveTextContent('Saved to archive');
+    expect(toast).toHaveClass('bg-stone-50');
+  });
+
+  it('applies success tone styles', () => {
+    renderWithProviders(<StatusToast message="Synced" tone="success" />);
+
+    const toast = screen.getByTestId('status-toast');
+    expect(toast).toHaveClass('bg-emerald-50');
+    expect(toast).toHaveClass('text-emerald-800');
+  });
+
+  it('renders action button and calls onAction', async () => {
+    const onAction = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <StatusToast message="Sync failed" tone="error" actionLabel="Retry" onAction={onAction} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders dismiss button and calls onDismiss', async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<StatusToast message="Will sync later" onDismiss={onDismiss} />);
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/ThemePicker.test.tsx
+++ b/tests/components/ThemePicker.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Phase 4: ThemePicker Component Tests
+ *
+ * Validates layout rendering and theme selection actions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, setMockTheme, getMockSetTheme } from '../utils/test-utils';
+import { ThemePicker } from '@/components/ThemePicker';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+describe('ThemePicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+    getMockSetTheme().mockClear();
+  });
+
+  it('renders inline layout by default', () => {
+    renderWithProviders(<ThemePicker />);
+
+    expect(screen.getByText('App Aesthetic')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /gallery/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /vault/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /atelier/i })).toBeInTheDocument();
+  });
+
+  it('calls setTheme when a theme option is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThemePicker />);
+
+    await user.click(screen.getByRole('button', { name: /vault/i }));
+    expect(getMockSetTheme()).toHaveBeenCalledWith('vault');
+  });
+
+  it('renders stacked layout when configured', () => {
+    renderWithProviders(<ThemePicker layout="stacked" />);
+
+    expect(screen.getByRole('button', { name: /gallery/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /vault/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /atelier/i })).toBeInTheDocument();
+  });
+});

--- a/tests/utils/fieldValidation.test.ts
+++ b/tests/utils/fieldValidation.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Phase 1: Field validation utilities
+ *
+ * Tests label normalization, reserved/duplicate detection, and selection rules.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeFieldLabel,
+  isReservedFieldLabel,
+  findDuplicateLabel,
+  validateFieldLabel,
+  validateFieldSelection,
+  FIELD_LABEL_MAX_LENGTH,
+  FIELD_MAX_COUNT,
+  FIELD_MIN_COUNT,
+  PINNED_MAX_COUNT,
+  PINNED_MIN_COUNT,
+} from '@/utils/fieldValidation';
+
+describe('fieldValidation utilities', () => {
+  describe('normalizeFieldLabel', () => {
+    it('trims and collapses whitespace', () => {
+      expect(normalizeFieldLabel('  Release   Year  ')).toBe('Release Year');
+    });
+  });
+
+  describe('isReservedFieldLabel', () => {
+    it('detects reserved labels (case insensitive)', () => {
+      expect(isReservedFieldLabel('Title')).toBe(true);
+      expect(isReservedFieldLabel('  NOTES ')).toBe(true);
+    });
+
+    it('returns false for non-reserved labels', () => {
+      expect(isReservedFieldLabel('Artist')).toBe(false);
+    });
+  });
+
+  describe('findDuplicateLabel', () => {
+    it('detects duplicates after normalization', () => {
+      const existing = ['Release Year', 'Artist'];
+      expect(findDuplicateLabel('release   year', existing)).toBe(true);
+    });
+
+    it('returns false for unique labels', () => {
+      expect(findDuplicateLabel('Condition', ['Artist', 'Album'])).toBe(false);
+    });
+  });
+
+  describe('validateFieldLabel', () => {
+    it('rejects empty labels', () => {
+      expect(validateFieldLabel('   ', [])).toEqual({
+        ok: false,
+        reason: 'empty',
+        label: '',
+      });
+    });
+
+    it('rejects labels longer than max length', () => {
+      const longLabel = 'a'.repeat(FIELD_LABEL_MAX_LENGTH + 1);
+      expect(validateFieldLabel(longLabel, [])).toEqual({
+        ok: false,
+        reason: 'too-long',
+        label: longLabel,
+      });
+    });
+
+    it('rejects reserved labels', () => {
+      expect(validateFieldLabel('Title', [])).toEqual({
+        ok: false,
+        reason: 'reserved',
+        label: 'Title',
+      });
+    });
+
+    it('rejects duplicate labels', () => {
+      expect(validateFieldLabel('Artist', ['artist'])).toEqual({
+        ok: false,
+        reason: 'duplicate',
+        label: 'Artist',
+      });
+    });
+
+    it('returns normalized label when valid', () => {
+      expect(validateFieldLabel('  Release   Year ', ['Artist'])).toEqual({
+        ok: true,
+        reason: null,
+        label: 'Release Year',
+      });
+    });
+  });
+
+  describe('validateFieldSelection', () => {
+    it('enforces minimum field count', () => {
+      const result = validateFieldSelection(Array(FIELD_MIN_COUNT - 1).fill('field'), ['a']);
+      expect(result).toEqual({ ok: false, reason: 'min' });
+    });
+
+    it('enforces maximum field count', () => {
+      const result = validateFieldSelection(Array(FIELD_MAX_COUNT + 1).fill('field'), ['a']);
+      expect(result).toEqual({ ok: false, reason: 'max' });
+    });
+
+    it('enforces minimum pinned count', () => {
+      const result = validateFieldSelection(Array(FIELD_MIN_COUNT).fill('field'), []);
+      expect(result).toEqual({ ok: false, reason: 'pin-min' });
+    });
+
+    it('enforces maximum pinned count', () => {
+      const result = validateFieldSelection(
+        Array(FIELD_MIN_COUNT).fill('field'),
+        Array(PINNED_MAX_COUNT + 1).fill('pinned'),
+      );
+      expect(result).toEqual({ ok: false, reason: 'pin-max' });
+    });
+
+    it('returns ok when counts are within limits', () => {
+      const result = validateFieldSelection(
+        Array(FIELD_MIN_COUNT).fill('field'),
+        Array(PINNED_MIN_COUNT).fill('pinned'),
+      );
+      expect(result).toEqual({ ok: true, reason: null });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add component tests for delete collection/item modals, status toast, and theme picker
- add utility tests for field label normalization and selection limits

## Test plan
- [x] npm run format:write
- [x] npm run format:check
- [x] npm test
- [x] npm run build
- [x] npm run test:e2e (1 skipped: authenticated-user.spec.ts requires credentials)