### PR TITLE
fix: ensure modals appear above bottom nav and remove misleading drag handles

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1142,11 +1142,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
           aria-describedby={dialogDescribedBy}
           className={`${surfaceClass} rounded-t-3xl rounded-b-none sm:rounded-3xl shadow-2xl w-full max-w-lg h-[100dvh] sm:h-auto max-h-[100dvh] sm:max-h-[90vh] overflow-hidden flex flex-col motion-panel pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
         >
-          <div className="sm:hidden flex items-center justify-center pt-2">
-            <span
-              className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-            />
-          </div>
+          <div className="sm:hidden h-3" />
           <div className={`flex items-center justify-between p-4 sm:p-6 border-b ${borderClass}`}>
             <h2
               id="add-item-modal-title"

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -117,11 +117,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, onAuthSuc
           data-testid="auth-modal"
           className={`${surfaceClass} rounded-t-[2.5rem] rounded-b-none sm:rounded-[2.5rem] shadow-2xl w-full max-w-md h-[100dvh] sm:h-auto max-h-[100dvh] overflow-hidden flex flex-col border motion-panel pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
         >
-          <div className="sm:hidden flex items-center justify-center pt-2">
-            <span
-              className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-            />
-          </div>
+          <div className="sm:hidden h-3" />
           <div className={`flex items-center justify-between p-8 border-b ${dividerBorder}`}>
             <div>
               <h2

--- a/src/components/ConflictResolutionModal.tsx
+++ b/src/components/ConflictResolutionModal.tsx
@@ -79,11 +79,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
         aria-labelledby="conflict-resolution-title"
         className={`${surfaceClass} rounded-t-3xl rounded-b-none sm:rounded-3xl shadow-2xl w-full max-w-xl max-h-[90vh] overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
             <div className="p-2 rounded-xl bg-amber-50 text-amber-600">

--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -838,11 +838,7 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
         data-testid="create-collection-modal"
         className={`${surfaceClass} rounded-t-3xl rounded-b-none sm:rounded-2xl shadow-xl w-full max-w-md h-[100dvh] sm:h-auto max-h-[100dvh] overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between p-4 border-b ${dividerBorder}`}>
           <h2
             id="create-collection-title"

--- a/src/components/DeleteCollectionModal.tsx
+++ b/src/components/DeleteCollectionModal.tsx
@@ -33,11 +33,7 @@ export const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
       <div
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
             <div className="p-1.5 rounded-lg bg-red-100 text-red-600">

--- a/src/components/DeleteItemModal.tsx
+++ b/src/components/DeleteItemModal.tsx
@@ -33,11 +33,7 @@ export const DeleteItemModal: React.FC<DeleteItemModalProps> = ({
       <div
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
             <div className="p-1.5 rounded-lg bg-red-100 text-red-600">

--- a/src/components/DeleteItemsModal.tsx
+++ b/src/components/DeleteItemsModal.tsx
@@ -32,11 +32,7 @@ export const DeleteItemsModal: React.FC<DeleteItemsModalProps> = ({
       <div
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
             <div className="p-1.5 rounded-lg bg-red-100 text-red-600">

--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -63,11 +63,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({
       <div
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-lg h-[100dvh] sm:h-auto max-h-[100dvh] sm:max-h-[85vh] overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
             <div

--- a/src/components/ImageEditModal.tsx
+++ b/src/components/ImageEditModal.tsx
@@ -75,11 +75,7 @@ export const ImageEditModal: React.FC<ImageEditModalProps> = ({
         aria-labelledby="image-edit-title"
         className={`${surfaceClass} rounded-t-3xl rounded-b-none sm:rounded-3xl shadow-2xl w-full max-w-lg overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
-        <div className="sm:hidden flex items-center justify-center pt-2">
-          <span
-            className={`${theme === 'vault' ? 'bg-white/20' : 'bg-stone-200'} h-1.5 w-12 rounded-full`}
-          />
-        </div>
+        <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between p-4 border-b ${borderClass}`}>
           <h2
             id="image-edit-title"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -268,7 +268,7 @@ export const Layout: React.FC<LayoutProps> = ({
       </main>
 
       <nav
-        className={`fixed bottom-0 left-0 right-0 z-[60] border-t ${bottomNavSurface} sm:hidden`}
+        className={`fixed bottom-0 left-0 right-0 z-40 border-t ${bottomNavSurface} sm:hidden`}
         aria-label="Primary"
         style={{ height: 'var(--bottom-nav-height, 5.5rem)' }}
       >


### PR DESCRIPTION
Lower the bottom navigation z-index from z-[60] to z-40 so all modals
(z-50+) properly layer above it on mobile. Replace the non-functional
drag handle bars with clean spacers across 9 modal components to avoid
implying swipe-to-dismiss behavior that doesn't exist.

https://claude.ai/code/session_01MDhCYS5UGcdJ11qiPWQGDz