### PR TITLE
feat: compact waterfall layout with 2-col mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1352,15 +1352,15 @@ export const AppContent: React.FC = () => {
             <div
               className={`${
                 viewMode === 'grid'
-                  ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 sm:gap-8'
-                  : 'columns-1 sm:columns-2 md:columns-3 lg:columns-4 [column-gap:1.5rem] sm:[column-gap:2rem]'
+                  ? 'grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4 md:gap-5'
+                  : 'columns-2 sm:columns-2 md:columns-3 lg:columns-4 [column-gap:0.625rem] sm:[column-gap:0.75rem] md:[column-gap:1rem]'
               } w-full`}
               data-testid="items-grid"
             >
               {visibleItems.map((item) => (
                 <div
                   key={item.id}
-                  className={`break-inside-avoid ${viewMode === 'waterfall' ? 'mb-8 inline-block w-full align-top' : ''}`}
+                  className={`break-inside-avoid ${viewMode === 'waterfall' ? 'mb-2.5 sm:mb-3 md:mb-4 inline-block w-full align-top' : ''}`}
                 >
                   <ItemCard
                     item={item}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -99,7 +99,7 @@ export const ItemCard: React.FC<ItemCardProps> = React.memo(function ItemCard({
       data-item-id={item.id}
       data-item-title={item.title}
       data-selected={isSelected ? 'true' : 'false'}
-      className={`group rounded-2xl transition-all duration-300 ease-out overflow-hidden border cursor-pointer flex flex-col motion-safe:active:scale-[0.98] ${layout === 'grid' ? 'h-full' : ''} motion-card ${cardSurface} ${cardShadow} ${tapRing} ${isSelected ? 'ring-2 ring-amber-400' : ''}`}
+      className={`group rounded-xl sm:rounded-2xl transition-all duration-300 ease-out overflow-hidden border cursor-pointer flex flex-col motion-safe:active:scale-[0.98] ${layout === 'grid' ? 'h-full' : ''} motion-card ${cardSurface} ${cardShadow} ${tapRing} ${isSelected ? 'ring-2 ring-amber-400' : ''}`}
     >
       <div
         className={`${layout === 'grid' ? 'aspect-[4/3]' : ''} ${theme === 'vault' ? 'bg-stone-800' : 'bg-stone-100'} overflow-hidden relative`}
@@ -133,18 +133,18 @@ export const ItemCard: React.FC<ItemCardProps> = React.memo(function ItemCard({
           <div
             className={`absolute top-2 right-2 backdrop-blur-sm px-1.5 py-0.5 rounded-md flex items-center gap-1 shadow-sm ${ratingSurface}`}
           >
-            <Star size={10} className={`fill-current ${ratingColorClasses[theme]}`} />
-            <span className="text-[13px] sm:text-xs font-bold">{item.rating}</span>
+            <Star size={9} className={`fill-current ${ratingColorClasses[theme]}`} />
+            <span className="text-[11px] sm:text-xs font-bold">{item.rating}</span>
           </div>
         )}
       </div>
 
-      <div className="p-4 flex flex-col flex-grow">
+      <div className="p-2.5 sm:p-3 md:p-4 flex flex-col flex-grow">
         <div className="relative">
           <h4
             title={item.title}
             aria-label={item.title}
-            className={`${typographyClasses.title} line-clamp-1 mb-1`}
+            className={`${typographyClasses.title} text-sm sm:text-base line-clamp-2 mb-1`}
           >
             {item.title}
           </h4>
@@ -155,7 +155,7 @@ export const ItemCard: React.FC<ItemCardProps> = React.memo(function ItemCard({
           </span>
         </div>
 
-        <div className="space-y-1 mb-3">
+        <div className="space-y-0.5 sm:space-y-1 mb-2 sm:mb-3">
           {displayFields.map((fieldId) => {
             const val = getValue(fieldId);
             const label = getLabel(fieldId);
@@ -172,7 +172,9 @@ export const ItemCard: React.FC<ItemCardProps> = React.memo(function ItemCard({
           })}
         </div>
 
-        <div className={`mt-auto flex flex-wrap gap-1.5 pt-2 border-t ${dividerClasses[theme]}`}>
+        <div
+          className={`mt-auto flex flex-wrap gap-1 sm:gap-1.5 pt-1.5 sm:pt-2 border-t ${dividerClasses[theme]}`}
+        >
           {badgeFields.map((fieldId) => {
             const val = getValue(fieldId);
             if (!val) return null;

--- a/tests/components/ItemCard.test.tsx
+++ b/tests/components/ItemCard.test.tsx
@@ -478,7 +478,7 @@ describe('ItemCard Component', () => {
 
       const titleElement = screen.getByRole('heading', { name: longTitle });
       expect(titleElement).toBeInTheDocument();
-      expect(titleElement.className).toContain('line-clamp-1');
+      expect(titleElement.className).toContain('line-clamp-2');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Always show 2 columns on mobile (both grid and waterfall modes) so users can browse items side-by-side, Xiaohongshu-style
- Tighten gaps (24-32px → 10-16px responsive), card padding (16px → 10-16px responsive), and waterfall margins (32px → 10-16px responsive)
- Align card border-radius with DESIGN.md (`rounded-xl` on mobile, `rounded-2xl` on sm+)
- Allow 2-line titles on compact cards (`line-clamp-2`) with smaller font on mobile

## Test plan
- [x] All 531 unit tests pass
- [x] All 36 e2e tests pass
- [x] Production build succeeds
- [ ] Visual check on mobile viewport (~375px) — should show 2 columns with compact cards
- [ ] Visual check on tablet (~768px) — should show 3 columns
- [ ] Visual check on desktop (~1280px) — should show 4 columns
- [ ] Verify both grid and waterfall view modes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)