### PR TITLE
fix: redesign exhibition view for immersive mobile layout

### DIFF
--- a/src/components/ExhibitionView.tsx
+++ b/src/components/ExhibitionView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { X, ChevronLeft, ChevronRight, Star } from 'lucide-react';
 import { UserCollection } from '../types';
@@ -20,52 +20,207 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const [index, setIndex] = useState(initialIndex);
+  const [showInfo, setShowInfo] = useState(true);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const getFieldLabel = (fieldId: string, fallback: string) =>
     getFieldTranslation(t, fieldId, fallback);
+
+  const next = useCallback(
+    () => setIndex((i) => (i + 1) % collection.items.length),
+    [collection.items.length],
+  );
+  const prev = useCallback(
+    () => setIndex((i) => (i - 1 + collection.items.length) % collection.items.length),
+    [collection.items.length],
+  );
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') next();
+      else if (e.key === 'ArrowLeft') prev();
+      else if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, next, prev, onClose]);
 
   if (!isOpen || collection.items.length === 0) return null;
 
   const item = collection.items[index];
-  const next = () => setIndex((i) => (i + 1) % collection.items.length);
-  const prev = () => setIndex((i) => (i - 1 + collection.items.length) % collection.items.length);
+
+  // Touch handlers for swipe navigation
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  };
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (!touchStartRef.current) return;
+    const dx = e.changedTouches[0].clientX - touchStartRef.current.x;
+    const dy = e.changedTouches[0].clientY - touchStartRef.current.y;
+    // Only swipe if horizontal movement > 50px and dominates vertical
+    if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+      if (dx < 0) next();
+      else prev();
+    }
+    touchStartRef.current = null;
+  };
 
   const content = (
-    <div className="fixed inset-0 z-[9999] bg-stone-950 text-white animate-in fade-in duration-500 grid grid-rows-[auto_1fr_auto] pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]">
-      {/* Header - fixed height, no expansion */}
-      <header className="py-3 px-4 sm:py-6 sm:px-8 flex justify-between items-center bg-gradient-to-b from-stone-950 via-stone-950/80 to-transparent">
-        <div>
-          <h2 className="text-[10px] font-mono tracking-[0.2em] uppercase opacity-40 mb-0.5">
-            {collection.name}
-          </h2>
-          <p className="text-base sm:text-xl font-serif italic text-amber-500">
-            {t('exhibitNo', { n: index + 1, total: collection.items.length })}
-          </p>
+    <div
+      className="fixed inset-0 z-[9999] bg-stone-950 text-white animate-in fade-in duration-500 flex flex-col pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      {/* ── MOBILE LAYOUT (< sm) ── */}
+      <div className="flex flex-col h-full sm:hidden">
+        {/* Image: hero, fills most of the screen */}
+        <div className="relative flex-1 min-h-0">
+          <ItemImage
+            itemId={item.id}
+            photoUrl={item.photoUrl}
+            enhancedPath={item.photoEnhancedPath}
+            collectionId={item.collectionId ?? collection.id}
+            type="enhanced"
+            alt={item.title || t('archivalRecord')}
+            className="w-full h-full object-contain"
+          />
+          {/* Gradient overlay at bottom for text legibility */}
+          <div className="absolute inset-x-0 bottom-0 h-48 bg-gradient-to-t from-stone-950 via-stone-950/70 to-transparent pointer-events-none" />
+          {/* Top bar: collection name + close */}
+          <div className="absolute inset-x-0 top-0 flex justify-between items-start px-4 pt-3 bg-gradient-to-b from-stone-950/60 to-transparent">
+            <div>
+              <h2 className="text-[10px] font-mono tracking-[0.2em] uppercase opacity-40">
+                {collection.name}
+              </h2>
+              <p className="text-sm font-serif italic text-amber-500">
+                {t('exhibitNo', { n: index + 1, total: collection.items.length })}
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              aria-label={t('close')}
+              className="p-2 bg-white/10 hover:bg-white/20 rounded-full transition-all"
+            >
+              <X size={18} />
+            </button>
+          </div>
+          {/* Title overlaid at bottom of image */}
+          <div className="absolute inset-x-0 bottom-0 px-4 pb-3">
+            <button
+              onClick={() => setShowInfo((s) => !s)}
+              className="w-full text-left"
+              aria-label="Toggle details"
+            >
+              {item.rating > 0 && (
+                <div className="flex items-center gap-0.5 text-amber-500 mb-1">
+                  {[...Array(item.rating)].map((_, i) => (
+                    <Star key={i} size={12} fill="currentColor" />
+                  ))}
+                </div>
+              )}
+              <h1 className="text-xl font-serif font-bold leading-snug drop-shadow-lg">
+                {item.title}
+              </h1>
+            </button>
+          </div>
+          {/* Navigation arrows - sides of image */}
+          <button
+            onClick={prev}
+            aria-label={t('previous')}
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/30 backdrop-blur-sm flex items-center justify-center transition-all active:scale-90"
+          >
+            <ChevronLeft size={18} />
+          </button>
+          <button
+            onClick={next}
+            aria-label={t('next')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/30 backdrop-blur-sm flex items-center justify-center transition-all active:scale-90"
+          >
+            <ChevronRight size={18} />
+          </button>
         </div>
-        <button
-          onClick={onClose}
-          aria-label={t('close')}
-          className="p-2 sm:p-3 bg-white/10 hover:bg-white/20 rounded-full transition-all"
-        >
-          <X size={20} className="sm:w-6 sm:h-6" />
-        </button>
-      </header>
 
-      {/* Content - fills remaining space, scrolls only when necessary */}
-      <div className="relative min-h-0 overflow-y-auto overflow-x-hidden">
-        <div className="h-full flex flex-col sm:flex-row items-start sm:items-center justify-start sm:justify-center px-4 sm:px-12 py-2 sm:py-4 gap-4 sm:gap-12">
+        {/* Expandable info panel */}
+        <div
+          className={`transition-all duration-300 ease-in-out overflow-hidden ${showInfo ? 'max-h-60' : 'max-h-0'}`}
+        >
+          <div className="px-4 py-3 space-y-2">
+            {item.notes && (
+              <p className="text-stone-400 text-sm font-serif italic line-clamp-2">{item.notes}</p>
+            )}
+            {collection.customFields.length > 0 && (
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 pt-2 border-t border-white/10">
+                {collection.customFields.slice(0, 4).map((f) => {
+                  const value = item.data[f.id];
+                  if (!value) return null;
+                  return (
+                    <div key={f.id}>
+                      <p className="text-[8px] font-mono tracking-widest uppercase opacity-40">
+                        {getFieldLabel(f.id, f.label)}
+                      </p>
+                      <p className="text-xs font-medium truncate">{value}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Pagination dots */}
+        <div className="flex justify-center items-center gap-1.5 py-2.5">
+          {collection.items.slice(0, 10).map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setIndex(i)}
+              className={`h-1 rounded-full transition-all ${
+                i === index ? 'w-6 bg-amber-500' : 'w-1.5 bg-white/20 hover:bg-white/30'
+              }`}
+            />
+          ))}
+          {collection.items.length > 10 && (
+            <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
+          )}
+        </div>
+      </div>
+
+      {/* ── DESKTOP LAYOUT (>= sm) ── */}
+      <div className="hidden sm:grid sm:grid-rows-[auto_1fr_auto] h-full">
+        {/* Header */}
+        <header className="py-6 px-8 flex justify-between items-center">
+          <div>
+            <h2 className="text-[10px] font-mono tracking-[0.2em] uppercase opacity-40 mb-0.5">
+              {collection.name}
+            </h2>
+            <p className="text-xl font-serif italic text-amber-500">
+              {t('exhibitNo', { n: index + 1, total: collection.items.length })}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label={t('close')}
+            className="p-3 bg-white/10 hover:bg-white/20 rounded-full transition-all"
+          >
+            <X size={24} />
+          </button>
+        </header>
+
+        {/* Content */}
+        <div className="relative min-h-0 flex items-center justify-center px-20">
           {/* Navigation arrows */}
           <button
             onClick={prev}
             aria-label={t('previous')}
-            className="hidden sm:flex absolute left-4 sm:left-8 top-1/2 -translate-y-1/2 w-10 h-10 sm:w-14 sm:h-14 rounded-full bg-white/5 hover:bg-white/10 items-center justify-center transition-all hover:scale-110 z-10"
+            className="absolute left-8 top-1/2 -translate-y-1/2 w-14 h-14 rounded-full bg-white/5 hover:bg-white/10 flex items-center justify-center transition-all hover:scale-110 z-10"
           >
-            <ChevronLeft size={24} className="sm:w-7 sm:h-7" />
+            <ChevronLeft size={28} />
           </button>
 
-          <div className="max-w-4xl w-full grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-12 items-start sm:items-center animate-in zoom-in-95 duration-700">
-            {/* Image container - responsive height based on viewport */}
-            <div className="relative w-full max-w-xs sm:max-w-none mx-auto">
-              <div className="aspect-[3/4] max-h-[50vh] sm:max-h-[60vh] rounded-xl sm:rounded-2xl overflow-hidden shadow-2xl border border-white/10 group">
+          <div className="max-w-5xl w-full grid grid-cols-[1.2fr_1fr] gap-12 items-center animate-in zoom-in-95 duration-700">
+            {/* Image */}
+            <div className="relative w-full h-full flex items-center justify-center">
+              <div className="w-full max-h-[70vh] aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl border border-white/10 group">
                 <ItemImage
                   itemId={item.id}
                   photoUrl={item.photoUrl}
@@ -75,59 +230,41 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
                   alt={item.title || t('archivalRecord')}
                   className="w-full h-full object-cover transition-transform duration-[2s] group-hover:scale-105"
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-stone-950/30 to-transparent pointer-events-none" />
-              </div>
-              {/* Mobile navigation arrows below image */}
-              <div className="flex sm:hidden justify-center gap-8 mt-3">
-                <button
-                  onClick={prev}
-                  aria-label={t('previous')}
-                  className="w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center transition-all"
-                >
-                  <ChevronLeft size={20} />
-                </button>
-                <button
-                  onClick={next}
-                  aria-label={t('next')}
-                  className="w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center transition-all"
-                >
-                  <ChevronRight size={20} />
-                </button>
+                <div className="absolute inset-0 bg-gradient-to-t from-stone-950/20 to-transparent pointer-events-none" />
               </div>
             </div>
 
             {/* Text content */}
-            <div className="space-y-3 sm:space-y-6 text-center sm:text-left w-full">
-              <div className="space-y-2 sm:space-y-3">
+            <div className="space-y-6 text-left">
+              <div className="space-y-3">
                 {item.rating > 0 && (
-                  <div className="flex items-center justify-center sm:justify-start gap-1 text-amber-500">
+                  <div className="flex items-center gap-1 text-amber-500">
                     {[...Array(item.rating)].map((_, i) => (
-                      <Star key={i} size={14} className="sm:w-4 sm:h-4" fill="currentColor" />
+                      <Star key={i} size={16} fill="currentColor" />
                     ))}
                   </div>
                 )}
-                <h1 className="text-2xl sm:text-4xl lg:text-5xl font-serif font-bold leading-tight">
+                <h1 className="text-4xl lg:text-5xl font-serif font-bold leading-tight">
                   {item.title}
                 </h1>
                 {item.notes && (
-                  <p className="text-stone-400 text-sm sm:text-lg font-light leading-relaxed font-serif italic sm:border-l-2 border-stone-800 sm:pl-4 line-clamp-3 sm:line-clamp-4">
+                  <p className="text-stone-400 text-lg font-light leading-relaxed font-serif italic border-l-2 border-stone-800 pl-4 line-clamp-4">
                     {item.notes}
                   </p>
                 )}
               </div>
 
-              {/* Custom fields - show fewer on mobile */}
               {collection.customFields.length > 0 && (
-                <div className="grid grid-cols-2 gap-x-4 sm:gap-x-8 gap-y-2 sm:gap-y-4 pt-3 sm:pt-6 border-t border-white/10 text-left">
+                <div className="grid grid-cols-2 gap-x-8 gap-y-4 pt-6 border-t border-white/10">
                   {collection.customFields.slice(0, 4).map((f) => {
                     const value = item.data[f.id];
                     if (!value) return null;
                     return (
                       <div key={f.id}>
-                        <p className="text-[8px] sm:text-[10px] font-mono tracking-widest uppercase opacity-40 mb-0.5">
+                        <p className="text-[10px] font-mono tracking-widest uppercase opacity-40 mb-0.5">
                           {getFieldLabel(f.id, f.label)}
                         </p>
-                        <p className="text-xs sm:text-base font-medium truncate">{value}</p>
+                        <p className="text-base font-medium truncate">{value}</p>
                       </div>
                     );
                   })}
@@ -136,36 +273,33 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
             </div>
           </div>
 
-          {/* Desktop right arrow */}
           <button
             onClick={next}
             aria-label={t('next')}
-            className="hidden sm:flex absolute right-4 sm:right-8 top-1/2 -translate-y-1/2 w-10 h-10 sm:w-14 sm:h-14 rounded-full bg-white/5 hover:bg-white/10 items-center justify-center transition-all hover:scale-110 z-10"
+            className="absolute right-8 top-1/2 -translate-y-1/2 w-14 h-14 rounded-full bg-white/5 hover:bg-white/10 flex items-center justify-center transition-all hover:scale-110 z-10"
           >
-            <ChevronRight size={24} className="sm:w-7 sm:h-7" />
+            <ChevronRight size={28} />
           </button>
         </div>
-      </div>
 
-      {/* Footer - fixed height, pagination */}
-      <footer className="py-3 px-4 sm:py-6 sm:px-8 flex justify-center bg-gradient-to-t from-stone-950 via-stone-950/80 to-transparent">
-        <div className="flex gap-1.5 sm:gap-2 items-center">
-          {collection.items.slice(0, 10).map((_, i) => (
-            <button
-              key={i}
-              onClick={() => setIndex(i)}
-              className={`h-1 sm:h-1.5 rounded-full transition-all ${
-                i === index
-                  ? 'w-6 sm:w-10 bg-amber-500'
-                  : 'w-1.5 sm:w-3 bg-white/20 hover:bg-white/30'
-              }`}
-            />
-          ))}
-          {collection.items.length > 10 && (
-            <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
-          )}
-        </div>
-      </footer>
+        {/* Footer pagination */}
+        <footer className="py-6 px-8 flex justify-center">
+          <div className="flex gap-2 items-center">
+            {collection.items.slice(0, 10).map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setIndex(i)}
+                className={`h-1.5 rounded-full transition-all ${
+                  i === index ? 'w-10 bg-amber-500' : 'w-3 bg-white/20 hover:bg-white/30'
+                }`}
+              />
+            ))}
+            {collection.items.length > 10 && (
+              <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
+            )}
+          </div>
+        </footer>
+      </div>
     </div>
   );
 


### PR DESCRIPTION
## Summary
- **Mobile**: Image now fills the viewport as the hero element with overlaid header/title (was previously constrained to `max-w-xs` making it tiny). Added swipe gesture navigation and a toggleable info panel for notes/metadata.
- **Desktop**: Increased image prominence (70vh, weighted grid column), added keyboard navigation (arrow keys + Escape).
- Separated mobile and desktop into distinct layout blocks for maintainability.

## Test plan
- [x] Unit tests pass (531 passed)
- [x] E2E tests pass (36 passed)
- [x] Build succeeds
- [ ] Manually verify exhibition view on mobile viewport (≤640px)
- [ ] Manually verify swipe left/right navigates items
- [ ] Manually verify tapping title toggles info panel
- [ ] Manually verify keyboard nav on desktop (←/→/Esc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)