### PR TITLE
fix: sort newest/oldest by createdAt instead of updatedAt

### DIFF
--- a/src/utils/collectionSorting.ts
+++ b/src/utils/collectionSorting.ts
@@ -2,13 +2,13 @@ import { CollectionItem } from '../types';
 
 export type ItemSort = 'newest' | 'oldest' | 'title' | 'rating';
 
-const getTimestamp = (item: CollectionItem) => item.updatedAt || item.createdAt || '';
+const getCreatedTimestamp = (item: CollectionItem) => item.createdAt || '';
 
 export const sortCollectionItems = (items: CollectionItem[], sortBy: ItemSort) => {
   const sorted = [...items];
   switch (sortBy) {
     case 'oldest':
-      sorted.sort((a, b) => getTimestamp(a).localeCompare(getTimestamp(b)));
+      sorted.sort((a, b) => getCreatedTimestamp(a).localeCompare(getCreatedTimestamp(b)));
       break;
     case 'title':
       sorted.sort((a, b) => a.title.localeCompare(b.title));
@@ -18,7 +18,7 @@ export const sortCollectionItems = (items: CollectionItem[], sortBy: ItemSort) =
       break;
     case 'newest':
     default:
-      sorted.sort((a, b) => getTimestamp(b).localeCompare(getTimestamp(a)));
+      sorted.sort((a, b) => getCreatedTimestamp(b).localeCompare(getCreatedTimestamp(a)));
       break;
   }
   return sorted;

--- a/tests/utils/collectionSorting.test.ts
+++ b/tests/utils/collectionSorting.test.ts
@@ -19,20 +19,39 @@ const runSort = (items: CollectionItem[], sortBy: ItemSort) =>
   sortCollectionItems(items, sortBy).map((item) => item.title);
 
 describe('sortCollectionItems', () => {
-  it('sorts by newest first', () => {
+  it('sorts by newest first (using createdAt)', () => {
     const items = [
-      createItem({ title: 'Old', updatedAt: '2024-01-01T00:00:00Z' }),
-      createItem({ title: 'New', updatedAt: '2024-02-01T00:00:00Z' }),
+      createItem({ title: 'Old', createdAt: '2024-01-01T00:00:00Z' }),
+      createItem({ title: 'New', createdAt: '2024-02-01T00:00:00Z' }),
     ];
     expect(runSort(items, 'newest')).toEqual(['New', 'Old']);
   });
 
-  it('sorts by oldest first', () => {
+  it('sorts by oldest first (using createdAt)', () => {
     const items = [
-      createItem({ title: 'Old', updatedAt: '2024-01-01T00:00:00Z' }),
-      createItem({ title: 'New', updatedAt: '2024-02-01T00:00:00Z' }),
+      createItem({ title: 'Old', createdAt: '2024-01-01T00:00:00Z' }),
+      createItem({ title: 'New', createdAt: '2024-02-01T00:00:00Z' }),
     ];
     expect(runSort(items, 'oldest')).toEqual(['Old', 'New']);
+  });
+
+  it('ignores updatedAt for newest/oldest sort', () => {
+    const items = [
+      createItem({
+        title: 'Added first, edited recently',
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-12-01T00:00:00Z',
+      }),
+      createItem({
+        title: 'Added second, never edited',
+        createdAt: '2024-06-01T00:00:00Z',
+        updatedAt: '2024-06-01T00:00:00Z',
+      }),
+    ];
+    expect(runSort(items, 'newest')).toEqual([
+      'Added second, never edited',
+      'Added first, edited recently',
+    ]);
   });
 
   it('sorts by title', () => {


### PR DESCRIPTION
## Summary
- Newest/oldest sorting was using `updatedAt`, so editing an old item would incorrectly move it to the top of the list
- Changed to sort by `createdAt` so items are ordered by when they were added, not last modified
- Added a regression test verifying `updatedAt` is ignored for newest/oldest sort

## Test plan
- [x] All 532 unit tests pass
- [x] Production build succeeds
- [ ] Verify in the app that sorting newest/oldest reflects item creation order, not edit order

🤖 Generated with [Claude Code](https://claude.com/claude-code)