### PR TITLE
docs: restructure product docs with clear ownership boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,17 @@ When changing code or product behavior, follow these documentation rules:
 - **Do not create duplicate docs.** Prefer updating an existing doc or deleting stale docs rather than adding more files.
 - **Keep docs aligned with reality.** If documentation contradicts the codebase, fix or remove it.
 - **Prefer code-adjacent docs** for implementation details (e.g., testing details in `tests/README.md`).
-- **Issues belong in GitHub.** Do not maintain long-term “TODO” lists in `docs/` when an issue already exists.
+- **Issues belong in GitHub.** Do not maintain long-term “TODO” lists or issue priority orders in `docs/` when issues already exist on GitHub.
 - **Issue drafts are temporary.** If you create `docs/issue-drafts/<YYYY-MM-DD>/...` for batch import, delete the drafts after issues exist on GitHub.
 - **Canonical docs list** lives in `README.md` under “Documentation (how we keep it clean)”.
+
+### Doc ownership (where to put what)
+
+Each product doc has a clear scope. When adding content, put it in the right file and cross-reference rather than duplicating:
+
+- **`docs/PRODUCT_STRATEGY.md`** — product thesis, target user, positioning, principles, core product decisions, platform stance, business model, deferred features, founder guidance.
+- **`docs/ROADMAP.md`** — execution phases with goals/key work/exit criteria, metrics to track. References strategy for context.
+- **`docs/PRODUCT_DESIGN.md`** — UX requirements, interaction design, mobile guidelines, design language, onboarding flows, AI UX stance. References strategy for context.
 
 ## Product Constraints (MVP: Value in 5 Minutes)
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ This repo intentionally keeps documentation **small, current, and non-duplicativ
 
 ### Canonical docs
 
-- **Product**: `docs/PRODUCT_DESIGN.md`
-- **Architecture**: `docs/TECHNICAL_DESIGN.md`
-- **Testing**: `docs/TESTING.md` (quick how-to) and `tests/README.md` (details)
-- **Issue filing**: `docs/GITHUB_ISSUES_PROTOCOL.md`
+| Doc | Owns | Does NOT own |
+|-----|------|-------------|
+| `docs/PRODUCT_STRATEGY.md` | Product thesis, target user, positioning, principles, core product decisions, platform stance, business model, deferred features, founder guidance | Execution timelines, UX specs, metrics |
+| `docs/ROADMAP.md` | Execution phases, exit criteria, metrics to track | Strategic decisions (reference PRODUCT_STRATEGY.md) |
+| `docs/PRODUCT_DESIGN.md` | UX requirements, interaction design, mobile guidelines, design language, onboarding flows, AI UX stance | Strategic decisions, execution phases (reference the above) |
+| `docs/TECHNICAL_DESIGN.md` | Architecture, data flow, infrastructure | Product decisions |
+| `docs/TESTING.md` + `tests/README.md` | Testing how-to and patterns | — |
+| `docs/GITHUB_ISSUES_PROTOCOL.md` | Issue filing format and labels | — |
+
+Issue prioritization and TODO tracking live in **GitHub Issues/Projects**, not in docs.
 
 ### Other docs (organized)
 
@@ -32,7 +38,9 @@ This repo intentionally keeps documentation **small, current, and non-duplicativ
 
 ### Onboarding essentials
 
-- **Product + UX constraints**: `docs/PRODUCT_DESIGN.md` (5-minute time-to-value rules)
+- **Product strategy + principles**: `docs/PRODUCT_STRATEGY.md`
+- **UX constraints + design**: `docs/PRODUCT_DESIGN.md` (5-minute time-to-value rules)
+- **Execution roadmap**: `docs/ROADMAP.md`
 - **System architecture + data flow**: `docs/TECHNICAL_DESIGN.md`
 - **Sync reliability expectations**: `docs/ops/INDEXEDDB_RELIABILITY.md`
 - **Testing workflow**: `docs/TESTING.md` and `tests/README.md`

--- a/docs/PRODUCT_DESIGN.md
+++ b/docs/PRODUCT_DESIGN.md
@@ -1,8 +1,10 @@
 # Curio - Product Design Document
 
+> This document owns **UX requirements, interaction design, mobile guidelines, and design language**. For product thesis, principles, and strategic decisions, see `docs/PRODUCT_STRATEGY.md`. For execution phases and metrics, see `docs/ROADMAP.md`.
+
 ## 1. Vision & Purpose
 
-Curio is a digital sanctuary for physical collectors. Unlike marketplace-driven apps, Curio is an **intimate archival tool**. It is designed for the "joy of ownership"—focusing on personal narratives, high-end aesthetics, and the emotional value of a curated collection.
+Curio is a personal museum for meaningful objects. Unlike marketplace-driven apps or generic inventory tools, Curio is an **identity-driven archival product**. It is designed around personal narratives, strong aesthetics, and the emotional value of a curated collection.
 
 ## 1.1 MVP North Star: Value in the First 5 Minutes
 
@@ -12,7 +14,7 @@ Curio is a digital sanctuary for physical collectors. Unlike marketplace-driven 
 
 - **Minute 0–1: Immediate delight (no friction)**
   - User lands in a beautiful **Public Sample Gallery** (read-only) or can enter it with one click.
-  - One-line positioning explains Curio: _a personal archival sanctuary, not a marketplace_.
+  - One-line positioning explains Curio: _a personal museum, not a marketplace or spreadsheet_.
 - **Minute 1–3: One clear action**
   - One primary CTA: **Add your first item** (secondary: **Explore sample**).
   - Capture is guided by a single, mobile-first screen (Upload photo → Details) where AI can auto-fill in the background (never blocking Save).
@@ -27,7 +29,7 @@ Curio is a digital sanctuary for physical collectors. Unlike marketplace-driven 
 - **AI must be recoverable:** AI latency/failure must never block the flow. Provide a clear fallback to manual entry and keep the user’s progress.
 - **Templates must be self-explanatory:** Template selection should show a short description + field preview so users can pick confidently in seconds.
 - **Read-only must be obvious:** Public/sample content must always show a persistent read-only indicator and disabled edit affordances.
-- **Defer advanced features:** Museum Guide, Exhibition, deep filtering, etc. should be discoverable _after_ the first successful save.
+- **Defer distractions:** Museum Guide, AI image enhancement, Vault Lock, and heavy social mechanics should not compete with the first-save experience.
 
 ## 1.3 MVP Behaviors (as implemented)
 
@@ -56,10 +58,11 @@ This section captures **current behavior in the codebase** (so docs stay actiona
 
 ### Design notes: Make capture “feel simple” on mobile
 
-- **Default view is minimal**: photo + title + a few “primary” fields + rating + Save.
+- **Default view is minimal but expressive**: photo + title + a few “primary” fields + Story prompt + rating + Save.
 - **Progress never blocks**: any AI-assisted work is communicated as “filling in” rather than “step 3/4”.
 - **Advanced inputs are secondary**:
-  - **Notes** is hidden behind a lightweight “Add narrative” toggle.
+  - **Story** is visible by default and should be easy to fill in.
+  - Extra notes or technical detail can sit behind a lightweight secondary toggle.
   - Remaining metadata fields are hidden behind a “More details” / “Technical spec” toggle.
   - Batch mode is present but not primary (it’s discoverable as an optional link).
 - **AI failures are boring**: show a short “AI unavailable—continue manually” message and keep the user on the same screen.
@@ -83,23 +86,21 @@ This section captures **current behavior in the codebase** (so docs stay actiona
 - **Offline clarity**: Persistent banner explains that edits are saved locally and will sync later.
 - **Undo/redo**: Lightweight history for in-session item edits to reduce accidental changes.
 
-## 2.1 AI image features (design + cost guardrails)
+## 2.1 Active AI stance
 
-Curio’s AI image work should be **explicitly optional**, **recoverable**, and **cost-aware**:
+Curio’s active AI work should stay **explicitly optional**, **recoverable**, and **cost-aware**.
 
-- **Two capabilities (separately toggleable)**:
-  - **Metadata extraction**: “fill in fields from an uploaded photo” (fast, low-risk).
-  - **Image-to-image enhancement**: “make this photo look cleaner / more presentable” or “generate a poster/ad version” (newer, higher-cost, higher-risk).
-- **Cost guardrail**: never generate multiple variations by default. Defaults:
-  - One-tap “Enhance” generates **one** result.
-  - “Try again” / “More like this” is an explicit user action (each action == one more generation).
-- **Transparency**:
-  - Always keep **Original** available.
-  - If enhancement fails, the user still has their item saved with original/display images.
+Current active use:
 
-### Gemini image editing reference
+- **Metadata extraction**: image to structured fields, titles, and prompts
 
-When using Google’s Gemini image-to-image models (Nano Banana), we should follow and link to the official API guidance: [Gemini image editing](https://ai.google.dev/gemini-api/docs/image-generation#gemini-image-editing).
+Current non-goals:
+
+- AI image enhancement
+- poster generation
+- multi-variant image editing workflows
+
+If AI is unavailable or inaccurate, the user must still be able to complete the flow manually without losing progress.
 
 ## 2.2 Mobile-first capture simplification (consolidated requirements)
 
@@ -114,8 +115,8 @@ This section consolidates prior standalone design docs into a single durable sou
 ### Default capture surface (single-screen)
 
 - **Primary action**: add photo (camera or upload)
-- **Always available**: title, key template fields, rating (optional), Save
-- **Secondary / optional**: notes, “More details”/technical spec, batch mode (discoverable, not primary)
+- **Always available**: title, key template fields, Story prompt, rating (optional), Save
+- **Secondary / optional**: extra notes, “More details”/technical spec, batch mode (discoverable, not primary)
 
 ### Non-blocking AI autofill behavior
 
@@ -131,64 +132,17 @@ This section consolidates prior standalone design docs into a single durable sou
 - **Keyboard ergonomics**: sensible Next/Done, correct input types, no jumpy layout when AI updates
 - **Clear AI state**: subtle “filling in…” indicator; no blocking spinners as the only signal
 
-## 2.3 AI image-to-image editing (Enhance + Poster) — trust + cost
+## 2.3 Deferred AI image experiments
 
-Curio treats these as separate capabilities from metadata extraction:
+Image-to-image enhancement and poster generation are deferred.
 
-- **Metadata extraction**: image → structured fields (core, low-risk)
-- **Image-to-image**: image → enhanced image (higher-cost/risk; always explicit)
+Reasons:
 
-### Phased rollout
+- they are expensive relative to current product value
+- they do not fix the core trust and story loop
+- they risk distracting from capture, editing, and sharing
 
-- **Phase 1: Enhance image (clean / presentable)**  
-  Outcome-first CTA: “Enhance image”. Generates **one** result, with before/after comparison, Accept/Keep original, and explicit “Try again”.
-- **Phase 2: Poster / ad (creative)**  
-  CTA: “Create poster”. Generates **one** result, optional style presets, explicit “Try again”. Typography imperfections are an expected V1 risk.
-
-### Two user-facing intents (make it explicit)
-
-- **Catalog / Documentation (default)**: accurate + clean, conservative changes
-- **Showcase / Aesthetic (opt-in)**: studio + pretty, more opinionated polish
-
-### Quality rubric (acceptance + QA)
-
-Score output \(0–2\) per dimension (total /12):
-
-1. **Subject prominence**
-2. **Legibility (if text exists)**
-3. **Exposure & dynamic range**
-4. **Color & white balance**
-5. **Geometry correctness**
-6. **Background cleanliness**
-
-Definition of “enhancement success” (Catalog mode):
-
-- Total score increases by **≥ 3 points**, and
-- **Geometry never worsens**, and
-- **Color does not materially drift** (human-obvious drift is a failure).
-
-### Trust boundaries (what enhancement may change)
-
-- **Generally safe**: straighten/crop, exposure/contrast, white balance, moderate denoise (text-safe), mild background declutter, bounded perspective correction
-- **Risky (opt-in or warn)**: aggressive relighting that changes material feel, heavy “beautify”, reconstruction of obscured text
-- **Forbidden by default**: changing/recreating logos/labels/serial numbers, altering colorways/edition markers, reshaping the object, adding new props/elements
-
-### Export / sharing note
-
-Some providers may embed provenance watermarks (e.g., SynthID). If a generated asset is exported/shared, the UI should be explicit that it’s generated and may include a watermark.
-
-### Cost guardrails (must-have)
-
-- **No multi-variant by default**: one generation per explicit user action
-- **Cheap-by-default**: default model/quality is routine-friendly; “High quality” is an explicit choice where needed
-- **Budget + rate limiting policy**: prevent accidental loops; enforce per-user limits (tracked in GitHub)
-
-### Open questions (track in GitHub)
-
-- Where does “Enhance image” live: during capture vs on item detail?
-- Should enhancement be allowed for public/sample collections (or only via “copy to my collection”)?
-- Do we need a paid tier or hard limits for image-to-image usage?
-- Export UX expectations given potential provenance watermarks.
+If reintroduced later, they should be treated as explicit, premium, opt-in creative tools rather than part of the core collecting flow.
 
 ## 6. UX review findings (2026-01-13) — consolidated summary
 
@@ -205,7 +159,7 @@ This is a short synthesis of the 2026-01-13 external UX review. Action items sho
 - **No feedback after key actions**: show clear confirmation after add/save and reliable error states when something fails.
 - **Unclear icon meaning**: tooltips/labels for non-obvious actions (some are tracked: [#68](https://github.com/Akkkkkkki/curio/issues/68), [#95](https://github.com/Akkkkkkki/curio/issues/95)).
 - **Metadata editing**: users need an edit path on item detail without delete-and-readd.
-- **Vocal Guide readiness**: if disabled/non-functional, hide or mark “coming soon” to avoid confusion.
+- **Museum Guide readiness**: if disabled or non-functional, keep it fully hidden or clearly feature-flagged to avoid confusing users.
 
 ### Card readability
 
@@ -227,24 +181,16 @@ We avoid keeping long-lived “implementation checklists” in `docs/` because t
 
 If you need a checklist for a short-lived push, keep it inside the relevant GitHub issue/PR description instead of a new doc.
 
-## 2. MVP Goals & Enhancements
+## 2. Active Priorities
 
-1. **Velocity of Capture**:
-   - **Rapid-Fire Mode**: Batch upload for serious archivists.
-   - **AI Auto-naming**: Gemini suggests high-quality archival names based on visual cues.
-2. **Emotional Utility**:
-   - **Archive Archeology**: "On This Day" feature to surface past memories.
-   - **Museum Guide**: A proactive vocal companion that acts as a sophisticated curator.
-3. **Global Aesthetic Curation**:
-   - **Dynamic Global Themes**: Users select from _The Gallery_ (Light/Airy), _The Vault_ (Moody/Dark), or _The Atelier_ (Artisanal/Warm).
-4. **Security for High-Value Collections**:
-   - **Vault Lock**: Optional biometric-style lock for specific collections. (Tracked in [#87](https://github.com/Akkkkkkki/curio/issues/87))
+See `docs/PRODUCT_STRATEGY.md` for product decisions and `docs/ROADMAP.md` for execution phases. The UX implications of those priorities are reflected throughout this document.
 
 ## 3. Design Language
 
 - **Typography**: _DM Serif Display_ for elegance; _Inter_ for precision.
 - **Visual Layout**: "Bento Grid" home screen for a modern museum feel; Masonry grids for item browsing.
 - **Theming**: Global theme selection replaces collection-specific accents for a unified aesthetic experience.
+- **Sharing surfaces**: exported cards and public pages should feel intentional, collectible, and aesthetically credible without becoming gimmicky.
 
 ## 4. Onboarding & Cloud Access
 
@@ -264,5 +210,4 @@ A curated public sample collection is visible to all users as inspiration. It is
 
 ## 5. Future Roadmap
 
-- **Social Curation**: Generate cinematic video "portraits" of items for sharing.
-- **NFC/QR Tagging**: Print tiny archival stickers that link directly to the Curio record.
+See `docs/ROADMAP.md` for execution phases and `docs/PRODUCT_STRATEGY.md` for platform stance and deferred features.

--- a/docs/PRODUCT_STRATEGY.md
+++ b/docs/PRODUCT_STRATEGY.md
@@ -1,0 +1,187 @@
+# Curio - Product Strategy
+
+**Date:** 2026-03-28
+**Status:** Current working strategy
+**Related docs:** `docs/ROADMAP.md` (execution phases), `docs/PRODUCT_DESIGN.md` (UX and interaction design), `docs/TECHNICAL_DESIGN.md` (architecture)
+
+## 1. Product Thesis
+
+Curio is a personal museum for meaningful objects.
+
+It is not a marketplace, not a generic inventory utility, and not a category-specific tracker. The core promise is that people can capture, remember, organize, and proudly share the things that define their taste and identity.
+
+The broad product vision stays broad. The go-to-market does not. Curio should narrow by user type, not by item category.
+
+## 2. Who Curio Is For
+
+Curio is for identity-driven collectors and memory keepers:
+
+- people who keep meaningful objects, not just expensive ones
+- people who care about the story behind an object, not only its metadata
+- people who want a beautiful archive, not a spreadsheet
+- people who want to share their collections in a way that feels expressive
+
+The product should work across mixed collections:
+
+- dark chocolate packaging
+- tea tins
+- flight tickets
+- posters
+- vinyl
+- sneakers
+- family heirlooms
+
+The point is not "collect everything." The point is "make meaningful objects feel alive."
+
+## 3. Positioning
+
+Curio should position itself as:
+
+- the most beautiful way to remember, organize, and share the things that define your taste
+
+Curio should not position itself as:
+
+- a generic database
+- a home inventory tracker
+- a resale marketplace
+- a museum CMS
+
+## 4. Product Principles
+
+1. **Identity before inventory**
+2. **Story before schema**
+3. **Beauty before bureaucracy**
+4. **Acceleration before automation**
+5. **Sharing before social complexity**
+6. **Trust before growth**
+
+These principles should break ties in product decisions.
+
+## 5. Core Product Decisions
+
+### 5.1 Story is human-authored
+
+The visible narrative layer should be written or shaped by the user.
+
+AI-generated object descriptions should not appear as the main story. They can remain as hidden metadata that the user can inspect when useful.
+
+AI can help by:
+
+- extracting metadata
+- suggesting prompt questions
+- helping refine user-written text
+
+AI should not invent the memory.
+
+### 5.2 Sharing is central from the start
+
+Curio is not only for private journaling. It should help users proudly show what they have collected.
+
+Early sharing should focus on:
+
+- public museum or profile pages
+- shareable item cards
+- shareable collection cards
+- tasteful customization of shared outputs
+
+Heavy social complexity should wait. No DMs, noisy feeds, or notification-heavy systems until repeat usage exists.
+
+### 5.3 Broad product, flexible structure
+
+Curio should support many collection types, but without turning the product into a complicated database builder on day one.
+
+The right path is:
+
+- starter templates for common use cases
+- a lightweight custom template builder
+- a stable common card contract across mixed schemas
+
+### 5.4 Trust is the first product job
+
+The product cannot claim to be a personal museum if users do not trust their data, photos, and edits.
+
+That means the first execution priority is:
+
+- sync reliability
+- clear save and upload states
+- reliable add and edit flows
+- safe handling of offline and conflict cases
+
+## 6. Platform And Distribution Stance
+
+Curio should remain web-first in product architecture.
+
+That does **not** mean avoiding Android or Google Play. It means:
+
+- keep the core product logic shared with web
+- use Android / Google Play as an early distribution and payment test channel
+- ship native packaging when it helps market validation
+- avoid broad native-only feature work until demand is proven
+
+The strategic distinction matters:
+
+- **keep Android on the roadmap**
+- **do not let native expansion displace the core product loop**
+
+## 7. Business Model
+
+The primary business model is consumer subscription.
+
+The hypothesis is that users will pay for:
+
+- a trustworthy home for meaningful collections
+- beautiful presentation and sharing
+- premium customization
+- long-term archive value
+
+Current stance:
+
+- subscription is the intended business model
+- willingness to pay is still a hypothesis to validate
+- ads are not the primary plan
+- marketplace or affiliate models are possible later, not the first business
+
+Possible future tiers:
+
+- **Free** for basic collecting and limited sharing
+- **Pro** for deeper customization, premium sharing, and higher usage limits
+- **Patron** for heavier collectors and superfans
+
+## 8. What Curio Must Be Better At
+
+Curio needs to win on the combination of:
+
+- aesthetic quality
+- emotional resonance
+- flexibility across object types
+- AI-assisted acceleration
+- sharing output that people are proud to post or send
+
+Curio does **not** need to win by having the most fields, the most enterprise controls, or the most marketplace features.
+
+## 9. What Is Deferred
+
+These are not current execution priorities:
+
+- Museum Guide / voice companion
+- AI image enhancement and poster generation
+- Vault Lock / biometric security
+- marketplace and trading
+- heavy social features
+- NFC / QR tagging
+- cinematic video portraits
+
+Deferred does not mean banned forever. It means they should not crowd out trust, story, sharing, and flexible collections.
+
+## 10. Founder Guidance
+
+When product choices feel ambiguous, choose the option that makes Curio:
+
+- more trustworthy
+- more personal
+- more beautiful
+- more worth sharing
+
+Do not choose the option that only makes it more feature-rich.
+
+Curio wins if users feel proud of what they made and trust it enough to keep coming back.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,57 +1,160 @@
-## Curio — Product review & prioritized roadmap (2026-03-15)
+# Curio — Execution Roadmap (2026-03-28)
 
-Summary
-• Curio = "personal museum" for collecting, organizing, and browsing personal items with optional AI-assisted metadata extraction. Public sample gallery, local caching + Supabase sync, PWA/desktop/web-first.
+This document owns **execution phases, exit criteria, and metrics**. For product thesis, principles, positioning, and strategic decisions, see `docs/PRODUCT_STRATEGY.md`. For UX and interaction design requirements, see `docs/PRODUCT_DESIGN.md`.
 
-Honest product evaluation (value proposition)
+Issue prioritization lives in GitHub Issues/Projects, not here.
 
-- Strengths
-  - Evocative positioning: "personal museum" differentiates from generic note/photo apps.
-  - Low friction discovery via public sample gallery.
-  - AI-assisted metadata extraction reduces friction for bulk adding.
-  - Offline-first / IndexedDB + sync focus improves real-world reliability.
-- Weaknesses / threats
-  - Narrow utility vs incumbents (Photos, Notion, Airtable, hobby-specific apps).
-  - AI quality/latency/cost/privacy can undermine perceived value.
-  - Unclear monetization path.
-  - Discovery risks — needs targeted channels.
-  - Trust & privacy expectations must be addressed.
+## Current Strategic Reality
 
-Critical gaps (must fix before market push)
+The main gap is no longer "what could Curio become?" It is "does the current product earn the right to the personal-museum claim?"
 
-1. Single primary persona + 1‑paragraph value prop.
-2. Privacy policy & data model clarity (what stays local, what goes to AI/cloud).
-3. Local-first UX fallback when AI is unavailable.
+Right now the biggest risks are:
 
-High-priority improvements
+- sync and persistence trust gaps
+- AI-generated object descriptions being mistaken for human story
+- hardcoded templates blocking the broad cross-category vision
+- too much speculative scope around native-only expansion, AI image editing, and voice companion ideas
 
-- Define monetization experiment (free local tier + paid cloud/AI).
-- Onboarding: 5-minute time-to-value first-add flow.
-- Performance readiness: optimize bundle and sample assets.
+## Execution Phases
 
-Medium
+### Phase 0 — Trust And Soul
 
-- Competitive positioning & landing page content.
-- Analytics plan (activation & retention metrics).
-- App store checklist (if targeting mobile).
+Goal: make the current product trustworthy and emotionally coherent.
 
-Nice-to-have
+Must ship:
 
-- Curated sample collections per persona.
-- Free trial or limited AI quota.
-- Lightweight share/publish feature.
+1. Fix sync and persistence trust issues.
+2. Replace AI-generated archive narrative with a real human story flow.
+3. Keep AI-generated object descriptions as hidden metadata, visible on demand but not the primary narrative.
+4. Fix broken image and edit-path credibility issues.
+5. Define the foundations for public sharing surfaces.
+6. Add product and feature tracking instrumentation.
 
-2-week roadmap (practical)
+Key work:
 
-1. Clarify persona + top 3 use cases (1 day)
-2. Harden onboarding & first-run flow (3 days)
-3. Draft privacy text & AI/data flow diagram (2 days)
-4. Build landing page + email capture + outreach templates (3 days)
-5. Launch to one community, measure activation, iterate (remaining days)
+- harden sync merge and offline delete handling
+- surface pending upload and sync states clearly
+- ensure item editing works reliably after creation
+- replace the visible narrative with a human-written Story field
+- let AI suggest metadata and prompt questions, but not invent the story
+- instrument item creation, story usage, sync failures, share events, and profile visits
 
-Next actions
+Exit criteria:
 
-- Draft a 1-page product brief (persona, value prop, 3 features, pricing).
-- Prepare onboarding UI changes and PRs if push access is available.
+- users trust that data and photos are safe
+- story capture is visibly human-centered
+- item editing and save paths feel solid
+- the product is ready for public-facing sharing surfaces
 
-Sources: internal product review (2026-03-15)
+### Phase 1 — Flexible Collections And Sharing
+
+Goal: let people shape their museum and proudly share it.
+
+Must ship:
+
+1. Flexible collection templates
+2. Public museum profile pages
+3. Shareable item and collection cards
+4. Public-facing customization system for profiles and shared artifacts
+5. Routing approach for clean public URLs and preview metadata
+
+Key work:
+
+- lightweight custom template builder
+- starter templates backed by data, not hardcoded forever
+- stable mixed-schema browsing
+- public museum page design and privacy model
+- item-card and collection-card share surfaces
+- profile and sharing customization that stays tasteful rather than turning into a generic filter/sticker app
+
+Exit criteria:
+
+- users can create non-food and mixed collections without confusion
+- at least some users share their museum or item cards
+- shared artifacts look good enough to send without apology
+
+### Phase 1.5 — Android Market Test
+
+Goal: use Google Play as an early market-test channel without broadening native scope.
+
+Must ship:
+
+1. A stable Android distribution path for the existing product
+2. Minimal Android polish needed for testing and trust
+3. Feature tracking needed to measure activation and retention from that channel
+
+Key work:
+
+- ensure Android packaging is reliable enough for internal / closed / public testing as appropriate
+- keep the product logic shared with web
+- avoid native-only features unless directly required for the test
+
+Exit criteria:
+
+- Android users can install, onboard, capture, save, and share without platform-specific blockers
+- subscription willingness and usage can be measured from Google Play traffic
+
+### Phase 2 — Discovery And Light Community
+
+Goal: make Curio feel alive without turning it into a noisy social app.
+
+Must ship:
+
+1. Curated discovery surface
+2. Lightweight follow model or discovery graph
+3. "Year in Objects" / "Collection Wrapped" once users have enough content
+
+Avoid:
+
+- DMs
+- heavy notifications
+- algorithmic feeds
+- social complexity before repeat usage exists
+
+### Phase 3 — Monetization And Expansion
+
+Goal: convert emotional attachment into sustainable revenue.
+
+Primary model:
+
+- Free
+- Pro
+- Patron
+
+Later options:
+
+- insurance referrals
+- affiliate commerce
+- marketplace experiments
+
+These are expansions, not the plan.
+
+## Metrics To Track
+
+Start tracking baselines now.
+
+Core events:
+
+- item creation starts
+- item saves
+- story field usage
+- item edits after creation
+- sync failures
+- upload failures
+- shares initiated
+- public profile visits once profiles exist
+- subscription funnel events once billing exists
+
+Product metrics:
+
+- item completion rate
+- 3-item first-week retention
+- sync failure rate
+- share rate
+- profile visit rate
+- conversion to paid
+
+Implementation note:
+
+- add a feature-tracking integration for these events early
+- keep the event taxonomy stable across web and Android


### PR DESCRIPTION
## Summary

- Introduces `docs/PRODUCT_STRATEGY.md` as the single source of truth for product thesis, positioning, principles, business model, and deferred features.
- Rewrites `docs/ROADMAP.md` from a loose evaluation into structured execution phases (0–3) with goals, key work, exit criteria, and metrics.
- Slims `docs/PRODUCT_DESIGN.md` to focus on UX/interaction/mobile/design, removing strategy and roadmap content that now lives in the other two docs.
- Adds doc ownership rules to `CLAUDE.md` and updates the canonical docs table in `README.md` so each doc's scope is explicit.

## Test plan

- [ ] Verify all cross-references between the three product docs resolve correctly
- [ ] Confirm no duplicate content across PRODUCT_STRATEGY, ROADMAP, and PRODUCT_DESIGN
- [ ] Check that CLAUDE.md doc ownership section matches the README table

🤖 Generated with [Claude Code](https://claude.com/claude-code)