### PR TITLE
docs: integrate competitor research into strategy, roadmap, and design

### DIFF
--- a/docs/PRODUCT_DESIGN.md
+++ b/docs/PRODUCT_DESIGN.md
@@ -86,6 +86,15 @@ This section captures **current behavior in the codebase** (so docs stay actiona
 - **Offline clarity**: Persistent banner explains that edits are saved locally and will sync later.
 - **Undo/redo**: Lightweight history for in-session item edits to reduce accidental changes.
 
+## 2.0 Quick-add mode
+
+Alongside the full capture wizard, Curio should offer a "quick add" mode for low-friction capture:
+
+- **Flow:** photo → AI auto-categorizes → item appears in collection → user can enrich later
+- **Purpose:** accommodates "capture now, curate later" behavior alongside "tell the full story" behavior
+- **The full wizard remains** for users who want to write stories upfront
+- Quick-add items should be visually distinguishable (e.g., subtle "enrich me" indicator) to encourage users to return and add their personal story
+
 ## 2.1 Active AI stance
 
 Curio’s active AI work should stay **explicitly optional**, **recoverable**, and **cost-aware**.
@@ -187,10 +196,37 @@ See `docs/PRODUCT_STRATEGY.md` for product decisions and `docs/ROADMAP.md` for e
 
 ## 3. Design Language
 
-- **Typography**: _DM Serif Display_ for elegance; _Inter_ for precision.
+- **Typography**: _DM Serif Display_ for elegance; _Inter_ for precision. Clean sans-serif, consistent English, sentence case throughout.
 - **Visual Layout**: "Bento Grid" home screen for a modern museum feel; Masonry grids for item browsing.
-- **Theming**: Global theme selection replaces collection-specific accents for a unified aesthetic experience.
+- **Theming**: Global theme selection replaces collection-specific accents for a unified aesthetic experience. Light mode (gallery/museum aesthetic) is the default; dark mode is optional.
 - **Sharing surfaces**: exported cards and public pages should feel intentional, collectible, and aesthetically credible without becoming gimmicky.
+- **Density**: medium-low with generous whitespace — let objects breathe.
+- **Photography direction**: objects in natural context (lifestyle photography aesthetic), not objects on dark backgrounds.
+- **Color palette**: warm neutrals, earth tones, restrained accent color. Avoid neon, gaming-adjacent, or tech-forward aesthetics.
+- **Metaphor consistency**: gallery/museum language throughout (exhibitions, curated collections, stories). Not gaming (levels, equipment), not tech (digital twin, archive entity).
+
+### 3.1 Visual category picker
+
+Collection selection during item creation should use image-backed category cards rather than a text dropdown. Each card shows the collection's cover image (or a representative item photo) as the card background. This reinforces the museum metaphor — you're choosing which gallery to place an item in.
+
+### 3.2 Voice and tone
+
+Curio's voice should feel like a thoughtful friend who appreciates beautiful things — not a tech platform, not a database, not an eco-warrior.
+
+| Instead of           | Use                       |
+| -------------------- | ------------------------- |
+| "Archive Entity"     | "Add to your museum"      |
+| "Target Destination" | "Choose a collection"     |
+| "Auto Detect"        | "Let Curio identify this" |
+| "Digital Twin"       | "Your story"              |
+
+### 3.3 Empty state design
+
+Empty states must feel inviting, not cold:
+
+- **Pre-populated example museum:** Show the Public Sample Gallery (beautifully curated with rich personal stories and photos) so new users immediately understand the vision.
+- **First-item prompt:** After signup, immediately prompt the user to add their first item with guided story questions. Don't drop them on an empty grid.
+- **Progressive disclosure:** Focus the UI on adding and enriching items until the user has enough content (3+ items) for the full museum layout to feel meaningful.
 
 ## 4. Onboarding & Cloud Access
 

--- a/docs/PRODUCT_STRATEGY.md
+++ b/docs/PRODUCT_STRATEGY.md
@@ -1,14 +1,16 @@
 # Curio - Product Strategy
 
-**Date:** 2026-03-28
+**Date:** 2026-04-12
 **Status:** Current working strategy
 **Related docs:** `docs/ROADMAP.md` (execution phases), `docs/PRODUCT_DESIGN.md` (UX and interaction design), `docs/TECHNICAL_DESIGN.md` (architecture)
 
 ## 1. Product Thesis
 
-Curio is a personal museum for meaningful objects.
+Curio is the **Letterboxd for physical objects** — a personal museum where the things you collect become an expression of who you are.
 
-It is not a marketplace, not a generic inventory utility, and not a category-specific tracker. The core promise is that people can capture, remember, organize, and proudly share the things that define their taste and identity.
+It is not a marketplace, not a generic inventory utility, and not a category-specific tracker. The core promise is that people can capture, remember, organize, and proudly share the things that define their taste and identity. The moat is emotional data gravity: irreplaceable personal narratives that create switching costs no feature can replicate.
+
+Everything the product does should pass this test: **Does this make users' stories richer, or their museums more beautiful, or their identity more shareable?** If not, it doesn't ship.
 
 The broad product vision stays broad. The go-to-market does not. Curio should narrow by user type, not by item category.
 
@@ -45,6 +47,21 @@ Curio should not position itself as:
 - a home inventory tracker
 - a resale marketplace
 - a museum CMS
+- a sustainability or upcycling platform
+
+### 3.1 Competitive Landscape
+
+The "personal museum for identity-driven collectors" positioning remains **unoccupied** in English-speaking markets. Existing players cluster in adjacent quadrants:
+
+| Quadrant                                                                | Players                        | Curio's distance                                  |
+| ----------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------- |
+| **Utility/Inventory** (high function, low emotion)                      | iCollect, Sortly, CLZ, Kolekto | Maximum — Curio is the opposite                   |
+| **Institutional Story** (high story, low consumer appeal)               | CatalogIt                      | Medium — same concept, wrong packaging            |
+| **Social/Gamified** (high social, low story depth)                      | Collectibles.com, REMUSE       | Medium — similar social ambitions, different soul |
+| **Vertical Trackers** (deep in one category)                            | Vivino, Untappd, Discogs       | Medium — Curio is cross-category                  |
+| **Identity/Story Museum** (high story + high identity + consumer-grade) | _Nobody_                       | **This is Curio's target quadrant**               |
+
+REMUSE (再生博物馆, Chinese market only) uses similar "museum" language and AI photo analysis but serves a fundamentally different motivation: sustainability and upcycling of old objects, not identity-driven collecting. It validates the broad concept (people want to digitize and appreciate physical objects) without competing on Curio's specific value proposition.
 
 ## 4. Product Principles
 
@@ -58,6 +75,10 @@ Curio should not position itself as:
 These principles should break ties in product decisions.
 
 ## 5. Core Product Decisions
+
+### 5.0 The one thing that must be true
+
+Before any feature work, any social features, any growth mechanics: **users must be writing personal stories about their objects.** If the Archive Narrative field is still AI-generated image descriptions, nothing else matters. The personal story is the moat. A competitor can copy the UI but not users' stories.
 
 ### 5.1 Story is human-authored
 
@@ -84,6 +105,8 @@ Early sharing should focus on:
 - shareable collection cards
 - tasteful customization of shared outputs
 
+Referral framing should be identity-first: "Come see my museum" or "I've been curating my tea collection — here's my museum." Not "Try this collection app" or "Organize your stuff with Curio."
+
 Heavy social complexity should wait. No DMs, noisy feeds, or notification-heavy systems until repeat usage exists.
 
 ### 5.3 Broad product, flexible structure
@@ -96,7 +119,17 @@ The right path is:
 - a lightweight custom template builder
 - a stable common card contract across mixed schemas
 
-### 5.4 Trust is the first product job
+### 5.4 AI budget discipline
+
+Every AI feature should make the personal narrative richer, not generate disposable content. Curio's AI investment should focus on:
+
+1. Better object identification and auto-fill
+2. Story prompting assistance (suggesting questions, not generating answers)
+3. Collection Wrapped generation
+
+Do not build: AI sticker generation, emoji pack creation, craft pattern generation, poster modes, or any AI feature that produces disposable creative output rather than enriching the user's story.
+
+### 5.5 Trust is the first product job
 
 The product cannot claim to be a personal museum if users do not trust their data, photos, and edits.
 
@@ -123,7 +156,18 @@ The strategic distinction matters:
 - **keep Android on the roadmap**
 - **do not let native expansion displace the core product loop**
 
-## 7. Business Model
+## 7. Beachhead Market
+
+**Specialty food/drink collectors** in UK/US — tea, coffee, chocolate, wine, spirits. These collectors are:
+
+- underserved by existing vertical trackers
+- willing to pay ($50-70/year for CellarTracker)
+- care about tasting notes and provenance (natural story prompts)
+- overlap with the aesthetic/taste curator persona
+
+If this beachhead doesn't convert, expand to vinyl, sneakers, and vintage. The product architecture should remain category-agnostic from day one.
+
+## 8. Business Model
 
 The primary business model is consumer subscription.
 
@@ -141,13 +185,18 @@ Current stance:
 - ads are not the primary plan
 - marketplace or affiliate models are possible later, not the first business
 
-Possible future tiers:
+Planned tiers:
 
-- **Free** for basic collecting and limited sharing
-- **Pro** for deeper customization, premium sharing, and higher usage limits
-- **Patron** for heavier collectors and superfans
+- **Free** — basic collecting, limited items (50), limited AI scans (10/month)
+- **Pro** ($29.99/yr or $4.99/mo) — unlimited items, unlimited AI scans, advanced stats, custom profile themes, export/insurance reports, ad-free
+- **Patron** ($49.99/yr or $9.99/mo) — Pro + premium Wrapped, early access, founding supporter badge
 
-## 8. What Curio Must Be Better At
+Later revenue options:
+
+- insurance referral partnerships (referral fees per policy)
+- AI scan credits as consumables for heavy users
+
+## 9. What Curio Must Be Better At
 
 Curio needs to win on the combination of:
 
@@ -159,21 +208,38 @@ Curio needs to win on the combination of:
 
 Curio does **not** need to win by having the most fields, the most enterprise controls, or the most marketplace features.
 
-## 9. What Is Deferred
+## 10. What Is Deferred
 
 These are not current execution priorities:
 
 - Museum Guide / voice companion
 - AI image enhancement and poster generation
 - Vault Lock / biometric security
-- marketplace and trading
+- marketplace and trading (requires trust infrastructure, payments, dispute resolution — Phase 4+ at 50K users)
 - heavy social features
 - NFC / QR tagging
 - cinematic video portraits
+- sustainability metrics / carbon tracking / donation facilitation (not Curio's positioning)
+- AI creative output generation (stickers, emoji packs, craft patterns)
+- eco-gamification (points, levels, environmental badges — conflicts with "reflection, not obligation" positioning)
+- AR object viewing / 3D capture
+- tax deduction tracking
 
-Deferred does not mean banned forever. It means they should not crowd out trust, story, sharing, and flexible collections.
+If Curio ever adds badges, make them about depth, not volume: "Storyteller" (items with rich narratives), "Archivist" (complete collection with provenance), "Curator" (public museum with themed collections). Never reward speed or quantity.
 
-## 10. Founder Guidance
+Deferred does not mean banned forever. It means they should not crowd out trust, story, sharing, and flexible collections. Every feature request should pass the test: does this make stories richer, museums more beautiful, or identity more shareable?
+
+## 11. Risk Register
+
+| Risk                                                                  | Likelihood | Impact                       | Mitigation                                                                                                       |
+| --------------------------------------------------------------------- | ---------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Users don't write personal stories (just use AI auto-fill)            | High       | Critical — destroys the moat | Make story prompts engaging, not obligatory. Show beautiful examples. Reward depth in Wrapped.                   |
+| A competitor enters English-speaking markets with similar positioning | Low-Medium | Medium                       | Speed to market with personal narratives. The moat is emotional data, not features.                              |
+| Beachhead market (specialty food/drink) is too niche                  | Medium     | High                         | Expand to vinyl/sneakers/vintage. Keep architecture category-agnostic.                                           |
+| Feature pressure from users ("add a marketplace," "add insurance")    | High       | Medium                       | Maintain the deferred list. Apply the feature test consistently.                                                 |
+| AI auto-fill quality degrades or API costs spike                      | Medium     | Medium                       | Maintain ability to swap providers. Keep AI as acceleration, not requirement — the product must work without AI. |
+
+## 12. Founder Guidance
 
 When product choices feel ambiguous, choose the option that makes Curio:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
-# Curio — Execution Roadmap (2026-03-28)
+# Curio — Execution Roadmap (2026-04-12)
 
-This document owns **execution phases, exit criteria, and metrics**. For product thesis, principles, positioning, and strategic decisions, see `docs/PRODUCT_STRATEGY.md`. For UX and interaction design requirements, see `docs/PRODUCT_DESIGN.md`.
+This document owns **execution phases, exit criteria, metrics, and go-to-market**. For product thesis, principles, positioning, and strategic decisions, see `docs/PRODUCT_STRATEGY.md`. For UX and interaction design requirements, see `docs/PRODUCT_DESIGN.md`.
 
 Issue prioritization lives in GitHub Issues/Projects, not here.
 
@@ -17,18 +17,21 @@ Right now the biggest risks are:
 
 ## Execution Phases
 
-### Phase 0 — Trust And Soul
+### Phase 0 — Foundation And Soul (6 weeks)
 
-Goal: make the current product trustworthy and emotionally coherent.
+Goal: every user who adds 3+ items feels genuine emotional attachment to their museum.
 
 Must ship:
 
-1. Fix sync and persistence trust issues.
-2. Replace AI-generated archive narrative with a real human story flow.
-3. Keep AI-generated object descriptions as hidden metadata, visible on demand but not the primary narrative.
-4. Fix broken image and edit-path credibility issues.
-5. Define the foundations for public sharing surfaces.
-6. Add product and feature tracking instrumentation.
+1. Replace AI-generated archive narrative with a real human story flow.
+2. Fix sync and persistence trust issues.
+3. Fix broken image and edit-path credibility issues.
+4. Add item edit flow.
+5. Add collection deletion.
+6. Theme contrast fixes.
+7. Add "quick add" mode (photo → AI auto-categorize → enrich later) alongside the full wizard.
+8. "On This Day" polish.
+9. Add product and feature tracking instrumentation.
 
 Key work:
 
@@ -37,26 +40,30 @@ Key work:
 - ensure item editing works reliably after creation
 - replace the visible narrative with a human-written Story field
 - let AI suggest metadata and prompt questions, but not invent the story
+- implement quick-add as a low-friction alternative to the full capture wizard
 - instrument item creation, story usage, sync failures, share events, and profile visits
 
 Exit criteria:
 
-- users trust that data and photos are safe
+- a new user can create a collection, add 5 items with personal stories and photos, trust that data syncs, edit any item, and feel something when browsing their museum
 - story capture is visibly human-centered
-- item editing and save paths feel solid
-- the product is ready for public-facing sharing surfaces
+- sync failure rate < 1%
 
-### Phase 1 — Flexible Collections And Sharing
+### Phase 1 — Shareability And Identity (12 weeks)
 
-Goal: let people shape their museum and proudly share it.
+Goal: every museum is shareable. The first "Collection Wrapped" ships. Organic growth begins.
 
 Must ship:
 
-1. Flexible collection templates
-2. Public museum profile pages
-3. Shareable item and collection cards
-4. Public-facing customization system for profiles and shared artifacts
-5. Routing approach for clean public URLs and preview metadata
+1. Public museum profile page (shareable URL)
+2. Shareable item cards (OG image generation)
+3. Flexible collection templates (move beyond hardcoded fields)
+4. Visual category picker with image-backed cards
+5. "Collection Wrapped" / Year in Objects
+6. Embeddable collection widget
+7. AI identification improvement (expand auto-fill)
+8. Bulk import (CSV)
+9. Basic stats/analytics (identity-reinforcing data)
 
 Key work:
 
@@ -64,14 +71,17 @@ Key work:
 - starter templates backed by data, not hardcoded forever
 - stable mixed-schema browsing
 - public museum page design and privacy model
-- item-card and collection-card share surfaces
-- profile and sharing customization that stays tasteful rather than turning into a generic filter/sticker app
+- item-card and collection-card share surfaces with OG metadata
+- visual category picker using collection cover images as card backgrounds
+- Collection Wrapped generation and social sharing optimization
+- embeddable widget that links back to Curio
 
 Exit criteria:
 
-- users can create non-food and mixed collections without confusion
-- at least some users share their museum or item cards
-- shared artifacts look good enough to send without apology
+- a user can share their museum profile on social media, the link renders a beautiful card
+- at least one Collection Wrapped has been generated and shared
+- > 30% of users create public profiles
+- median items per user > 8
 
 ### Phase 1.5 — Android Market Test
 
@@ -94,15 +104,18 @@ Exit criteria:
 - Android users can install, onboard, capture, save, and share without platform-specific blockers
 - subscription willingness and usage can be measured from Google Play traffic
 
-### Phase 2 — Discovery And Light Community
+### Phase 2 — Community And Discovery (12 weeks)
 
-Goal: make Curio feel alive without turning it into a noisy social app.
+Goal: users discover each other. The Explore page becomes a reason to open the app.
 
 Must ship:
 
-1. Curated discovery surface
-2. Lightweight follow model or discovery graph
-3. "Year in Objects" / "Collection Wrapped" once users have enough content
+1. Explore feed (editorially curated, not algorithmic)
+2. Follow system + activity feed (restrained — no DMs, no notification spam)
+3. Collaborative collections with invitation codes
+4. Story prompts / challenges ("The oldest thing you own," "Something you'll never sell," "An object that reminds you of someone")
+5. Cross-collection discovery ("collectors who love X also collect Y")
+6. Comments/reactions on public museums (restrained)
 
 Avoid:
 
@@ -111,48 +124,98 @@ Avoid:
 - algorithmic feeds
 - social complexity before repeat usage exists
 
+Exit criteria:
+
+- users are discovering and following other museums
+- > 20% of users follow at least one other user
+- at least one community prompt has generated 50+ responses
+- Explore page DAU/MAU > 15%
+
 ### Phase 3 — Monetization And Expansion
 
 Goal: convert emotional attachment into sustainable revenue.
 
-Primary model:
+Primary model (see `PRODUCT_STRATEGY.md` § Business Model for pricing):
 
-- Free
-- Pro
-- Patron
+- Free (limited items and AI scans)
+- Pro (unlimited items, full features)
+- Patron (premium extras, early access)
+
+Targets:
+
+- free-to-paid conversion > 4%
+- annual subscription ratio > 60% of paid users
+- net revenue retention > 90%
 
 Later options:
 
 - insurance referrals
-- affiliate commerce
-- marketplace experiments
+- AI scan credits as consumables
+- marketplace experiments (Phase 4+ at 50K users)
 
 These are expansions, not the plan.
+
+## Go-To-Market Plan
+
+### Channel strategy
+
+| Phase      | Channel                       | Tactic                                                                                                                                | Target               |
+| ---------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| Pre-launch | Hand-recruitment              | Recruit 50 passionate collectors from specialty food/drink communities (r/tea, r/coffee, r/chocolate, r/whiskey)                      | 50 founding curators |
+| Pre-launch | Waitlist                      | Landing page with "Apply to be a founding curator" framing. Identity-expression language.                                             | 500 waitlist signups |
+| Month 1-3  | Invitation-only beta          | Each founding curator gets 5 invite codes.                                                                                            | 1,000 users          |
+| Month 3-6  | Content marketing             | Long-tail SEO: "how to organize my tea collection," "best way to catalog wine," "chocolate tasting journal app." Blog posts, not ads. | 5,000 users          |
+| Month 6    | Product Hunt launch           | 2+ months preparation. Realistic: 500-2,000 quality signups.                                                                          | 7,000 users          |
+| Month 6-9  | Collection Wrapped viral loop | Every user becomes a distribution channel. Optimize for Instagram Stories and Twitter/X.                                              | 10,000 users         |
+| Month 9+   | Embeddable widgets            | Collector bloggers embed shelves on personal sites. Each widget links back to Curio.                                                  | Ongoing organic      |
 
 ## Metrics To Track
 
 Start tracking baselines now.
 
-Core events:
+### Phase 0 metrics
+
+| Metric                                               | Target            | Why it matters                                                 |
+| ---------------------------------------------------- | ----------------- | -------------------------------------------------------------- |
+| Items with personal stories (>20 words user-written) | >60% of all items | This IS the moat                                               |
+| D7 retention                                         | >25%              | Users who add 3+ items with stories in week 1 should come back |
+| Sync failure rate                                    | <1%               | Trust is the foundation                                        |
+
+### Phase 1 metrics
+
+| Metric                  | Target                        | Why it matters                                    |
+| ----------------------- | ----------------------------- | ------------------------------------------------- |
+| Public profiles created | >30% of users                 | If they won't share, the identity thesis is wrong |
+| Shares per Wrapped      | >2 per user who generates one | Viral coefficient of the growth feature           |
+| Items per user (median) | >8                            | Enough items for a meaningful collection          |
+
+### Phase 2 metrics
+
+| Metric                  | Target                                       | Why it matters                  |
+| ----------------------- | -------------------------------------------- | ------------------------------- |
+| Follow rate             | >20% of users follow at least one other user | Social layer has value          |
+| Explore page DAU/MAU    | >15%                                         | Discovery is a reason to return |
+| Challenge participation | >50 responses per prompt                     | Community is alive              |
+
+### Phase 3 metrics
+
+| Metric                    | Target             | Why it matters               |
+| ------------------------- | ------------------ | ---------------------------- |
+| Free-to-paid conversion   | >4%                | Above median (2.18%)         |
+| Annual subscription ratio | >60% of paid users | Annual billing reduces churn |
+| Net revenue retention     | >90%               | Paid users stay              |
+
+### Core events to instrument
 
 - item creation starts
 - item saves
-- story field usage
+- story field usage (length, user-written vs untouched AI)
 - item edits after creation
 - sync failures
 - upload failures
 - shares initiated
 - public profile visits once profiles exist
 - subscription funnel events once billing exists
-
-Product metrics:
-
-- item completion rate
-- 3-item first-week retention
-- sync failure rate
-- share rate
-- profile visit rate
-- conversion to paid
 
 Implementation note:
 


### PR DESCRIPTION
## Summary

Merges findings from the competitor research report (REMUSE analysis, market landscape, GTM insights) into the three product docs while maintaining MECE ownership boundaries:

- **PRODUCT_STRATEGY.md** — sharpened thesis ("Letterboxd for physical objects"), added competitive landscape table, beachhead market, specific pricing tiers, AI budget discipline, expanded deferred features list, and risk register
- **ROADMAP.md** — added time horizons to phases, new items (quick-add, visual category picker, collaborative collections, story prompts), quantitative exit criteria, GTM channel strategy, and per-phase success metrics with targets
- **PRODUCT_DESIGN.md** — added quick-add mode UX spec, visual category picker design, voice/tone guide, empty state principles, and expanded design language (density, photography, color, metaphor consistency)

**Intentionally omitted (flagged for discussion):**
1. "Drop Capacitor" recommendation — conflicts with existing Android/Google Play goal
2. "English-only until PMF" — EN/ZH i18n is already shipped
3. Effort estimates — speculative and not consistent with existing doc style
4. "Dark-mode-only risk" — already solved (3 themes including light mode)

## Test plan

- [x] `npm run format:check` passes
- [x] `npm run build` passes
- [x] `npm test` — 1 pre-existing failure unrelated to doc changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)