### PR TITLE
fix(export): show drag handle at peek and unbreak Save Image

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -168,7 +168,6 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     );
     return toBlob(node, {
       pixelRatio: 2,
-      cacheBust: true,
       backgroundColor: '#ffffff',
     });
   }, []);
@@ -232,7 +231,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     }
   }, [exportAction, item.title, renderCardToBlob, t]);
 
-  const PEEK_HEIGHT_PX = 88;
+  const PEEK_HEIGHT_PX = 56;
 
   const handleSheetPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (window.matchMedia('(min-width: 768px)').matches) return;
@@ -423,7 +422,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     ? `${dragHeight}px`
     : isExpanded
       ? '85dvh'
-      : `${PEEK_HEIGHT_PX}px`;
+      : 'var(--peek-height)';
 
   return (
     <div
@@ -454,11 +453,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
       )}
       <div
         ref={sheetRef}
-        className={`absolute inset-x-0 bottom-0 md:absolute md:top-0 md:left-auto md:inset-x-auto md:right-0 md:w-96 md:!h-full bg-white rounded-t-3xl md:rounded-none shadow-2xl flex flex-col z-10 print:hidden [--export-footer-height:8.5rem] md:[--export-footer-height:9.5rem] ${isDragging ? '' : 'transition-[height] duration-300 ease-out'}`}
+        className={`absolute inset-x-0 bottom-0 md:absolute md:top-0 md:left-auto md:inset-x-auto md:right-0 md:w-96 md:!h-full min-h-0 overflow-hidden bg-white rounded-t-3xl md:rounded-none shadow-2xl flex flex-col z-10 print:hidden [--export-footer-height:8.5rem] md:[--export-footer-height:9.5rem] ${isDragging ? '' : 'transition-[height] duration-300 ease-out'}`}
         style={{ height: mobileSheetHeight }}
       >
         <div
-          className="md:hidden w-full flex justify-center py-3 cursor-grab active:cursor-grabbing touch-none"
+          className="md:hidden w-full h-14 shrink-0 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none"
           onPointerDown={handleSheetPointerDown}
           onPointerMove={handleSheetPointerMove}
           onPointerUp={handleSheetPointerUp}


### PR DESCRIPTION
Follow-up to #210. Two regressions in the export modal that the merged PR didn't catch:

## 1. Drag handle hidden / Print button unreachable

The footer's `min-h-[8.5rem]` (136px) propagates as a min-content constraint up through the flex column, which silently overrode the 88px peek height. The sheet rendered tall enough that only the footer's first button (Save Image) was visible at the bottom of the viewport — the drag handle, header, and Print/Share row were all clipped above. Tapping anywhere in the visible area only ever hit Save Image, so the user couldn't expand the sheet or use Print/Share at all.

Fix: add `overflow-hidden` + `min-h-0` to the sheet so the inline pixel height wins, give the handle a dedicated 56px touch target, and tie peek + sheet collapsed height to the same `--peek-height` variable so the handle clears the iPhone home-bar safe area.

## 2. Save Image throws "Could not save image"

`toBlob({ cacheBust: true })` appends `?<timestamp>` to every image src before fetching. The card's image is a `blob:` URL (created from an IndexedDB / Supabase download), and `blob:` URLs reject query strings — so html-to-image's internal image fetch returned empty, `toBlob` returned `null`, and the generic error toast fired.

Fix: drop `cacheBust`. There's no caching layer in front of these blob URLs to defeat anyway.

## Test plan

- [ ] Open a real (cloud-synced) item on mobile → tap the print/export icon → drag handle is visible at the bottom and the image fills the area above it
- [ ] Drag the handle up → sheet expands smoothly, all controls (Style / Aspect Ratio / Image Fit / Save / Print / Share) are reachable
- [ ] Drag back down or tap the dimmed area → sheet collapses, image is unchanged
- [ ] Tap "Save Image" → PNG downloads without the "Could not save image" toast
- [ ] Tap "Share" → native share sheet appears (or download fallback) with no error
- [ ] Desktop (md+): side-panel layout unchanged

https://claude.ai/code/session_01XofZuqfC6o1KbG1ADPmtFj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XofZuqfC6o1KbG1ADPmtFj)_