### PR TITLE
Document Stripe subscription billing defaults and platform caveats

### DIFF
--- a/docs/GOOGLE_PLAY_SUBMISSION_GUIDE.md
+++ b/docs/GOOGLE_PLAY_SUBMISSION_GUIDE.md
@@ -2,7 +2,7 @@
 
 This document is the single source of truth for Curio's Android readiness and Google Play submission flow.
 
-> **Strategic context:** This supports **Phase 1.5 - Android Market Test** in `docs/ROADMAP.md`. Keep the product web-first, use Android as a distribution and pricing test, and avoid native-only scope unless it is required for launch trust.
+> **Strategic context:** This supports **Phase 1.5 - Android Market Test** in `docs/ROADMAP.md`. Keep the product web-first, use Android as a distribution and willingness-to-pay signal, and avoid native-only scope unless it is required for launch trust. Verify platform billing rules before exposing paid digital subscription flows inside a Play-distributed build.
 
 ## What this doc owns
 
@@ -57,6 +57,12 @@ These are the Android-specific issues worth treating as stop-ship for a public m
 - Save succeeds locally before cloud sync.
 - Offline or failed sync states are visible.
 - Silent failure paths are not acceptable for a public launch.
+
+### 7. Billing policy must be explicit before paid features
+
+- If the Android market test ships as a free app, hide or disable Stripe-powered subscription CTAs inside the Play-distributed build.
+- If paid Pro or Patron features are enabled in the Android build, confirm the applicable Google Play Billing or alternative billing requirements before submission.
+- Web/PWA Stripe subscriptions remain the default web billing path; the Play build must not route users to Stripe for digital subscriptions unless current policy and program eligibility allow it.
 
 ## Pre-submission checklist
 

--- a/docs/PRODUCT_STRATEGY.md
+++ b/docs/PRODUCT_STRATEGY.md
@@ -147,9 +147,10 @@ Curio should remain web-first in product architecture.
 That does **not** mean avoiding Android or Google Play. It means:
 
 - keep the core product logic shared with web
-- use Android / Google Play as an early distribution and payment test channel
+- use Android / Google Play as an early distribution and willingness-to-pay signal
 - ship native packaging when it helps market validation
 - avoid broad native-only feature work until demand is proven
+- do not assume web Stripe checkout can be promoted inside store-distributed native shells for digital subscriptions; verify platform billing rules before launch
 
 The strategic distinction matters:
 
@@ -184,6 +185,8 @@ Current stance:
 - willingness to pay is still a hypothesis to validate
 - ads are not the primary plan
 - marketplace or affiliate models are possible later, not the first business
+- for the web/PWA product, the default payment integration is Stripe-hosted Checkout Sessions in subscription mode, paired with Stripe Customer Portal for self-service billing
+- do not build a custom card form, raw PaymentIntents subscription flow, or bespoke billing management until checkout customization becomes a proven product need
 
 Planned tiers:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -107,11 +107,12 @@ Key work:
 - ensure Android packaging is reliable enough for internal / closed / public testing as appropriate
 - keep the product logic shared with web
 - avoid native-only features unless directly required for the test
+- validate platform billing constraints before exposing any Stripe-powered subscription CTA inside a store-distributed native shell
 
 Exit criteria:
 
 - Android users can install, onboard, capture, save, and share without platform-specific blockers
-- subscription willingness and usage can be measured from Google Play traffic
+- subscription willingness and usage can be measured from Android / Google Play traffic without locking Curio into native-only billing architecture
 
 ### Phase 2 — Community And Discovery (12 weeks)
 
@@ -149,6 +150,14 @@ Primary model (see `PRODUCT_STRATEGY.md` § Business Model for pricing):
 - Free (limited items and AI scans)
 - Pro (unlimited items, full features)
 - Patron (premium extras, early access)
+
+Payment implementation default:
+
+- use Stripe-hosted Checkout Sessions for web/PWA subscription purchase
+- use Stripe Customer Portal for cancellation, payment method updates, invoices, and plan management
+- use Stripe webhooks to reconcile paid status into Supabase before enforcing Pro/Patron entitlements
+- keep Payment Links or Stripe Pricing Table acceptable only as quick validation shortcuts; production entitlement enforcement still depends on webhook reconciliation
+- avoid raw PaymentIntents or a custom Payment Element checkout unless the product proves it needs deeper checkout control
 
 Targets:
 

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -6,6 +6,7 @@
 
 - **Storage**: Supabase (PostgreSQL + Auth + Storage) as source of truth, IndexedDB as cache.
 - **AI Inference**: Gemini-3-flash-preview via a server-side proxy (local dev: `server/geminiProxy.js`; deploy: same-origin `/api/*` via Vercel rewrites and/or `api/*` handlers) to keep API keys off the client.
+- **Billing (planned)**: Stripe-hosted Checkout Sessions for web/PWA subscriptions, Stripe Customer Portal for self-service billing, and Stripe webhooks into Supabase for entitlement state.
 
 ### See also
 
@@ -40,6 +41,17 @@ If a user has existing IndexedDB data from older builds, they can trigger a manu
 Curated sample collections live in the same tables and are flagged with `is_public = true`. In the current implementation, authenticated users can read them, but only admin users (profiles with `is_admin = true`) can edit or delete them. The client treats public collections as read-only for non-admins.
 
 For Phase 1, that public-collection foundation should extend into anonymous-readable public museum routes for profile, collection, item, Wrapped, and widget surfaces. Those routes must expose only content derived from explicitly public collections.
+
+## 2.1 Billing and Entitlements (Planned)
+
+Curio's default billing path is web-first and low-maintenance:
+
+- **Purchase flow**: create Stripe Checkout Sessions server-side with `mode: 'subscription'` for Pro and Patron plans, then redirect the user to Stripe-hosted Checkout.
+- **Plan management**: send paid users to Stripe Customer Portal for cancellation, card updates, invoices, and plan changes.
+- **Entitlement source of truth**: Stripe webhooks reconcile subscription lifecycle events into Supabase. The client must read server-owned entitlement state rather than trusting checkout redirects or local state.
+- **Early validation shortcut**: Stripe Payment Links or Stripe Pricing Table are acceptable for fast market tests, but paid access should not be enforced until webhook reconciliation maps the purchase back to a Supabase user.
+- **Avoid for v1**: raw PaymentIntents, custom card collection, or a custom Payment Element checkout. Those paths increase PCI, tax, discount, renewal, and support surface without a current product requirement.
+- **Native-store caveat**: for PWA/browser usage, Stripe is the default. For Apple App Store or Google Play-distributed native shells, do not expose Stripe purchase links or prompts for digital subscriptions unless current store policy, regional programs, and review requirements allow it. Native packages may need app-store billing while web subscribers keep web-managed entitlements where policy permits.
 
 ### Local cache and retry invariants
 


### PR DESCRIPTION
## Summary
- Documented the Stripe integration decision across product, roadmap, technical design, and Android submission docs.
- Set Stripe-hosted Checkout Sessions in subscription mode as the default web/PWA billing path, with Customer Portal for self-service billing.
- Added entitlement reconciliation and platform-billing caveats for store-distributed native shells.

## Testing
- Not run (not requested)
- Reviewed the resulting Markdown diff and verified there were no whitespace issues in the edited docs