### PR TITLE
[CUR-59] Make access gate, error states, and On This Day cards theme-aware

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1202,13 +1202,13 @@ export const AppContent: React.FC = () => {
                 </Button>
               )}
               <div
-                className={`flex rounded-xl p-1 ${theme === 'vault' ? 'bg-white/5' : 'bg-stone-200/50'}`}
+                className={`flex rounded-xl p-1 ${theme === 'vault' ? 'bg-white/5' : theme === 'atelier' ? 'bg-[#D4C9B8]/30' : 'bg-stone-200/50'}`}
               >
                 <button
                   onClick={() => setViewMode('grid')}
                   aria-label={t('viewGrid')}
                   title={t('viewGrid')}
-                  className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? 'bg-white text-stone-900 shadow-sm' : 'text-stone-400 hover:text-stone-600'}`}
+                  className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
                 >
                   <LayoutGrid size={18} />
                 </button>
@@ -1216,7 +1216,7 @@ export const AppContent: React.FC = () => {
                   onClick={() => setViewMode('waterfall')}
                   aria-label={t('viewWaterfall')}
                   title={t('viewWaterfall')}
-                  className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? 'bg-white text-stone-900 shadow-sm' : 'text-stone-400 hover:text-stone-600'}`}
+                  className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
                 >
                   <LayoutTemplate size={18} className="rotate-180" />
                 </button>
@@ -2307,22 +2307,30 @@ export const AppContent: React.FC = () => {
       className="flex flex-col items-center justify-center px-4 py-16 sm:py-24"
       data-testid="access-gate"
     >
-      <div className="max-w-md w-full text-center bg-white/70 border border-stone-200 rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl">
-        <div className="w-12 h-12 sm:w-14 sm:h-14 rounded-2xl bg-stone-100 text-stone-500 flex items-center justify-center mx-auto mb-5 sm:mb-6">
+      <div
+        className={`max-w-md w-full text-center border rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl ${theme === 'vault' ? 'bg-white/5 border-white/10' : theme === 'atelier' ? 'bg-[#EDE4D3]/70 border-[#D4C9B8]' : 'bg-white/70 border-stone-200'}`}
+      >
+        <div
+          className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-white/10 text-stone-400' : theme === 'atelier' ? 'bg-[#D4C9B8]/50 text-[#8C7B6B]' : 'bg-stone-100 text-stone-500'}`}
+        >
           {!authReady && isSupabaseReady ? (
             <Loader2 size={24} className="animate-spin" />
           ) : (
             <Lock size={24} />
           )}
         </div>
-        <h1 className="font-serif text-2xl font-bold text-stone-900 mb-2">
+        <h1
+          className={`font-serif text-2xl font-bold mb-2 ${theme === 'vault' ? 'text-white' : theme === 'atelier' ? 'text-[#3D3530]' : 'text-stone-900'}`}
+        >
           {!authReady && isSupabaseReady
             ? t('authLoading')
             : isSupabaseReady
               ? t('authRequiredTitle')
               : t('cloudRequiredTitle')}
         </h1>
-        <p className="text-sm text-stone-500 mb-6">
+        <p
+          className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+        >
           {!authReady && isSupabaseReady
             ? t('authLoadingDesc')
             : isSupabaseReady
@@ -2350,12 +2358,18 @@ export const AppContent: React.FC = () => {
             </Button>
           )}
           {!isSupabaseReady ? (
-            <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-stone-400">
+            <div
+              className={`text-[11px] font-semibold uppercase tracking-[0.16em] ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+            >
               {t('cloudRequiredAction')}
             </div>
           ) : null}
         </div>
-        <p className="text-[12px] text-stone-400 mt-5 leading-relaxed">{t('ctaPromise')}</p>
+        <p
+          className={`text-[12px] mt-5 leading-relaxed ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+        >
+          {t('ctaPromise')}
+        </p>
       </div>
     </div>
   );

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -86,14 +86,24 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   if (loadError)
     return (
       <div className="flex flex-col items-center justify-center px-4 py-16 sm:py-24">
-        <div className="max-w-md w-full text-center bg-white/70 border border-stone-200 rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl">
-          <div className="w-12 h-12 sm:w-14 sm:h-14 rounded-2xl bg-amber-50 text-amber-600 flex items-center justify-center mx-auto mb-5 sm:mb-6">
+        <div
+          className={`max-w-md w-full text-center border rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl ${theme === 'vault' ? 'bg-white/5 border-white/10' : theme === 'atelier' ? 'bg-[#EDE4D3]/70 border-[#D4C9B8]' : 'bg-white/70 border-stone-200'}`}
+        >
+          <div
+            className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-amber-500/10 text-amber-400' : theme === 'atelier' ? 'bg-[#A86F3C]/10 text-[#A86F3C]' : 'bg-amber-50 text-amber-600'}`}
+          >
             <AlertCircle size={24} />
           </div>
-          <h2 className="font-serif text-2xl font-bold text-stone-900 mb-2">
+          <h2
+            className={`font-serif text-2xl font-bold mb-2 ${theme === 'vault' ? 'text-white' : theme === 'atelier' ? 'text-[#3D3530]' : 'text-stone-900'}`}
+          >
             {t('syncPausedTitle')}
           </h2>
-          <p className="text-sm text-stone-500 mb-6">{loadError}</p>
+          <p
+            className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+          >
+            {loadError}
+          </p>
           <Button onClick={() => refreshCollections()} size="lg" className="w-full">
             {t('actionRetry')}
           </Button>
@@ -218,7 +228,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             className={`relative overflow-hidden rounded-[2rem] p-6 sm:p-7 border flex flex-col justify-between transition-all duration-500 ${themeBaseClasses[theme]} shadow-md`}
           >
             <div className="flex items-center justify-between mb-3 sm:mb-4">
-              <div className="p-2 bg-amber-50 rounded-xl text-amber-600">
+              <div
+                className={`p-2 rounded-xl ${theme === 'vault' ? 'bg-amber-500/10 text-amber-400' : theme === 'atelier' ? 'bg-[#A86F3C]/10 text-[#A86F3C]' : 'bg-amber-50 text-amber-600'}`}
+              >
                 <Calendar size={18} />
               </div>
               <span className={`${typographyClasses.labelSmall} ${labelColorClasses[theme]}`}>
@@ -252,11 +264,17 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                         key={item.id}
                         type="button"
                         onClick={() => navigate(`/collection/${item.collectionId}/item/${item.id}`)}
-                        className="w-full text-left rounded-xl border border-stone-200/60 bg-white/70 px-3 py-2 text-xs sm:text-sm shadow-sm transition hover:border-amber-200 hover:bg-amber-50/60"
+                        className={`w-full text-left rounded-xl border px-3 py-2 text-xs sm:text-sm shadow-sm transition ${theme === 'vault' ? 'border-white/10 bg-white/5 hover:border-[#D4A574]/30 hover:bg-white/10' : theme === 'atelier' ? 'border-[#D4C9B8]/60 bg-[#EDE4D3]/70 hover:border-[#A86F3C]/30 hover:bg-[#EDE4D3]' : 'border-stone-200/60 bg-white/70 hover:border-amber-200 hover:bg-amber-50/60'}`}
                       >
                         <div className="flex items-center justify-between gap-2">
-                          <span className="truncate font-medium text-stone-700">{item.title}</span>
-                          <span className="text-[11px] uppercase tracking-wide text-stone-400">
+                          <span
+                            className={`truncate font-medium ${theme === 'vault' ? 'text-white' : theme === 'atelier' ? 'text-[#3D3530]' : 'text-stone-700'}`}
+                          >
+                            {item.title}
+                          </span>
+                          <span
+                            className={`text-[11px] uppercase tracking-wide ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+                          >
                             {itemYear}
                           </span>
                         </div>
@@ -265,7 +283,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                   })}
                 </div>
                 {historyOverflow > 0 && (
-                  <p className="text-xs text-stone-400">
+                  <p
+                    className={`text-xs ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+                  >
                     {t('onThisDayMore', { count: historyOverflow })}
                   </p>
                 )}


### PR DESCRIPTION
## Problem

Several UI surfaces use hardcoded light-mode classes (`bg-white/70`, `text-stone-900`, `border-stone-200`) without theme conditionals. In Vault (dark) and Atelier (warm) themes, these surfaces appear as bright white cards on a dark or cream background, breaking visual coherence. This undermines the three-theme system — a core differentiator — and makes the product feel unfinished. Protects **Beauty before bureaucracy**.

## Approach

Applied theme-conditional classes to all 4 affected locations using existing design tokens from `DESIGN.md`:

1. **Access gate** (`src/App.tsx`) — card surface, icon container, title, description, and footer text now adapt to Vault (`bg-white/5`, `border-white/10`, `text-white`) and Atelier (`bg-[#EDE4D3]/70`, `border-[#D4C9B8]`, `text-[#3D3530]`).
2. **HomeScreen load error state** (`src/components/HomeScreen.tsx`) — same pattern as access gate; amber icon also adapts (Vault: `bg-amber-500/10 text-amber-400`, Atelier: `bg-[#A86F3C]/10 text-[#A86F3C]`).
3. **"On This Day" history item buttons** (`src/components/HomeScreen.tsx`) — button surface, hover states, item title text, year label, overflow text, and Calendar icon all themed.
4. **View mode toggle buttons** (`src/App.tsx`) — active state (`bg-white/10` in Vault, `bg-[#F5EFE4]` in Atelier) and inactive state use theme-appropriate text colors. Container background also gets an Atelier variant.

## Why this approach

Smallest change that fully resolves the issue: inline theme ternaries matching the existing codebase pattern, using exact color tokens from `DESIGN.md` and `theme.tsx`. No new abstractions, no new imports, no new components. Gallery (light) theme behavior is unchanged — all Gallery classes are preserved as the default branch.

## Risks

Low. CSS/Tailwind-only changes. No data flow, sync, AI, auth, or routing changes. Gallery theme is the default fallback in every ternary, so existing behavior is preserved. All 533 unit tests pass. Build succeeds.

## How to verify

Vercel Preview: available after deploy

Steps:
1. Open the app in an incognito window (access gate visible).
2. Switch to **Vault** theme → card should have dark surface, white text, subtle border.
3. Switch to **Atelier** theme → card should have warm cream surface, brown text, warm border.
4. Switch back to **Gallery** → should look identical to before this change.
5. Sign in, navigate to a collection with items → view mode toggles (grid/waterfall) should match theme.
6. Trigger an error state or check the "On This Day" section on Home → cards should match theme.

Checks:
- [x] npm run format:check
- [x] npm test (533 passed)
- [x] npm run build
- [ ] npm run test:e2e — cannot run (Playwright browser install blocked by sandbox network restrictions; pre-existing environment limitation)

## Linear

Closes CUR-59

https://claude.ai/code/session_01QWwkVuStjcN3HgpFxzby2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWwkVuStjcN3HgpFxzby2T)_