### PR TITLE
[CUR-67] Route the Explore tab straight to the sample gallery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2411,6 +2411,7 @@ export const AppContent: React.FC = () => {
         onImportLocal={handleImportLocal}
         statusBanner={statusBanner}
         onAddItem={handleAddAction}
+        onExploreSamples={handleExploreSamples}
         headerExtras={
           <div className="flex items-center gap-2 sm:gap-3">
             {sampleCollection && (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -30,6 +30,7 @@ interface LayoutProps {
   headerExtras?: React.ReactNode;
   statusBanner?: React.ReactNode;
   onAddItem?: () => void;
+  onExploreSamples?: () => void;
 }
 
 export const Layout: React.FC<LayoutProps> = ({
@@ -46,6 +47,7 @@ export const Layout: React.FC<LayoutProps> = ({
   headerExtras,
   statusBanner,
   onAddItem,
+  onExploreSamples,
 }) => {
   const { t } = useTranslation();
   const { theme } = useTheme();
@@ -122,6 +124,7 @@ export const Layout: React.FC<LayoutProps> = ({
   const bottomNavMuted = theme === 'vault' ? 'text-white/60' : 'text-stone-400';
   const statusBadgeSurface =
     theme === 'vault' ? 'bg-stone-900 border-white/10' : 'bg-white border-stone-200';
+  const exploreTo = sampleCollectionId ? `/collection/${sampleCollectionId}` : null;
   const isExploreActive =
     location.pathname === '/explore' ||
     (sampleCollectionId
@@ -286,7 +289,7 @@ export const Layout: React.FC<LayoutProps> = ({
         style={{ height: 'var(--bottom-nav-height, 5.5rem)' }}
       >
         <div className="mx-auto max-w-4xl h-full px-2 pb-[env(safe-area-inset-bottom,0px)] pt-2 flex items-center">
-          <div className="grid grid-cols-4 items-center w-full">
+          <div className={`grid ${exploreTo ? 'grid-cols-4' : 'grid-cols-3'} items-center w-full`}>
             <Link
               to="/"
               className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${location.pathname === '/' ? 'text-amber-500' : bottomNavMuted}`}
@@ -295,13 +298,16 @@ export const Layout: React.FC<LayoutProps> = ({
               {t('navHome')}
             </Link>
 
-            <Link
-              to="/explore"
-              className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
-            >
-              <Compass size={22} />
-              {t('exploreSample')}
-            </Link>
+            {exploreTo && (
+              <Link
+                to={exploreTo}
+                onClick={onExploreSamples}
+                className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
+              >
+                <Compass size={22} />
+                {t('exploreSample')}
+              </Link>
+            )}
 
             <button
               onClick={onAddItem}

--- a/tests/components/ExplorePlaceholderRoute.test.tsx
+++ b/tests/components/ExplorePlaceholderRoute.test.tsx
@@ -10,7 +10,7 @@ vi.mock('@/theme', async () => {
   return createThemeMock();
 });
 
-describe('Explore placeholder routing', () => {
+describe('Explore navigation routing', () => {
   const defaultProps = {
     onOpenAuth: vi.fn(),
     onSignOut: vi.fn(),
@@ -22,14 +22,24 @@ describe('Explore placeholder routing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setMockTheme('gallery');
+    window.location.hash = '#/';
   });
 
-  it('navigates to the explore placeholder from the bottom nav', async () => {
+  it('routes the bottom-nav Explore tab straight to the sample collection in one tap', async () => {
+    const onExploreSamples = vi.fn();
     renderWithProviders(
-      <Layout {...defaultProps}>
+      <Layout
+        {...defaultProps}
+        sampleCollectionId="sample-vinyl-1"
+        onExploreSamples={onExploreSamples}
+      >
         <Routes>
           <Route path="/" element={<div>Home</div>} />
           <Route path="/explore" element={<ExplorePlaceholder />} />
+          <Route
+            path="/collection/:id"
+            element={<div data-testid="sample-gallery">Sample gallery</div>}
+          />
         </Routes>
       </Layout>,
     );
@@ -37,7 +47,31 @@ describe('Explore placeholder routing', () => {
     const exploreLink = screen.getByRole('link', { name: /explore/i });
     fireEvent.click(exploreLink);
 
-    expect(await screen.findByTestId('explore-placeholder')).toBeInTheDocument();
+    expect(await screen.findByTestId('sample-gallery')).toBeInTheDocument();
+    expect(screen.queryByText('Community features are coming soon.')).not.toBeInTheDocument();
+    expect(onExploreSamples).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Explore tab when no sample collection exists (no dead end)', () => {
+    renderWithProviders(
+      <Layout {...defaultProps} sampleCollectionId={null}>
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </Layout>,
+    );
+
+    expect(screen.queryByRole('link', { name: /explore/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the Explore placeholder as a destination for the future feed', () => {
+    renderWithProviders(<ExplorePlaceholder sampleCollectionId="sample-vinyl-1" />);
+
+    expect(screen.getByTestId('explore-placeholder')).toBeInTheDocument();
     expect(screen.getByText('Community features are coming soon.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sample gallery/i })).toHaveAttribute(
+      'href',
+      '#/collection/sample-vinyl-1',
+    );
   });
 });


### PR DESCRIPTION
## Problem

The mobile bottom-nav **Explore** tab (one of four primary slots) linked to `/explore`, which renders the `ExplorePlaceholder` — "Community features are coming soon." So discovery took two taps: Explore → read "coming soon" → "Explore the sample gallery." Worse, when no sample collection was loaded the placeholder showed no CTA at all, a dead end.

This is an anticlimax at the most curiosity-driven moment of first use, and pushes the Public Sample Gallery (the thing that demonstrates the product) one tap further than necessary. Protects **Delight before auth** and **Single-path first run**.

## Approach

- `Layout.tsx`: the bottom-nav Explore item now links directly to `/collection/{sampleCollectionId}` and fires `onExploreSamples` on tap (mirroring the placeholder's existing CTA), so signed-out users clear the access gate and land on browsable sample content in one tap.
- When no sample collection exists, the Explore tab is hidden and the bottom nav collapses to 3 columns — no dead end.
- `App.tsx`: passes the existing `handleExploreSamples` into `Layout` as `onExploreSamples`.
- The `/explore` route and `ExplorePlaceholder` are intentionally kept for direct navigation and for the future Explore feed (CUR-3).
- Rewrote `ExplorePlaceholderRoute.test.tsx` to cover the new one-tap routing, the hidden-tab case, and that the placeholder is preserved.

## Why this approach

It reuses the exact "set public-browse + navigate to sample" pattern the placeholder CTA already uses, so behavior stays consistent and the access gate keeps working. It's a contained routing change in one nav item — no new dependencies, no change to the desktop "Explore sample" affordance, and the placeholder stays available for the real feed.

## Risks

Low-to-moderate (Yellow: route behavior change). The Explore tab now depends on `sampleCollectionId`, which is derived from a public collection or the always-present fallback sample, so in practice it is never null; the hidden-tab path is defensive. `onExploreSamples` is the same handler the placeholder already invoked, so no new side effects. Desktop affordance untouched.

## How to verify

Vercel Preview: https://curio-git-claude-happy-planck-gayxl-qs-projects-72b20d9d.vercel.app

Steps (mobile-width viewport):
1. Open Curio signed-out, behind the access gate.
2. Tap **Explore** in the bottom nav.
3. Expect: you land directly on the sample collection (no "coming soon" interstitial, no second tap).
4. Confirm the desktop header "Explore sample" button still works unchanged at `sm:` and above.
5. (Defensive) With no sample collection available, confirm the Explore tab is absent and the nav shows 3 evenly spaced items.

Checks:
- [x] npm run format:check
- [x] npm test (542 passed, 2 skipped, 1 todo — includes 3 rewritten Explore routing tests)
- [x] npm run build
- [ ] npm run test:e2e — **not run locally**: the sandbox network allowlist blocks the Playwright Chromium download (`403 'Host not in allowlist'` from `cdn.playwright.dev`), so no browser binary is available here. Unrelated to this diff (pure bottom-nav routing). Running in CI ("Format / Unit / Build / E2E").

## Screenshot / GIF

Not captured in-sandbox — no headless browser (see e2e note) and no live Supabase to seed the sample collection here. The change is verifiable on the Vercel preview via the steps above.

## Linear

Closes CUR-67
https://linear.app/qiuyue/issue/CUR-67/ux-route-the-explore-tab-to-the-sample-gallery-instead-of-a-coming

## Rollback plan

Revert the single commit on this branch:

```
git revert 47b0179
```

No data, schema, RLS, or feature-flag changes — pure presentational/routing revert.