### PR TITLE
fix(layout): hide duplicated header Profile icon on mobile (CUR-69)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -252,7 +252,7 @@ export const Layout: React.FC<LayoutProps> = ({
           <nav className="flex items-center gap-2 justify-end">
             {headerExtras}
 
-            <div className="relative" ref={profileRef}>
+            <div className="relative hidden sm:block" ref={profileRef}>
               <button
                 onClick={() => setProfileSource((prev) => (prev === 'header' ? null : 'header'))}
                 aria-label={t('account')}

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -17,7 +17,12 @@ test.describe('Accessibility', () => {
     if (await gate.isVisible()) {
       await page.getByTestId('cta-primary-add-first').click();
     } else {
-      await page.getByRole('button', { name: 'Account' }).click();
+      // Account button is in the header on desktop; on mobile, it's the bottom-nav Profile.
+      await page
+        .getByRole('button', { name: 'Account' })
+        .or(page.getByRole('button', { name: 'Profile', exact: true }))
+        .first()
+        .click();
       // Button text is "Sign In" (t('login') = 'Sign In'); fall back gracefully if not found.
       const signInBtn = page.getByRole('button', { name: /sign in/i });
       if (!(await signInBtn.isVisible({ timeout: 3000 }).catch(() => false))) return false;

--- a/tests/e2e/authenticated-user.spec.ts
+++ b/tests/e2e/authenticated-user.spec.ts
@@ -20,7 +20,12 @@ async function signIn(page: Page) {
   if (await gate.isVisible()) {
     await page.getByTestId('cta-primary-add-first').click();
   } else {
-    await page.getByRole('button', { name: 'Account' }).click();
+    // Account button is in the header on desktop; on mobile, it's the bottom-nav Profile.
+    await page
+      .getByRole('button', { name: 'Account' })
+      .or(page.getByRole('button', { name: 'Profile', exact: true }))
+      .first()
+      .click();
     await page.getByRole('button', { name: /login/i }).click();
   }
 

--- a/tests/e2e/first-time-user.spec.ts
+++ b/tests/e2e/first-time-user.spec.ts
@@ -140,6 +140,10 @@ test.describe('First-Time User Experience', () => {
     await page.getByRole('button', { name: 'The Vault (Moody)' }).click();
     await expect(page.locator('[data-theme="vault"]')).toBeVisible();
 
+    // Dismiss the profile menu so subsequent clicks on the header aren't intercepted
+    // by the mobile bottom-sheet backdrop.
+    await page.keyboard.press('Escape');
+
     // Toggle language button in header.
     // Use a stable locator (Globe icon button) since the title changes with language.
     const langToggle = page.locator('button', { has: page.locator('text=ZH') });

--- a/tests/e2e/first-time-user.spec.ts
+++ b/tests/e2e/first-time-user.spec.ts
@@ -130,7 +130,12 @@ test.describe('First-Time User Experience', () => {
     await ensureSampleBrowse(page);
 
     // Open account menu → switch theme.
-    await page.getByRole('button', { name: 'Account' }).click();
+    // Account button is in the header on desktop; on mobile, it's the bottom-nav Profile.
+    await page
+      .getByRole('button', { name: 'Account' })
+      .or(page.getByRole('button', { name: 'Profile', exact: true }))
+      .first()
+      .click();
     // Avoid matching the "The Vinyl Vault" collection card button.
     await page.getByRole('button', { name: 'The Vault (Moody)' }).click();
     await expect(page.locator('[data-theme="vault"]')).toBeVisible();


### PR DESCRIPTION
## Summary
- The bottom-nav Profile button (added in CUR-58) and the header `<User>` account icon were both visible at the same time on mobile, leading to two different surfaces (top-anchored dropdown vs. bottom sheet) for the same Account menu.
- Hide the header trigger on viewports < 640px so the bottom-nav Profile is the single mobile entry point. Desktop behaviour is unchanged.
- Update two E2E specs (`first-time-user.spec.ts`, `authenticated-user.spec.ts`) so the Pixel 7 project can reach the Account menu via the bottom-nav Profile button.

## Linear
Closes [CUR-69](https://linear.app/qiuyue/issue/CUR-69)

## Test plan
- [x] `npm run format:check` clean
- [x] `npm test` — 544 passed (Layout suite: 47/47)
- [x] `npm run build` — clean
- [ ] `npm run test:e2e` — could not run in this remote environment (Playwright Chromium download blocked by network policy). The two test-file edits use `locator.or(...).first()` which preserves the current desktop locator and adds the mobile bottom-nav fallback — equivalent behaviour on desktop.

## Notes for reviewer
This is the small, safe fix split out of a wider UI/UX review pass. Four additional UX findings were filed as separate Linear issues and are NOT in this PR (CUR-70…CUR-73): language toggle `dark:` prefix bug, bottom-nav Add pill not theme-aware, auth submit spinner with no text, and item-detail title focus indicator too subtle.

---
_Generated by [Claude Code](https://claude.ai/code/session_017MERnDsnPMHvRdLxgcar6n)_