### PR TITLE
[CUR-70] Make language toggle theme-aware (drop Tailwind dark: prefix)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2536,7 +2536,13 @@ export const AppContent: React.FC = () => {
             )}
             <button
               onClick={() => setLanguage(language === 'en' ? 'zh' : 'en')}
-              className="p-2 hover:bg-stone-100 dark:hover:bg-white/10 rounded-full text-stone-500 hover:text-stone-900 transition-colors flex items-center gap-1 sm:gap-1.5"
+              className={`p-2 rounded-full transition-colors flex items-center gap-1 sm:gap-1.5 ${
+                theme === 'vault'
+                  ? 'text-white/70 hover:text-white hover:bg-white/10'
+                  : theme === 'atelier'
+                    ? 'text-[#6B5344] hover:text-[#3D3530] hover:bg-[#EDE4D3]'
+                    : 'text-stone-500 hover:text-stone-900 hover:bg-stone-100'
+              }`}
               title={t('switchLanguage')}
             >
               <Globe size={18} />


### PR DESCRIPTION
## Problem

The header language toggle (Globe + EN/ZH) was the **only** place in `src/` using Tailwind's `dark:` utility prefix (verified by `grep -rn "dark:" src/`). `tailwind.config.js` has no `darkMode` setting, so `dark:` resolved to OS `prefers-color-scheme` — independent of Curio's user-selected Gallery / Vault / Atelier theme.

Result:
- Vault on a light-OS device → hover renders as a bright `stone-100` pill on a `stone-900/80` header; stray light chip.
- Vault on a dark-OS device → `dark:hover:bg-white/10` activates but the base `text-stone-900` hover state goes dark-on-dark, failing WCAG AA contrast.
- Base `text-stone-500` is also low contrast against Vault's dark header.

Bilingual users hit this on their primary header action. Protects **Beauty before bureaucracy** and **Trust before growth**.

## Approach

`src/App.tsx`: replaced the hand-rolled class string with a theme-conditional template mirroring the existing `navGhost` pattern in `Layout.tsx:120-123`:

- **Vault** → `text-white/70 hover:text-white hover:bg-white/10` (matches `navGhost`)
- **Atelier** → `text-[#6B5344] hover:text-[#3D3530] hover:bg-[#EDE4D3]` (warm tokens already used in `HomeScreen.tsx` and the access-gate text hierarchy)
- **Gallery** → `text-stone-500 hover:text-stone-900 hover:bg-stone-100` (unchanged from before)

`theme` is already in scope in `AppContent` (line 145), so no new imports.

## Why this approach

Smallest fix that satisfies every acceptance criterion: one button's `className`, no new abstractions, no Layout.tsx churn, no new theme tokens. Reuses the exact tokens already established for header surfaces — Atelier hover is the same `[#EDE4D3]` used by On-This-Day cards, Vault hover is the same `white/10` used by the rest of the header's ghost controls. Gallery rendering is byte-identical to before.

## Risks

Low (Green tier). Pure presentational change to one `<button>` class string. No data flow, sync, AI, auth, routing, layout, or i18n behavior changes. Gallery is the default fallthrough so existing screenshots/specs stay valid. Verified via `grep -rn "dark:" src/` that no other `dark:` utilities exist in the source tree.

## How to verify

Vercel Preview: auto-deployed on push (link will appear on the PR)

Steps:
1. Open the app, switch to **Vault** theme.
2. Hover/focus the Globe + EN/ZH button in the header → expect light-on-dark text and a subtle `white/10` hover pill (no light-pill artifact, no dark-on-dark text).
3. Switch to **Atelier** → expect warm brown text and a tactile `#EDE4D3` hover.
4. Switch to **Gallery** → expect identical behavior to before (stone-500 → stone-900 on hover, stone-100 hover pill).
5. Toggle OS dark-mode preference while in Vault → no visual change (the bug is fixed precisely because we no longer depend on OS preference).
6. `grep -rn "dark:" src/` → returns no matches.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 561 passed, 2 skipped, 1 todo (no regressions)
- [x] `npm run build` — passed (vite 6.4.1, 1813 modules)
- [ ] `npm run test:e2e` — **not run locally**: sandbox has Playwright Chromium build 1194 preinstalled at `/opt/pw-browsers`, but Playwright 1.57 expects build 1200, and `npx playwright install chromium` is blocked by the sandbox network allowlist (`403 'Host not in allowlist'` from `playwright.download.prss.microsoft.com`). Same pre-existing environment limitation called out in PRs #222, #223, #228, #231, #233, #236. CI ("Format / Unit / Build / E2E") will run it. The diff touches only one header button's `className` — no SPA routing, no spec selectors, no theme-token foundation.

## Screenshot / GIF

Not captured in-sandbox (no headless browser available — see e2e note). Verifiable on the Vercel preview via the steps above.

## Linear

Closes CUR-70
https://linear.app/qiuyue/issue/CUR-70/ux-language-toggle-uses-tailwind-dark-prefix-decoupled-from

## Rollback plan

Revert the single commit on this branch:

```
git revert b6515f8
```

No schema, RLS, storage, feature flag, env var, or data changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyTw2Ex5PhKCav8MQ1NqW5)_