### PR TITLE
[CUR-72] Show inline loading label on auth submit

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -363,9 +363,10 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                     <input
                       type="email"
                       required
+                      disabled={loading}
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
-                      className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all ${inputSurface}`}
+                      className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                       placeholder="curator@museum.com"
                     />
                   </div>
@@ -401,9 +402,10 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                     <input
                       type="password"
                       required
+                      disabled={loading}
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
-                      className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all ${inputSurface}`}
+                      className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                       placeholder="••••••••"
                     />
                   </div>
@@ -428,11 +430,12 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                         id="auth-new-password"
                         type="password"
                         required
+                        disabled={loading}
                         minLength={MIN_PASSWORD_LENGTH}
                         autoComplete="new-password"
                         value={newPassword}
                         onChange={(e) => setNewPassword(e.target.value)}
-                        className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all ${inputSurface}`}
+                        className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                         placeholder="••••••••"
                       />
                     </div>
@@ -453,11 +456,12 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                         id="auth-confirm-password"
                         type="password"
                         required
+                        disabled={loading}
                         minLength={MIN_PASSWORD_LENGTH}
                         autoComplete="new-password"
                         value={confirmPassword}
                         onChange={(e) => setConfirmPassword(e.target.value)}
-                        className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all ${inputSurface}`}
+                        className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                         placeholder="••••••••"
                       />
                     </div>
@@ -468,9 +472,25 @@ export const AuthModal: React.FC<AuthModalProps> = ({
           )}
 
           {mode !== 'reset-sent' && (
-            <Button type="submit" className="w-full h-14 text-lg" disabled={loading}>
+            <Button
+              type="submit"
+              className="w-full h-14 text-lg"
+              disabled={loading}
+              aria-busy={loading}
+            >
               {loading ? (
-                <Loader2 className="animate-spin" size={20} />
+                <span className="inline-flex items-center justify-center gap-2">
+                  <Loader2 className="animate-spin" size={20} aria-hidden="true" />
+                  <span>
+                    {mode === 'signin'
+                      ? t('signingIn')
+                      : mode === 'signup'
+                        ? t('creatingAccount')
+                        : mode === 'reset-request'
+                          ? t('sendingResetLink')
+                          : t('savingPassword')}
+                  </span>
+                </span>
               ) : mode === 'signin' ? (
                 t('login')
               ) : mode === 'signup' ? (

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -235,6 +235,10 @@ export const translations = {
     // Auth & Cloud
     login: 'Sign In',
     register: 'Create Account',
+    signingIn: 'Signing in…',
+    creatingAccount: 'Creating account…',
+    sendingResetLink: 'Sending reset link…',
+    savingPassword: 'Saving password…',
     close: 'Close',
     email: 'Email Address',
     password: 'Password',
@@ -660,6 +664,10 @@ export const translations = {
     // Auth & Cloud
     login: '登录',
     register: '创建账号',
+    signingIn: '正在登录…',
+    creatingAccount: '正在创建账号…',
+    sendingResetLink: '正在发送重置链接…',
+    savingPassword: '正在保存密码…',
     close: '关闭',
     email: '电子邮箱',
     password: '密码',

--- a/tests/components/AuthModal.test.tsx
+++ b/tests/components/AuthModal.test.tsx
@@ -238,9 +238,12 @@ describe('AuthModal', () => {
 
   describe('Loading State', () => {
     it('shows loading indicator during authentication', async () => {
-      // Make sign in take some time
+      let resolveSignIn!: (v: { user: { id: string } }) => void;
       mockSignIn.mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve({ user: { id: 'test' } }), 1000)),
+        () =>
+          new Promise((resolve) => {
+            resolveSignIn = resolve;
+          }),
       );
 
       const user = userEvent.setup();
@@ -256,11 +259,18 @@ describe('AuthModal', () => {
       await waitFor(() => {
         expect(submitButton).toBeDisabled();
       });
+
+      resolveSignIn({ user: { id: 'test' } });
+      await waitFor(() => expect(mockOnAuthSuccess).toHaveBeenCalled());
     });
 
-    it('disables form inputs during authentication', async () => {
+    it('shows "Signing in…" label and aria-busy on submit during sign-in', async () => {
+      let resolveSignIn!: (v: { user: { id: string } }) => void;
       mockSignIn.mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve({ user: { id: 'test' } }), 1000)),
+        () =>
+          new Promise((resolve) => {
+            resolveSignIn = resolve;
+          }),
       );
 
       const user = userEvent.setup();
@@ -268,14 +278,67 @@ describe('AuthModal', () => {
 
       await user.type(screen.getByPlaceholderText(/curator@museum.com/i), 'test@example.com');
       await user.type(screen.getByPlaceholderText(/••••••••/), 'password123');
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
 
-      const submitButton = screen.getByRole('button', { name: /sign in/i });
-      await user.click(submitButton);
+      const busyButton = await screen.findByRole('button', { name: /signing in/i });
+      expect(busyButton).toHaveAttribute('aria-busy', 'true');
+      expect(busyButton).toBeDisabled();
 
-      // Check button becomes disabled while loading
+      // Resolve the pending sign-in so the component finishes its work and
+      // does not leak a pending promise into later tests.
+      resolveSignIn({ user: { id: 'test' } });
+      await waitFor(() => expect(mockOnAuthSuccess).toHaveBeenCalled());
+    });
+
+    it('shows "Creating account…" label on submit during sign-up', async () => {
+      let resolveSignUp!: (v: { user: { id: string } }) => void;
+      mockSignUp.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSignUp = resolve;
+          }),
+      );
+
+      const user = userEvent.setup();
+      renderWithProviders(<AuthModal {...defaultProps} />);
+
+      await user.click(screen.getByText(/Don't have an account/i));
+      await user.type(screen.getByPlaceholderText(/curator@museum.com/i), 'new@example.com');
+      await user.type(screen.getByPlaceholderText(/••••••••/), 'password123');
+      await user.click(screen.getByRole('button', { name: /create account/i }));
+
+      const busyButton = await screen.findByRole('button', { name: /creating account/i });
+      expect(busyButton).toHaveAttribute('aria-busy', 'true');
+
+      resolveSignUp({ user: { id: 'test' } });
+      await waitFor(() => expect(mockOnAuthSuccess).toHaveBeenCalled());
+    });
+
+    it('disables form inputs during authentication', async () => {
+      let resolveSignIn!: (v: { user: { id: string } }) => void;
+      mockSignIn.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSignIn = resolve;
+          }),
+      );
+
+      const user = userEvent.setup();
+      renderWithProviders(<AuthModal {...defaultProps} />);
+
+      const emailInput = screen.getByPlaceholderText(/curator@museum.com/i);
+      const passwordInput = screen.getByPlaceholderText(/••••••••/);
+      await user.type(emailInput, 'test@example.com');
+      await user.type(passwordInput, 'password123');
+      await user.click(screen.getByRole('button', { name: /sign in/i }));
+
       await waitFor(() => {
-        expect(submitButton).toBeDisabled();
+        expect(emailInput).toBeDisabled();
+        expect(passwordInput).toBeDisabled();
       });
+
+      resolveSignIn({ user: { id: 'test' } });
+      await waitFor(() => expect(mockOnAuthSuccess).toHaveBeenCalled());
     });
   });
 


### PR DESCRIPTION
## Problem

When a user submits the sign-in / sign-up / reset / set-password form, the AuthModal submit button replaced its entire content with a lone `<Loader2>` spinner — no text. On a cold Supabase call or slow mobile network this is several seconds of silence: users can't tell whether the request is in flight, whether the button broke, or which action is happening. The acceptance criteria from CUR-72 (and the **Explicit outcomes** constraint in `CLAUDE.md` — *"Surface clear feedback for 'Saved', 'Synced', and 'Will sync / retrying' states so users trust the system"*) call for an inline, localized loading label plus `aria-busy`.

## Approach

- `src/components/AuthModal.tsx`: while `loading` is true, the submit button now renders the spinner alongside a mode-specific localized label — `signingIn`, `creatingAccount`, `sendingResetLink`, or `savingPassword` — and sets `aria-busy={loading}` so screen readers announce the busy state. The 4 input fields (email, password, new password, confirm password) gain `disabled={loading}` plus matching disabled styling so the whole form is consistently inert during the request, not just the submit button.
- `src/i18n.ts`: added 4 new keys in both `en` and `zh` (`signingIn`, `creatingAccount`, `sendingResetLink`, `savingPassword`).
- `tests/components/AuthModal.test.tsx`: added 3 focused tests covering the new label per mode, `aria-busy="true"`, and disabled inputs. Also tightened the pre-existing `"shows loading indicator"` test to resolve its pending promise — without that fix, adding more loading-state tests caused the file's `set-password` test to flake under the full suite because three leaked pending sign-in promises shifted timing enough that the `onAuthSuccess` call count drifted across tests.

## Why this approach

It's the smallest taste-aligned change that satisfies the issue's acceptance criteria: same component, same i18n pattern as every other auth string, no new components, no design-system changes. The disabled-state styling reuses Tailwind's standard `disabled:opacity-60 disabled:cursor-not-allowed` — no new tokens. The leaky-promise fix in the existing test is contained to the same `describe('Loading State')` block I was already editing and avoids introducing a real-world regression risk into CI flake.

## Risks

Low (Green tier).

- Pure presentational / a11y change on an existing flow; no auth, sync, RLS, or storage behavior changes.
- Possible test-id / text-match drift: existing tests look up the submit button by `name: /sign in/i` BEFORE the click, so they're unaffected. New i18n keys are typed via `TranslationKey = keyof translations.en` and are present in both `en` and `zh`.
- The screen-reader experience changes from "Sign In (button, disabled)" to "Signing in… (button, busy, disabled)" — strictly clearer.

## How to verify

Vercel Preview: _will be attached by the Vercel bot when this PR builds._

Steps (mobile-width viewport recommended):

1. Open Curio signed-out → click an action that opens the auth modal (e.g. "Add your first item").
2. With DevTools → Network throttled to **Slow 3G**, enter valid credentials and click **Sign In**. Expect the button to read **"⟳ Signing in…"**, `aria-busy="true"`, and both email + password fields to be visibly disabled until the request resolves.
3. Toggle to sign-up via "Don't have an account? Sign up", submit, and confirm the label reads **"⟳ Creating account…"**.
4. From the sign-in screen click "Forgot password?", submit an email, and confirm the button reads **"⟳ Sending reset link…"** while the request is pending.
5. Switch language to ZH (settings menu) and repeat — labels should read **"正在登录…"**, **"正在创建账号…"**, **"正在发送重置链接…"**, **"正在保存密码…"** respectively.
6. With a screen reader (VoiceOver / NVDA), tab to the submit button after clicking it — confirm the busy state is announced.

Checks:
- [x] `npm run format:check` (passed)
- [x] `npm test` (passed: 563 passed, 2 skipped, 1 todo — includes 3 new tests + 1 tightened test)
- [x] `npm run build` (passed)
- [ ] `npm run test:e2e` — **not run locally**: the sandbox network policy blocks the Playwright Chromium download (`403 'Host not in allowlist'` from `cdn.playwright.dev` and `playwright.download.prss.microsoft.com`), so no browser binary is available here. The change is presentational, touches no E2E-covered routing, and CI ("Format / Unit / Build / E2E") will exercise it.

## Screenshot / GIF

Not captured locally — same Playwright-CDN block prevents headless capture in this environment. Verifiable on the Vercel preview via the steps above.

## Linear

Closes CUR-72
https://linear.app/qiuyue/issue/CUR-72/ux-auth-submit-button-shows-only-a-spinner-during-sign-inup-add-inline

## Rollback plan

Revert the single commit on this branch:

```
git revert 30bbbe8
```

No data, schema, RLS, env var, or feature-flag changes — pure presentational + i18n revert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyf23CkX8qmAZdwdc2ACub)_