### PR TITLE
[CUR-67] Route the Explore tab straight to the sample gallery (review-ready, supersedes #228)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2373,6 +2373,17 @@ export const AppContent: React.FC = () => {
     }
   };
 
+  // The bottom-nav Explore tab is only rendered when the sample collection is
+  // already present in `collections` (see `sampleCollectionId`), so it just
+  // needs to clear the access gate and let the <Link> navigate. We deliberately
+  // skip refreshCollections() here: a transient cloud failure during that
+  // click-time refresh would replace `collections` with local-only data and
+  // drop the already-loaded target, turning this one-tap link back into the
+  // dead link we set out to remove.
+  const handleExploreFromNav = useCallback(() => {
+    setAllowPublicBrowse(true);
+  }, []);
+
   const handleAddAction = useCallback(() => {
     if (!isAuthenticated) {
       setPendingAuthAction('add-item');
@@ -2524,7 +2535,7 @@ export const AppContent: React.FC = () => {
         onImportLocal={handleImportLocal}
         statusBanner={statusBanner}
         onAddItem={handleAddAction}
-        onExploreSamples={handleExploreSamples}
+        onExploreSamples={handleExploreFromNav}
         headerExtras={
           <div className="flex items-center gap-2 sm:gap-3">
             {sampleCollection && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2514,6 +2514,7 @@ export const AppContent: React.FC = () => {
         onImportLocal={handleImportLocal}
         statusBanner={statusBanner}
         onAddItem={handleAddAction}
+        onExploreSamples={handleExploreSamples}
         headerExtras={
           <div className="flex items-center gap-2 sm:gap-3">
             {sampleCollection && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2291,7 +2291,17 @@ export const AppContent: React.FC = () => {
   const isExploreRoute = location.pathname === '/explore';
   const shouldShowAccessGate = showAccessGate && !isExploreRoute;
   const fallbackSampleCollectionId = fallbackSampleCollections[0]?.id ?? null;
-  const sampleCollectionId = sampleCollection?.id ?? fallbackSampleCollectionId;
+  // Only expose a sample collection id that is actually present in `collections`.
+  // The fallback sample is not part of merged cloud state for an authenticated
+  // user with only private collections, so linking to it would bounce off
+  // CollectionScreen back to Home (a dead Explore tab). Fall back to null in that
+  // case so the bottom-nav Explore tab hides instead of dead-linking.
+  const sampleCollectionId = useMemo(() => {
+    if (sampleCollection) return sampleCollection.id;
+    return collections.some((c) => c.id === fallbackSampleCollectionId)
+      ? fallbackSampleCollectionId
+      : null;
+  }, [sampleCollection, collections, fallbackSampleCollectionId]);
 
   const statusBanner = useMemo(() => {
     if (!isSupabaseReady) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -32,6 +32,7 @@ interface LayoutProps {
   headerExtras?: React.ReactNode;
   statusBanner?: React.ReactNode;
   onAddItem?: () => void;
+  onExploreSamples?: () => void;
 }
 
 export const Layout: React.FC<LayoutProps> = ({
@@ -48,6 +49,7 @@ export const Layout: React.FC<LayoutProps> = ({
   headerExtras,
   statusBanner,
   onAddItem,
+  onExploreSamples,
 }) => {
   const { t } = useTranslation();
   const { theme } = useTheme();
@@ -138,6 +140,7 @@ export const Layout: React.FC<LayoutProps> = ({
   const bottomNavMuted = theme === 'vault' ? 'text-white/60' : 'text-stone-400';
   const statusBadgeSurface =
     theme === 'vault' ? 'bg-stone-900 border-white/10' : 'bg-white border-stone-200';
+  const exploreTo = sampleCollectionId ? `/collection/${sampleCollectionId}` : null;
   const isExploreActive =
     location.pathname === '/explore' ||
     (sampleCollectionId
@@ -310,7 +313,7 @@ export const Layout: React.FC<LayoutProps> = ({
         style={{ height: 'var(--bottom-nav-height, 5.5rem)' }}
       >
         <div className="mx-auto max-w-4xl h-full px-2 pb-[env(safe-area-inset-bottom,0px)] pt-2 flex items-center">
-          <div className="grid grid-cols-4 items-center w-full">
+          <div className={`grid ${exploreTo ? 'grid-cols-4' : 'grid-cols-3'} items-center w-full`}>
             <Link
               to="/"
               className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${location.pathname === '/' ? 'text-amber-500' : bottomNavMuted}`}
@@ -319,13 +322,16 @@ export const Layout: React.FC<LayoutProps> = ({
               {t('navHome')}
             </Link>
 
-            <Link
-              to="/explore"
-              className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
-            >
-              <Compass size={22} />
-              {t('exploreSample')}
-            </Link>
+            {exploreTo && (
+              <Link
+                to={exploreTo}
+                onClick={onExploreSamples}
+                className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
+              >
+                <Compass size={22} />
+                {t('exploreSample')}
+              </Link>
+            )}
 
             <button
               onClick={onAddItem}

--- a/tests/components/ExplorePlaceholderRoute.test.tsx
+++ b/tests/components/ExplorePlaceholderRoute.test.tsx
@@ -10,7 +10,7 @@ vi.mock('@/theme', async () => {
   return createThemeMock();
 });
 
-describe('Explore placeholder routing', () => {
+describe('Explore navigation routing', () => {
   const defaultProps = {
     onOpenAuth: vi.fn(),
     onSignOut: vi.fn(),
@@ -22,14 +22,24 @@ describe('Explore placeholder routing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setMockTheme('gallery');
+    window.location.hash = '#/';
   });
 
-  it('navigates to the explore placeholder from the bottom nav', async () => {
+  it('routes the bottom-nav Explore tab straight to the sample collection in one tap', async () => {
+    const onExploreSamples = vi.fn();
     renderWithProviders(
-      <Layout {...defaultProps}>
+      <Layout
+        {...defaultProps}
+        sampleCollectionId="sample-vinyl-1"
+        onExploreSamples={onExploreSamples}
+      >
         <Routes>
           <Route path="/" element={<div>Home</div>} />
           <Route path="/explore" element={<ExplorePlaceholder />} />
+          <Route
+            path="/collection/:id"
+            element={<div data-testid="sample-gallery">Sample gallery</div>}
+          />
         </Routes>
       </Layout>,
     );
@@ -37,7 +47,31 @@ describe('Explore placeholder routing', () => {
     const exploreLink = screen.getByRole('link', { name: /explore/i });
     fireEvent.click(exploreLink);
 
-    expect(await screen.findByTestId('explore-placeholder')).toBeInTheDocument();
+    expect(await screen.findByTestId('sample-gallery')).toBeInTheDocument();
+    expect(screen.queryByText('Community features are coming soon.')).not.toBeInTheDocument();
+    expect(onExploreSamples).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Explore tab when no sample collection exists (no dead end)', () => {
+    renderWithProviders(
+      <Layout {...defaultProps} sampleCollectionId={null}>
+        <Routes>
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </Layout>,
+    );
+
+    expect(screen.queryByRole('link', { name: /explore/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the Explore placeholder as a destination for the future feed', () => {
+    renderWithProviders(<ExplorePlaceholder sampleCollectionId="sample-vinyl-1" />);
+
+    expect(screen.getByTestId('explore-placeholder')).toBeInTheDocument();
     expect(screen.getByText('Community features are coming soon.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /sample gallery/i })).toHaveAttribute(
+      'href',
+      '#/collection/sample-vinyl-1',
+    );
   });
 });

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -263,6 +263,33 @@ describe('App Integration Tests', () => {
     expect(screen.getByTestId('cta-secondary-explore-sample')).toBeInTheDocument();
   });
 
+  it('hides the bottom-nav Explore tab when no sample collection is loaded (no dead link)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Authenticated user whose only collection is private and cloud returns no
+    // public collection: the fallback sample id is not present in `collections`,
+    // so the Explore tab must hide rather than link to a collection that
+    // CollectionScreen cannot find (which would bounce back to Home).
+    vi.mocked(supabaseService.isSupabaseConfigured).mockReturnValue(true);
+    vi.mocked(db.getLocalCollections).mockResolvedValue([mockCollection]);
+    vi.mocked(db.fetchCloudCollections).mockResolvedValue([]);
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Test Collection')[0]).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link', { name: /explore/i })).not.toBeInTheDocument();
+  });
+
   it('has i18n keys for collection search empty state', async () => {
     const { translations } = await import('@/i18n');
 

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AppContent } from '@/App';
 import { LanguageProvider } from '@/i18n';
@@ -288,6 +288,61 @@ describe('App Integration Tests', () => {
     });
 
     expect(screen.queryByRole('link', { name: /explore/i })).not.toBeInTheDocument();
+  });
+
+  it('does not refetch cloud collections when following the bottom-nav Explore link', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Signed-out visitor, Supabase configured, with a public sample collection
+    // already loaded. The bottom-nav Explore tap must clear the access gate and
+    // navigate to the loaded target WITHOUT a click-time cloud refetch — a
+    // transient failure in that refetch would drop the loaded collection and
+    // turn the one-tap link back into a dead link (Codex review on #241).
+    const publicSample = {
+      id: 'sample-vinyl',
+      name: 'The Vinyl Vault',
+      templateId: 'vinyl',
+      icon: '🎵',
+      customFields: [],
+      items: [],
+      isPublic: true,
+      updatedAt: new Date().toISOString(),
+    };
+    vi.mocked(supabaseService.isSupabaseConfigured).mockReturnValue(true);
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as never);
+    vi.mocked(db.getLocalCollections).mockResolvedValue([]);
+    vi.mocked(db.fetchCloudCollections).mockResolvedValue([publicSample]);
+    vi.mocked(db.mergeCollections).mockImplementation((local, cloud) =>
+      cloud.length ? cloud : local,
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('access-gate')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(vi.mocked(db.fetchCloudCollections)).toHaveBeenCalled();
+    });
+    const fetchCallsAfterLoad = vi.mocked(db.fetchCloudCollections).mock.calls.length;
+
+    const bottomNav = screen.getByRole('navigation', { name: 'Primary' });
+    fireEvent.click(within(bottomNav).getByRole('link', { name: /explore/i }));
+
+    // Gate clears (public browsing enabled) and no extra cloud fetch fires.
+    await waitFor(() => {
+      expect(screen.queryByTestId('access-gate')).not.toBeInTheDocument();
+    });
+    expect(vi.mocked(db.fetchCloudCollections).mock.calls.length).toBe(fetchCallsAfterLoad);
   });
 
   it('has i18n keys for collection search empty state', async () => {


### PR DESCRIPTION
## Summary

This supersedes #228 (whose branch I can't push to) — it carries that PR's change **plus** the fix for the two open Codex review threads, and is rebased on the latest `main`.

The mobile bottom-nav **Explore** tab linked to `/explore` → the "Community features are coming soon" placeholder, making discovery a two-tap dead end (and a no-CTA dead end when no sample was loaded). This routes Explore straight to the Public Sample Gallery in one tap, protecting **Delight before auth** and **Single-path first run**.

## Changes

- `Layout.tsx`: the bottom-nav Explore item now links directly to `/collection/{sampleCollectionId}` and fires `onExploreSamples` on tap. When there is no sample collection, the tab is hidden and the nav collapses from 4 to 3 columns — no dead end.
- `App.tsx`: passes `handleExploreSamples` into `Layout` as `onExploreSamples`.
- The `/explore` route and `ExplorePlaceholder` are intentionally preserved for the future Explore feed (CUR-3).
- Tests rewritten/added in `ExplorePlaceholderRoute.test.tsx`.

## Codex review fix (addresses both open P2 threads on #228)

The reviews flagged that for an authenticated non-admin user with only private collections (and a Supabase env returning no public collection), `App` still fell back `sampleCollectionId` to the fallback sample id (`sample-vinyl`) even though that collection isn't part of merged cloud state. The Explore tab rendered but navigated to a collection `CollectionScreen` couldn't find, bouncing back to Home — a dead link.

Fix: `sampleCollectionId` is now derived only from ids actually present in `collections`, returning `null` otherwise. So the tab reliably hides (rather than dead-links) whenever the target collection isn't loaded. This also guarantees the desktop affordance and the `/explore` route never point at an unloadable collection.

Added an `AppNavigation` integration regression test covering the authenticated-private-only scenario (verified it fails without the fix, passes with it).

## Verification

- [x] `npm run format:check`
- [x] `npm test` — 566 passed, 2 skipped, 1 todo
- [x] `npm run build`
- [ ] `npm run test:e2e` — **not run here**: the sandbox network allowlist blocks the Playwright Chromium download (`cdn.playwright.dev`), so no browser binary is available. Unrelated to this diff (pure bottom-nav routing). Runs in CI.

## Linear

Closes CUR-67


---
_Generated by [Claude Code](https://claude.ai/code/session_01NMK39PGuKtKtk2H1rVykNa)_