### PR TITLE
[CUR-71] Make bottom-nav Add pill theme-aware

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -138,6 +138,12 @@ export const Layout: React.FC<LayoutProps> = ({
         ? 'bg-[#F5EFE4]/95 border-[#D4C9B8]'
         : 'bg-white/95 border-stone-200/70';
   const bottomNavMuted = theme === 'vault' ? 'text-white/60' : 'text-stone-400';
+  const bottomNavAddPill =
+    theme === 'vault'
+      ? 'bg-[#D4A574]/20 text-[#D4A574]'
+      : theme === 'atelier'
+        ? 'bg-[#A86F3C]/15 text-[#A86F3C]'
+        : 'bg-amber-100 text-amber-700';
   const statusBadgeSurface =
     theme === 'vault' ? 'bg-stone-900 border-white/10' : 'bg-white border-stone-200';
   const exploreTo = sampleCollectionId ? `/collection/${sampleCollectionId}` : null;
@@ -337,7 +343,10 @@ export const Layout: React.FC<LayoutProps> = ({
               onClick={onAddItem}
               className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${bottomNavMuted}`}
             >
-              <div className="p-1 rounded-full bg-amber-100 text-amber-700 -mt-1">
+              <div
+                data-testid="bottom-nav-add-pill"
+                className={`p-1 rounded-full -mt-1 ${bottomNavAddPill}`}
+              >
                 <Plus size={20} strokeWidth={2.5} />
               </div>
               {t('add')}

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -423,6 +423,22 @@ describe('Layout Component', () => {
       });
     });
 
+    describe('Add button pill is theme-aware', () => {
+      it.each([
+        { theme: 'gallery' as const, expected: ['bg-amber-100', 'text-amber-700'] },
+        { theme: 'vault' as const, expected: ['bg-[#D4A574]/20', 'text-[#D4A574]'] },
+        { theme: 'atelier' as const, expected: ['bg-[#A86F3C]/15', 'text-[#A86F3C]'] },
+      ])('uses theme accent in $theme', ({ theme, expected }) => {
+        setMockTheme(theme);
+        renderWithProviders(<Layout {...defaultProps} />);
+
+        const pill = screen.getByTestId('bottom-nav-add-pill');
+        for (const className of expected) {
+          expect(pill.className).toContain(className);
+        }
+      });
+    });
+
     it('renders profile menu as a bottom sheet (not the header dropdown) when triggered from bottom nav', async () => {
       renderWithProviders(<Layout {...defaultProps} />);
 


### PR DESCRIPTION
## Problem

The mobile bottom navigation's Add (`+`) pill was hardcoded `bg-amber-100 text-amber-700` regardless of theme. In Vault it rendered as a pale lemon dot against a near-black surface — visually loud and inconsistent with the cinematic palette. In Atelier it competed with the warm-brown accent. The other bottom-nav items already use the theme-aware `bottomNavMuted` token; only this pill ignored the theme.

This is a "beauty before bureaucracy" violation: the primary creation affordance was off-brand in two of the three themes.

## Approach

Added a small `bottomNavAddPill` theme map in `Layout.tsx`, mirroring the existing `bottomNavSurface` / `bottomNavMuted` pattern. The pill now uses each theme's accent token:

- **Gallery** — `bg-amber-100 text-amber-700` (unchanged)
- **Vault** — `bg-[#D4A574]/20 text-[#D4A574]` (brass tint over dark)
- **Atelier** — `bg-[#A86F3C]/15 text-[#A86F3C]` (leather tint over cream)

The new map is colocated with the other per-theme nav classes (`Layout.tsx:140-146`) and the rendered pill picks it up via the existing JSX with a `data-testid` for test coverage.

Added three component-test cases that assert the correct accent classes per theme so we don't regress.

## Why this approach

Reuses the same `theme === 'vault' ? … : theme === 'atelier' ? … : …` pattern already used for `bottomNavSurface`, `bottomNavMuted`, `headerSurface`, and `footerGradient` in this same file — no new abstraction, no new tokens, and no change to the accent palette in `DESIGN.md`. The accent colours come straight from the `themeColors` entries already documented (`#D4A574` brass for Vault, `#A86F3C` leather for Atelier). Two files, ~26 lines total.

## Risks

Low. Visual-only change scoped to a single 16×16 pill in the bottom nav. Gallery is byte-identical. Vault and Atelier render the same shape with their own accent token; both maintain icon contrast against the per-theme nav surface (white/60 → brass/leather is well within WCAG AA on the respective backgrounds).

## How to verify

Vercel Preview: https://curio-git-claude-curio-71-bottom-na-654180-qs-projects-72b20d9d.vercel.app

Steps:

1. Open the preview on a mobile viewport (or DevTools mobile mode).
2. Switch to **Gallery** — Add pill should look identical to today (light amber pill, amber `+` icon).
3. Switch to **Vault** — Add pill should be a soft brass tint with a brass `+` icon, not pale lemon.
4. Switch to **Atelier** — Add pill should be a warm leather tint with a leather-brown `+` icon.
5. Confirm the icon stays legible against each theme's bottom-nav surface.

Checks:

- [x] `npm run format:check`
- [x] `npm test` (570 passed, 2 skipped, 1 todo — 39 files)
- [x] `npm run build`
- [ ] `npm run test:e2e` — could not run locally: the sandbox Playwright cache holds chromium build 1194 but `playwright@1.56.x` expects build 1200, and the environment has no network to `npx playwright install`. CI runs `npx playwright install --with-deps chromium` in `.github/workflows/ci.yml` and will execute the suite on this PR. The diff is presentational/CSS-only and does not touch any e2e-covered behaviour.

## Screenshot / GIF

_(Open the Vercel preview above on a mobile viewport and switch themes to see the Add pill recolour to brass / leather instead of pale lemon.)_

## Linear

Closes CUR-71

## Rollback plan

Green-tier presentational change. Revert with `git revert 55153da` or hand-revert the `bottomNavAddPill` map and the inline `${bottomNavAddPill}` substitution in `src/components/Layout.tsx`; remove the `Add button pill is theme-aware` describe block from `tests/components/Layout.test.tsx`.