### PR TITLE
[CUR-76] Clear bottom nav on Item Detail mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1789,7 +1789,7 @@ export const AppContent: React.FC = () => {
     return (
       <>
         <div
-          className={`max-w-4xl mx-auto rounded-[2rem] sm:rounded-[4rem] border overflow-hidden animate-in zoom-in-95 duration-500 mb-20 ${detailBaseClasses[theme]}`}
+          className={`max-w-4xl mx-auto rounded-[2rem] sm:rounded-[4rem] border overflow-hidden animate-in zoom-in-95 duration-500 mb-[calc(var(--bottom-nav-height,5.5rem)+env(safe-area-inset-bottom,0px))] sm:mb-20 ${detailBaseClasses[theme]}`}
           onAnimationEnd={(e) => {
             // Remove animation classes after animation ends to fix fixed positioning in children
             e.currentTarget.classList.remove('animate-in', 'zoom-in-95', 'duration-500');


### PR DESCRIPTION
## Problem

On Item Detail on mobile, the bottom of the card — including the Story migration banner's action buttons and the `_aiDescription` observation card — bleeds into the translucent bottom nav and is hard to read or tap. The card had a fixed `mb-20` (80px) that didn't account for the safe-area inset on notch / home-indicator phones, so the last few useful pixels of every detail card ended up under the nav's blurred backdrop.

Protects the **beauty before bureaucracy** and **trust before growth** principles: a core surface shouldn't visually clip its own controls.

## Approach

Match the same `calc(var(--bottom-nav-height) + env(safe-area-inset-bottom))` pattern already in use in `ExportModal.tsx:480` for sticky-footer clearance. Applied as `mb-[calc(...)]` on mobile with `sm:mb-20` retained for desktop, so the change is mobile-only.

```diff
- mb-20
+ mb-[calc(var(--bottom-nav-height,5.5rem)+env(safe-area-inset-bottom,0px))] sm:mb-20
```

Compiled CSS (verified in `dist/`):
```css
margin-bottom: calc(var(--bottom-nav-height,5.5rem) + env(safe-area-inset-bottom,0px))
```

## Why this approach

- Reuses the project's existing convention (`--bottom-nav-height` CSS var + `env(safe-area-inset-bottom)`) rather than introducing a new utility or magic number.
- Scoped to mobile via `sm:mb-20` so desktop spacing stays identical.
- One-line CSS-only change, no data flow or component structure touched.

## Risks

Low. CSS-only Tailwind arbitrary-value change on a single element. No behavior change on desktop. The new value is a strict superset of the old `mb-20` on mobile, so the only visible delta is more breathing room below the card.

## How to verify

Vercel Preview: _will populate when CI builds_

Steps:
1. Open an item with a long story / migration banner on a mobile viewport (e.g. Pixel/iPhone with a non-zero safe-area inset).
2. Scroll to the bottom of Item Detail.
3. Confirm the story migration banner's buttons (`Start fresh / Edit / Keep`), the AI observation `<details>`, and any other lower controls all sit fully above the bottom nav — not under its translucent backdrop.
4. Switch to a desktop viewport (≥ `sm`) and confirm spacing is unchanged from `main`.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (570 passed, 2 skipped, 1 todo)
- [x] `npm run build`
- [ ] `npm run test:e2e` — **could not run in this environment**: `npx playwright install chromium` is blocked by the network policy (`Host not in allowlist` for `playwright.download.prss.microsoft.com`). CI should run e2e normally.

## Screenshot / GIF

Reference (pre-fix, from issue): the story migration banner text and CTAs fading into the bottom nav.

## Linear

Closes CUR-76


---
_Generated by [Claude Code](https://claude.ai/code/session_01GccnpRp3hXYo9Q7FQhJ4pj)_