### PR TITLE
[CUR-74] Stop clipping long titles on export Minimal/Retro cards

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -336,7 +336,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
               </div>
               <div className="flex-shrink-0 w-full">
                 <h3
-                  className={`font-serif ${titleSize} font-bold text-stone-900 leading-tight mb-2 line-clamp-2`}
+                  className={`font-serif ${titleSize} font-bold text-stone-900 leading-tight mb-2 break-words`}
                 >
                   {item.title}
                 </h3>
@@ -394,13 +394,13 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
                 )}
               </div>
               <div className="flex-shrink-0 text-left">
-                <div className="flex justify-between items-end border-b-2 border-stone-800 pb-2 mb-3">
+                <div className="flex justify-between items-end gap-3 border-b-2 border-stone-800 pb-2 mb-3">
                   <h3
-                    className={`font-serif ${aspectRatio === '1:1' ? 'text-lg' : 'text-2xl'} font-bold text-stone-900 uppercase tracking-tighter line-clamp-2`}
+                    className={`font-serif ${aspectRatio === '1:1' ? 'text-lg' : 'text-2xl'} font-bold text-stone-900 uppercase tracking-tighter break-words min-w-0 flex-1`}
                   >
                     {item.title}
                   </h3>
-                  <span className="font-mono text-xs font-bold bg-stone-900 text-[#f4ebd9] px-1">
+                  <span className="font-mono text-xs font-bold bg-stone-900 text-[#f4ebd9] px-1 flex-shrink-0">
                     NO. {item.rating}
                   </span>
                 </div>

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../utils/test-utils';
+import { ExportModal } from '@/components/ExportModal';
+import type { CollectionItem, FieldDefinition } from '@/types';
+
+vi.mock('@/services/db', () => ({
+  extractCurioAssetPath: vi.fn().mockReturnValue(null),
+  getAsset: vi.fn().mockResolvedValue(null),
+  getEnhancedAsset: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('html-to-image', () => ({
+  toBlob: vi.fn().mockResolvedValue(new Blob(['fake'], { type: 'image/png' })),
+}));
+
+vi.mock('@/theme', async () => {
+  const actual = await vi.importActual('@/theme');
+  return {
+    ...actual,
+    useTheme: () => ({ theme: 'gallery', setTheme: vi.fn() }),
+  };
+});
+
+const LONG_TITLE = 'Karuna Pipa Barrel Aged Dark Chocolate 75%';
+
+const makeItem = (overrides: Partial<CollectionItem> = {}): CollectionItem => ({
+  id: 'item-1',
+  collectionId: 'col-1',
+  photoUrl: 'asset',
+  title: LONG_TITLE,
+  rating: 4,
+  data: {},
+  createdAt: new Date().toISOString(),
+  notes: '',
+  ...overrides,
+});
+
+const FIELDS: FieldDefinition[] = [];
+
+const findTitleHeading = () => {
+  const headings = screen.getAllByRole('heading', { level: 3, name: LONG_TITLE });
+  // The card preview renders exactly one <h3> for the active template.
+  expect(headings).toHaveLength(1);
+  return headings[0];
+};
+
+describe('ExportModal — CUR-74 long title rendering', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the full title without line-clamp on the Minimal template', () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+    // Minimal is the default template.
+    const heading = findTitleHeading();
+    expect(heading).toHaveTextContent(LONG_TITLE);
+    expect(heading.className).not.toMatch(/line-clamp-/);
+  });
+
+  it('renders the full title without line-clamp on the Retro template', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const user = userEvent.setup();
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    await user.click(screen.getByRole('button', { name: /retro/i }));
+
+    const heading = findTitleHeading();
+    expect(heading).toHaveTextContent(LONG_TITLE);
+    expect(heading.className).not.toMatch(/line-clamp-/);
+  });
+});


### PR DESCRIPTION
## Problem

Sharing is a core Curio surface, but two of the three export card templates hard-clamped the item title to two lines. A long title like "Karuna Pipa Barrel Aged Dark Chocolate 75%" was baked into the saved / shared image as **"Karuna Pipa Barrel Aged Dar…"** (see attachment on CUR-74). The full title is visible on Item Detail, only the exported/shared image misrepresents it.

This violates **Beauty before bureaucracy** and **Sharing before social complexity**: the share artifact has to be honest about what the user collected, otherwise the surface that's meant to make collectors proud quietly trims the thing they're proud of.

Root cause:
- `src/components/ExportModal.tsx` Minimal title: `... line-clamp-2`
- `src/components/ExportModal.tsx` Retro title: `... line-clamp-2`
- Full template was already unclamped.

## Approach

CSS-only on the two affected templates. No data flow or component structure changes.

- **Minimal**: drop `line-clamp-2`, add `break-words`. The image lives in a `flex-1 min-h-0` container above the title block, so the image shrinks to give the title room.
- **Retro**: drop `line-clamp-2`, add `break-words`. The title sits in a `flex justify-between items-end` row with a "NO. X" badge — give the heading `flex-1 min-w-0`, the badge `flex-shrink-0`, and the row `gap-3` so the title can wrap across multiple lines without pushing the badge off-card.
- **Full**: untouched (already unclamped).

## Why this approach

Smallest possible change that satisfies the acceptance criteria. Matches the existing flex-1 / min-h-0 pattern already used elsewhere in the card preview so the layout absorbs longer titles gracefully across 1:1, 3:4, and 9:16 aspect ratios. No new utilities, no font-fit JS, no template restructure.

## Risks

Low. Tailwind class swap on two `<h3>` elements plus three flex utilities on the Retro title row. No behavior change to Full. Worst case for an extremely long title (10+ words) is that the image area on Minimal/Retro shrinks more than before — still inside the card bounds — which is the intended trade-off per the issue's acceptance criteria.

## How to verify

Vercel Preview: https://curio-git-claude-curio-74-export-ca-6a64e3-qs-projects-72b20d9d.vercel.app

Steps:
1. Open an item with a long title (e.g. "Karuna Pipa Barrel Aged Dark Chocolate 75%").
2. Open the share/export sheet.
3. **Minimal**: confirm the title renders in full (no `…`) in the live preview and in the downloaded PNG; the card border doesn't overflow; the image area visibly shrinks to make room. Verify at 1:1, 3:4, and 9:16.
4. **Retro**: same, and confirm the "NO. X" badge stays inside the card next to the title even when the title wraps to 3 lines.
5. **Full**: confirm it looks identical to `main`.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (574 passed, 2 skipped, 1 todo — adds 2 new tests in `tests/components/ExportModal.test.tsx`)
- [x] `npm run build`
- [ ] `npm run test:e2e` — **could not run in this environment**: `npx playwright install chromium` is blocked by the network policy (`Host not in allowlist` for `cdn.playwright.dev` and `playwright.download.prss.microsoft.com`). Same situation as PR #243. CI runs e2e (`Format / Unit / Build / E2E` job on this commit).

## Screenshot / GIF

Reference (pre-fix, from the issue): the share card showing "Karuna Pipa Barrel Aged Dar…" with the title ellipsized after two lines.

## Linear

Closes CUR-74

## Rollback plan

Single commit; revert with `git revert <sha>`. No data, schema, or config changes.
