### PR TITLE
[CUR-82] Close CreateCollectionModal on Escape

### DIFF
--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -365,6 +365,21 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     }
   }, [step, isIconPickerOpen]);
 
+  // The icon-picker effect above owns Escape while the picker is open, so this
+  // top-level handler stays unregistered in that state to preserve picker-only dismissal.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (isIconPickerOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      handleClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, isIconPickerOpen]);
+
   if (!isOpen) return null;
 
   const renderEntry = () => (

--- a/tests/components/CreateCollectionModal.test.tsx
+++ b/tests/components/CreateCollectionModal.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { CreateCollectionModal } from '@/components/CreateCollectionModal';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+vi.mock('@/services/geminiService', () => ({
+  suggestCollectionFields: vi.fn().mockResolvedValue([]),
+}));
+
+describe('CreateCollectionModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onCreate: vi.fn().mockReturnValue(true),
+    onAddFirstItem: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+  });
+
+  describe('Escape key dismissal (CUR-82)', () => {
+    it('closes the modal when Escape is pressed on the entry step', async () => {
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      expect(screen.getByTestId('create-collection-modal')).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('closes only the icon picker (not the modal) when Escape fires while the picker is open', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      await user.click(screen.getByTestId('collection-icon-picker'));
+      // Picker opens an options grid.
+      expect(screen.getByRole('button', { name: '🎴' })).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: '🎴' })).not.toBeInTheDocument();
+      });
+
+      // Modal itself remains; onClose was not invoked.
+      expect(screen.getByTestId('create-collection-modal')).toBeInTheDocument();
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+
+      // Pressing Escape again now closes the modal.
+      fireEvent.keyDown(document, { key: 'Escape' });
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('does nothing when Escape fires while the modal is closed', () => {
+      renderWithProviders(<CreateCollectionModal {...defaultProps} isOpen={false} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(defaultProps.onClose).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`CreateCollectionModal` only registers an Escape handler inside the icon-picker effect (`src/components/CreateCollectionModal.tsx:339-359`), and that handler dismisses the picker — never the modal itself. The dialog wrapper at `:835` has no top-level Escape listener.

Keyboard-only users have no way to close the modal. If the AI-suggestion fetch hangs (15s timeout), they are visually trapped until they mouse-click the X. This violates the Esc-to-close pattern already used by `AddItemModal` and `AuthModal`.

Protects Curio's **trust before growth** principle: keyboard users should never feel stuck inside a dialog.

## Approach

Add a single top-level `useEffect` gated on `isOpen` that registers a document-level `keydown` listener for `Escape` and calls `handleClose()`. The effect is also gated on `!isIconPickerOpen` so it does not register while the icon picker is open — that effect retains exclusive ownership of Escape (and continues to dismiss only the picker).

Net change is 15 source lines plus a new focused test file.

## Why this approach

Smallest possible fix that satisfies all three acceptance criteria without touching unrelated logic. Re-gating on `isIconPickerOpen` (rather than checking inside the handler) means there is never a second handler registered while the picker is open, which preserves the picker's existing dismiss-only-the-picker behavior exactly. Mirrors the pattern in `AddItemModal.tsx:282-318` so future maintainers see a consistent shape across modals.

## Risks

Low. Single file, additive effect, no change to existing handlers. The icon-picker effect at `:339-359` is untouched. No state, sync, RLS, storage, or AI surface is touched.

Edge cases verified by tests:
- Escape on entry step → modal closes
- Escape while icon picker is open → picker closes, modal stays, `onClose` not called
- Escape after closing the picker → modal then closes
- Escape while `isOpen=false` → no-op

## How to verify

Vercel Preview: _populates when CI builds_

Steps:
1. Open Curio, tap **Create new collection** from Home.
2. Without opening the icon picker, press <kbd>Esc</kbd> → modal dismisses.
3. Reopen the modal, open the icon picker (`✨` button), press <kbd>Esc</kbd> → only the picker closes; the modal stays.
4. Press <kbd>Esc</kbd> again → modal dismisses.
5. Switch to **中文** and repeat — behavior is identical (no copy changes).

Checks:
- [x] `npm run format:check` — passes
- [x] `npm test` — **578 passed**, 2 skipped, 1 todo (3 new tests added)
- [x] `npm run build` — passes (vite 6.4.1, 1813 modules)
- [ ] `npm run test:e2e` — **could not run in this environment**: bundled Playwright Chromium binary is missing and `npx playwright install chromium` is blocked by the sandbox network allowlist (same pre-existing limitation called out in PRs #222, #223, #228, #231, #233, #236, #243, #246, #248, #250). CI's `Format / Unit / Build / E2E` job will run e2e against this commit.

## Screenshot / GIF

No visual change — pure keyboard-handler addition. Verifiable on the Vercel preview via the steps above.

## Linear

Closes CUR-82

## Rollback plan

Single commit; revert with:

```
git revert b0549c4
```

No schema, RLS, storage, feature flag, env var, or data changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp8Fuu8rWBB2YDNBm7UJQF)_