### PR TITLE
[CUR-78] Add Esc, role=dialog, and focus trap to 5 modals

### DIFF
--- a/src/components/DeleteCollectionModal.tsx
+++ b/src/components/DeleteCollectionModal.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { X, AlertTriangle } from 'lucide-react';
 import { UserCollection } from '../types';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses } from '../theme';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 interface DeleteCollectionModalProps {
   isOpen: boolean;
@@ -24,6 +25,10 @@ export const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: cancelRef });
+
   if (!isOpen || !collection) return null;
 
   return (
@@ -31,6 +36,10 @@ export const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
       className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-collection-modal-title"
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
         <div className="sm:hidden h-3" />
@@ -40,6 +49,7 @@ export const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
               <AlertTriangle size={18} />
             </div>
             <h2
+              id="delete-collection-modal-title"
               className={`font-serif font-bold text-lg ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}
             >
               {t('deleteCollectionTitle')}
@@ -67,7 +77,7 @@ export const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
         <div
           className={`px-6 py-4 border-t flex items-center justify-end gap-2 ${theme === 'vault' ? 'border-white/10 bg-white/5' : 'border-stone-100 bg-white'}`}
         >
-          <Button variant="ghost" onClick={onClose}>
+          <Button ref={cancelRef} variant="ghost" onClick={onClose}>
             {t('cancel')}
           </Button>
           <button

--- a/src/components/DeleteItemModal.tsx
+++ b/src/components/DeleteItemModal.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { X, AlertTriangle } from 'lucide-react';
 import { CollectionItem } from '../types';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses } from '../theme';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 interface DeleteItemModalProps {
   isOpen: boolean;
@@ -24,6 +25,10 @@ export const DeleteItemModal: React.FC<DeleteItemModalProps> = ({
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: cancelRef });
+
   if (!isOpen || !item) return null;
 
   return (
@@ -31,6 +36,10 @@ export const DeleteItemModal: React.FC<DeleteItemModalProps> = ({
       className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-item-modal-title"
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
         <div className="sm:hidden h-3" />
@@ -40,6 +49,7 @@ export const DeleteItemModal: React.FC<DeleteItemModalProps> = ({
               <AlertTriangle size={18} />
             </div>
             <h2
+              id="delete-item-modal-title"
               className={`font-serif font-bold text-lg ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}
             >
               {t('deleteItemTitle')}
@@ -65,7 +75,7 @@ export const DeleteItemModal: React.FC<DeleteItemModalProps> = ({
         <div
           className={`px-6 py-4 border-t flex items-center justify-end gap-2 ${theme === 'vault' ? 'border-white/10 bg-white/5' : 'border-stone-100 bg-white'}`}
         >
-          <Button variant="ghost" onClick={onClose}>
+          <Button ref={cancelRef} variant="ghost" onClick={onClose}>
             {t('cancel')}
           </Button>
           <button

--- a/src/components/DeleteItemsModal.tsx
+++ b/src/components/DeleteItemsModal.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { X, AlertTriangle } from 'lucide-react';
 import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses } from '../theme';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 interface DeleteItemsModalProps {
   isOpen: boolean;
@@ -23,6 +24,10 @@ export const DeleteItemsModal: React.FC<DeleteItemsModalProps> = ({
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: cancelRef });
+
   if (!isOpen) return null;
 
   return (
@@ -30,6 +35,10 @@ export const DeleteItemsModal: React.FC<DeleteItemsModalProps> = ({
       className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-items-modal-title"
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-md overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
         <div className="sm:hidden h-3" />
@@ -39,6 +48,7 @@ export const DeleteItemsModal: React.FC<DeleteItemsModalProps> = ({
               <AlertTriangle size={18} />
             </div>
             <h2
+              id="delete-items-modal-title"
               className={`font-serif font-bold text-lg ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}
             >
               {t('deleteItemsTitle')}
@@ -64,7 +74,7 @@ export const DeleteItemsModal: React.FC<DeleteItemsModalProps> = ({
         <div
           className={`px-6 py-4 border-t flex items-center justify-end gap-2 ${theme === 'vault' ? 'border-white/10 bg-white/5' : 'border-stone-100 bg-white'}`}
         >
-          <Button variant="ghost" onClick={onClose}>
+          <Button ref={cancelRef} variant="ghost" onClick={onClose}>
             {t('cancel')}
           </Button>
           <button

--- a/src/components/EnhanceImageModal.tsx
+++ b/src/components/EnhanceImageModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { X, Loader2, Sparkles, AlertCircle, Check, RotateCcw } from 'lucide-react';
 import { useTheme } from '../theme';
 import { useTranslation } from '../i18n';
+import { useModalA11y } from '../hooks/useModalA11y';
 import { EnhancementStrength } from '../types';
 import {
   enhanceImage,
@@ -69,6 +70,9 @@ export const EnhanceImageModal: React.FC<EnhanceImageModalProps> = ({
   const originalUrlRef = useRef<string | null>(null);
   const enhancedUrlRef = useRef<string | null>(null);
   const enhanceTimeoutRef = useRef<number | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useModalA11y(dialogRef, isOpen, onClose);
 
   // Check if AI image editing is enabled
   useEffect(() => {
@@ -287,6 +291,10 @@ export const EnhanceImageModal: React.FC<EnhanceImageModalProps> = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="enhance-image-modal-title"
         className={`relative w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-3xl shadow-2xl ${modalBg[theme]} ${textColor[theme]}`}
       >
         {/* Header */}
@@ -298,7 +306,9 @@ export const EnhanceImageModal: React.FC<EnhanceImageModalProps> = ({
               <Sparkles size={20} />
             </div>
             <div>
-              <h2 className="font-serif text-xl font-bold">{t('enhanceImage')}</h2>
+              <h2 id="enhance-image-modal-title" className="font-serif text-xl font-bold">
+                {t('enhanceImage')}
+              </h2>
               <p className={`text-sm ${mutedText[theme]}`}>{t('enhanceImageDesc')}</p>
             </div>
           </div>

--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { X, Filter, RotateCcw, ChevronDown } from 'lucide-react';
 import { FieldDefinition } from '../types';
 import { Button } from './ui/Button';
 import { useTranslation, getFieldTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 interface FilterModalProps {
   isOpen: boolean;
@@ -38,6 +39,9 @@ export const FilterModal: React.FC<FilterModalProps> = ({
     if (isOpen) setLocalFilters(activeFilters);
   }, [isOpen, activeFilters]);
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useModalA11y(dialogRef, isOpen, onClose);
+
   if (!isOpen) return null;
 
   const handleApply = () => {
@@ -58,6 +62,10 @@ export const FilterModal: React.FC<FilterModalProps> = ({
       className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="filter-modal-title"
         className={`${surfaceClass} rounded-t-[1.75rem] rounded-b-none sm:rounded-[1.75rem] shadow-2xl w-full max-w-lg h-[100dvh] sm:h-auto max-h-[100dvh] sm:max-h-[85vh] overflow-hidden flex flex-col motion-panel border pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] sm:pt-0 sm:pb-0`}
       >
         <div className="sm:hidden h-3" />
@@ -69,6 +77,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({
               <Filter size={18} />
             </div>
             <h2
+              id="filter-modal-title"
               className={`font-serif font-bold text-lg ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}
             >
               {t('filterCollection')}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,14 +6,10 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: React.ReactNode;
 }
 
-export const Button: React.FC<ButtonProps> = ({
-  children,
-  variant = 'primary',
-  size = 'md',
-  className = '',
-  icon,
-  ...props
-}) => {
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { children, variant = 'primary', size = 'md', className = '', icon, ...props },
+  ref,
+) {
   const baseStyles =
     'inline-flex items-center justify-center font-medium transition-all duration-200 ease-out focus:outline-none focus:ring-2 focus:ring-offset-1 rounded-full disabled:opacity-50 disabled:cursor-not-allowed motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 motion-safe:active:scale-[0.98]';
 
@@ -31,7 +27,11 @@ export const Button: React.FC<ButtonProps> = ({
   };
 
   return (
-    <button className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`} {...props}>
+    <button
+      ref={ref}
+      className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`}
+      {...props}
+    >
       {icon && (
         <span className="w-4 h-4 md:w-5 md:h-5 flex items-center justify-center shrink-0 [&>svg]:w-full [&>svg]:h-full">
           {icon}
@@ -40,4 +40,4 @@ export const Button: React.FC<ButtonProps> = ({
       {children}
     </button>
   );
-};
+});

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+interface UseModalA11yOptions {
+  /**
+   * Element to receive initial focus instead of the first focusable child.
+   * Use this on confirm-style modals (e.g. delete) so focus lands on the
+   * safe action, not the destructive primary.
+   */
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+/**
+ * Modal accessibility primitive: Escape-to-close, focus trap inside the
+ * dialog, initial focus, and focus restore on dismiss. Mirrors the pattern
+ * in AuthModal/AddItemModal so all dialogs feel the same to keyboard and
+ * screen-reader users.
+ */
+export function useModalA11y(
+  dialogRef: React.RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose: () => void,
+  options: UseModalA11yOptions = {},
+): void {
+  const { initialFocusRef } = options;
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    lastFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const focusTarget = initialFocusRef?.current;
+    const dialog = dialogRef.current;
+    const frameId = requestAnimationFrame(() => {
+      if (focusTarget) {
+        focusTarget.focus();
+        return;
+      }
+      const firstFocusable = dialog?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      firstFocusable?.focus();
+    });
+
+    const getFocusable = () => {
+      const el = dialogRef.current;
+      if (!el) return [] as HTMLElement[];
+      return Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (n) => n.offsetParent !== null,
+      );
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+
+      const active = document.activeElement as HTMLElement | null;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const isInside = active ? focusable.includes(active) : false;
+
+      if (!isInside) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (e.shiftKey) {
+        if (!active || active === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      cancelAnimationFrame(frameId);
+      document.removeEventListener('keydown', onKeyDown);
+      lastFocusedElementRef.current?.focus?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, onClose]);
+}

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -26,6 +26,13 @@ export function useModalA11y(
 ): void {
   const { initialFocusRef } = options;
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  // Inline onClose handlers from parents change identity every render. Holding
+  // the latest in a ref lets the focus-trap effect depend only on `isOpen`,
+  // so parent rerenders don't tear down listeners or steal focus back.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -58,7 +65,7 @@ export function useModalA11y(
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
 
@@ -95,5 +102,5 @@ export function useModalA11y(
       lastFocusedElementRef.current?.focus?.();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, onClose]);
+  }, [isOpen]);
 }

--- a/tests/components/DeleteCollectionModal.test.tsx
+++ b/tests/components/DeleteCollectionModal.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders, setMockTheme } from '../utils/test-utils';
 import { DeleteCollectionModal } from '@/components/DeleteCollectionModal';
@@ -63,5 +63,32 @@ describe('DeleteCollectionModal', () => {
 
     await user.click(screen.getByRole('button', { name: /delete collection/i }));
     expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  describe('accessibility (CUR-78)', () => {
+    it('renders as a labelled dialog', () => {
+      renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby');
+    });
+
+    it('closes on Escape', async () => {
+      renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('lands initial focus on Cancel (safe action), not Delete', async () => {
+      renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: /cancel/i }));
+      });
+    });
   });
 });

--- a/tests/components/DeleteItemModal.test.tsx
+++ b/tests/components/DeleteItemModal.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders, setMockTheme } from '../utils/test-utils';
 import { DeleteItemModal } from '@/components/DeleteItemModal';
@@ -59,5 +59,32 @@ describe('DeleteItemModal', () => {
 
     await user.click(screen.getByRole('button', { name: /delete item/i }));
     expect(defaultProps.onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  describe('accessibility (CUR-78)', () => {
+    it('renders as a labelled dialog', () => {
+      renderWithProviders(<DeleteItemModal {...defaultProps} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby');
+    });
+
+    it('closes on Escape', async () => {
+      renderWithProviders(<DeleteItemModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('lands initial focus on Cancel (safe action), not Delete', async () => {
+      renderWithProviders(<DeleteItemModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: /cancel/i }));
+      });
+    });
   });
 });

--- a/tests/components/DeleteItemsModal.test.tsx
+++ b/tests/components/DeleteItemsModal.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { DeleteItemsModal } from '@/components/DeleteItemsModal';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+describe('DeleteItemsModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    count: 3,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(<DeleteItemsModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  describe('accessibility (CUR-78)', () => {
+    it('renders as a labelled dialog', () => {
+      renderWithProviders(<DeleteItemsModal {...defaultProps} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby');
+    });
+
+    it('closes on Escape', async () => {
+      renderWithProviders(<DeleteItemsModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('lands initial focus on Cancel (safe action), not Delete', async () => {
+      renderWithProviders(<DeleteItemsModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: /cancel/i }));
+      });
+    });
+  });
+});

--- a/tests/components/FilterModal.test.tsx
+++ b/tests/components/FilterModal.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { FilterModal } from '@/components/FilterModal';
+import { FieldDefinition } from '@/types';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+describe('FilterModal', () => {
+  const fields: FieldDefinition[] = [
+    { id: 'artist', label: 'Artist', type: 'text', displayMode: 'primary' },
+    { id: 'year', label: 'Year', type: 'number', displayMode: 'badge' },
+  ];
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    fields,
+    activeFilters: {},
+    onApply: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(<FilterModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  describe('accessibility (CUR-78)', () => {
+    it('renders as a labelled dialog', () => {
+      renderWithProviders(<FilterModal {...defaultProps} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby');
+    });
+
+    it('closes on Escape', async () => {
+      renderWithProviders(<FilterModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/tests/hooks/useModalA11y.test.tsx
+++ b/tests/hooks/useModalA11y.test.tsx
@@ -99,4 +99,45 @@ describe('useModalA11y', () => {
 
     expect(document.activeElement).toBe(screen.getByTestId('confirm'));
   });
+
+  it('does not restore focus when a fresh inline onClose causes a rerender', async () => {
+    // Regression for the Codex P2 review: parents typically pass
+    // `onClose={() => setOpen(false)}`, which changes identity every render.
+    // The cleanup must NOT fire on those rerenders, or focus jumps back to
+    // the trigger and the trap breaks.
+    function Outer() {
+      const [, force] = React.useState(0);
+      return (
+        <>
+          <button data-testid="outside" onClick={() => force((n) => n + 1)}>
+            rerender
+          </button>
+          <Harness isOpen={true} onClose={() => {}} />
+        </>
+      );
+    }
+
+    render(<Outer />);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const first = screen.getByTestId('first');
+    expect(document.activeElement).toBe(first);
+
+    // Force a parent rerender while the modal is still open. The cleanup
+    // must not run, so focus must stay inside the dialog.
+    fireEvent.click(screen.getByTestId('outside'));
+
+    expect(document.activeElement).toBe(first);
+
+    // Escape still calls the latest onClose because we read through a ref.
+    const latestOnClose = vi.fn();
+    function OuterWithLatest() {
+      return <Harness isOpen={true} onClose={latestOnClose} />;
+    }
+    cleanup();
+    render(<OuterWithLatest />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(latestOnClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/hooks/useModalA11y.test.tsx
+++ b/tests/hooks/useModalA11y.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, screen, cleanup } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { useModalA11y } from '@/hooks/useModalA11y';
+
+function Harness({
+  isOpen,
+  onClose,
+  useInitialFocus = false,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  useInitialFocus?: boolean;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  useModalA11y(dialogRef, isOpen, onClose, {
+    initialFocusRef: useInitialFocus ? cancelRef : undefined,
+  });
+
+  if (!isOpen) return null;
+  return (
+    <div ref={dialogRef} role="dialog" aria-modal="true" data-testid="dialog">
+      <button data-testid="first">first</button>
+      <button ref={cancelRef} data-testid="cancel">
+        cancel
+      </button>
+      <button data-testid="confirm">confirm</button>
+    </div>
+  );
+}
+
+describe('useModalA11y', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not bind Escape when closed', () => {
+    const onClose = vi.fn();
+    render(<Harness isOpen={false} onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose on Escape when open', () => {
+    const onClose = vi.fn();
+    render(<Harness isOpen={true} onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('focuses the first focusable element by default', async () => {
+    const onClose = vi.fn();
+    render(<Harness isOpen={true} onClose={onClose} />);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(document.activeElement).toBe(screen.getByTestId('first'));
+  });
+
+  it('focuses initialFocusRef when provided (safe action on confirm modals)', async () => {
+    const onClose = vi.fn();
+    render(<Harness isOpen={true} onClose={onClose} useInitialFocus />);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(document.activeElement).toBe(screen.getByTestId('cancel'));
+  });
+
+  it('wraps focus from last to first on Tab', () => {
+    const onClose = vi.fn();
+    render(<Harness isOpen={true} onClose={onClose} />);
+
+    const last = screen.getByTestId('confirm');
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(document, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(screen.getByTestId('first'));
+  });
+
+  it('wraps focus from first to last on Shift+Tab', () => {
+    const onClose = vi.fn();
+    render(<Harness isOpen={true} onClose={onClose} />);
+
+    const first = screen.getByTestId('first');
+    first.focus();
+
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByTestId('confirm'));
+  });
+});


### PR DESCRIPTION
## Problem

`FilterModal`, `DeleteCollectionModal`, `DeleteItemModal`, `DeleteItemsModal`, and `EnhanceImageModal` shipped without the dialog accessibility pattern already used by `AddItemModal` and `AuthModal`. Keyboard-only users could not dismiss them with Escape, focus could escape into the page behind them, and screen readers did not announce the surfaces as dialogs. The Delete\* modals were the worst case: a keyboard user staring down a destructive confirmation had no way to cancel without grabbing the mouse, and the destructive button was as easy to land on as the safe one.

This protects Curio's "Trust before growth" principle — destructive surfaces have to be safe to back out of, on every input modality.

## Approach

- Extracted the Escape + focus-trap + focus-restore pattern from `AuthModal` into a single `useModalA11y(dialogRef, isOpen, onClose, opts?)` hook in `src/hooks/useModalA11y.ts`. `opts.initialFocusRef` lets callers pick the safe initial target (used by the Delete\* modals to land focus on Cancel).
- Wired the hook into all five modals and added `role="dialog" aria-modal="true" aria-labelledby="..."` with stable heading ids.
- Promoted the shared `Button` component to `forwardRef` so the Delete\* modals can target their existing ghost Cancel button directly.

`AddItemModal`, `AuthModal`, and `CreateCollectionModal` already had their own dialog patterns and were intentionally left untouched to keep the diff small and avoid behavior drift in the larger flows.

## Why this approach

Mirroring `AuthModal`'s pattern (rather than introducing a focus-trap dependency) keeps the surface area tiny and matches what AddItemModal/AuthModal/CreateCollectionModal already feel like to a user. The hook is small and unit-tested, so the next modal that needs the same treatment is one import away.

## Risks

Low. The hook only attaches listeners while `isOpen` is true, restores focus on close, and the Delete\* `initialFocusRef` targets a button that already existed in the DOM. The Button forwardRef change is additive — existing callers that don't pass a ref are unaffected. No data, sync, RLS, or AI behavior was touched.

## How to verify

Vercel Preview: (auto-published by Vercel on PR open — link will appear in the PR checks)

Steps:
1. Open a collection in the sample gallery or your own. Click the Filter button, then press <kbd>Esc</kbd> — the FilterModal closes. Tab cycles within the modal.
2. Open the overflow on a collection card and choose Delete. Notice the Cancel button starts focused. Press <kbd>Esc</kbd> — the modal closes without confirming.
3. Same for DeleteItemModal (from an item in your own collection) and DeleteItemsModal (multi-select → delete).
4. Open the Enhance Image modal on an item with a photo. <kbd>Esc</kbd> closes it; Tab cycles inside.
5. Sanity-check AddItemModal, AuthModal, CreateCollectionModal still work — they were not touched.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (45 files, 602 passed)
- [x] `npm run build`
- [ ] `npm run test:e2e` — **not run**: this remote execution environment's network policy blocks the Playwright browser CDN (`cdn.playwright.dev` 403 "Host not in allowlist"), so `npx playwright install chromium` cannot fetch the binary. The Vitest suite covers the new behavior at the unit level, and the existing e2e `accessibility.spec.ts` keyboard/focus assertions should continue to pass on CI.

## Screenshot / GIF

No visual changes — pure a11y wiring. Visible state on screen is identical before/after.

## Linear

Closes CURIO-78

## Rollback plan

Single-commit revert:

```
git revert <commit-sha-of-this-PR-merge>
```

The hook file (`src/hooks/useModalA11y.ts`) is the only new runtime entry point; reverting the modal imports restores the prior behavior. No migrations, no env vars, no schema changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KxbxK9fFR48LYnCUK3nXG9)_