### PR TITLE
[CUR-83] Demote ExportModal Print CTA so Save image leads

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -131,19 +131,6 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     };
   }, [isOpen, item.id, item.collectionId, item.photoEnhancedPath, remoteAssetPath, directPhotoUrl]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    if (import.meta.env.DEV) {
-      setTimeout(() => {
-        const modal = document.querySelector('[data-export-modal]') as HTMLElement;
-        if (modal) {
-          const rect = modal.getBoundingClientRect();
-          console.log('Modal position check:', rect);
-        }
-      }, 600);
-    }
-  }, [isOpen]);
-
   const renderCardToBlob = useCallback(async (): Promise<Blob | null> => {
     const node = cardRef.current;
     if (!node) return null;
@@ -453,7 +440,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
       )}
       <div
         ref={sheetRef}
-        className={`absolute inset-x-0 bottom-0 md:absolute md:top-0 md:left-auto md:inset-x-auto md:right-0 md:w-96 md:!h-full min-h-0 overflow-hidden bg-white rounded-t-3xl md:rounded-none shadow-2xl flex flex-col z-10 print:hidden [--export-footer-height:8.5rem] md:[--export-footer-height:9.5rem] ${isDragging ? '' : 'transition-[height] duration-300 ease-out'}`}
+        className={`absolute inset-x-0 bottom-0 md:absolute md:top-0 md:left-auto md:inset-x-auto md:right-0 md:w-96 md:!h-full min-h-0 overflow-hidden bg-white rounded-t-3xl md:rounded-none shadow-2xl flex flex-col z-10 print:hidden [--export-footer-height:11.5rem] md:[--export-footer-height:12.5rem] ${isDragging ? '' : 'transition-[height] duration-300 ease-out'}`}
         style={{ height: mobileSheetHeight }}
       >
         <div
@@ -561,30 +548,30 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
           >
             {exportAction === 'save' ? t('saving') : t('saveImage')}
           </Button>
-          <div className="flex gap-2">
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={handleShare}
+            disabled={exportAction !== null || isLoadingImage}
+            icon={
+              exportAction === 'share' ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Share2 size={16} />
+              )
+            }
+          >
+            {exportAction === 'share' ? t('sharing') : t('share')}
+          </Button>
+          <div className="flex justify-center">
             <Button
-              variant="outline"
-              className="flex-1"
+              variant="ghost"
+              size="sm"
               onClick={() => window.print()}
               disabled={exportAction !== null}
-              icon={<Printer size={16} />}
+              icon={<Printer size={14} />}
             >
               {t('print')}
-            </Button>
-            <Button
-              variant="outline"
-              className="flex-1"
-              onClick={handleShare}
-              disabled={exportAction !== null || isLoadingImage}
-              icon={
-                exportAction === 'share' ? (
-                  <Loader2 size={16} className="animate-spin" />
-                ) : (
-                  <Share2 size={16} />
-                )
-              }
-            >
-              {exportAction === 'share' ? t('sharing') : t('share')}
             </Button>
           </div>
         </div>

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -77,3 +77,52 @@ describe('ExportModal — CUR-74 long title rendering', () => {
     expect(heading.className).not.toMatch(/line-clamp-/);
   });
 });
+
+describe('ExportModal — CUR-83 footer CTA hierarchy', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('demotes Print below Save image and Share so it stops competing on mobile', () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    const save = screen.getByRole('button', { name: /save image/i });
+    const share = screen.getByRole('button', { name: /^share$/i });
+    const print = screen.getByRole('button', { name: /^print$/i });
+
+    // Visual hierarchy: Save (lg primary) > Share (md outline) > Print (sm ghost).
+    // Save keeps the dominant stone-800 surface, Share keeps an outline border,
+    // and Print drops the outline border + shrinks so it reads as a quiet
+    // tertiary action.
+    expect(save.className).toMatch(/bg-stone-800/);
+    expect(save.className).toMatch(/text-base/);
+
+    expect(share.className).toMatch(/border-stone-300/);
+    expect(share.className).toMatch(/text-sm/);
+
+    expect(print.className).not.toMatch(/border-stone-300/);
+    expect(print.className).toMatch(/text-xs/);
+  });
+
+  it('Print still triggers window.print()', async () => {
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const user = userEvent.setup();
+    const printSpy = vi.fn();
+    const originalPrint = window.print;
+    window.print = printSpy;
+    try {
+      renderWithProviders(<ExportModal {...baseProps} />);
+      await user.click(screen.getByRole('button', { name: /^print$/i }));
+      expect(printSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      window.print = originalPrint;
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`ExportModal` rendered three CTAs of competing visual weight in its footer: `Save image` (primary), `Print`, and `Share` (both outline buttons of equal width and weight). On a small mobile sheet this was three near-equal actions, which violates the "Single-path first run" / "Beauty before bureaucracy" principles — first-time exporters could not tell which action was the intended one, and Print is rarely the desired action on a phone.

There was also a dev-only `setTimeout` + `console.log('Modal position check', rect)` firing on every `isOpen` flip. It was gated to `import.meta.env.DEV` so prod was unaffected, but it was noisy debug cruft.

## Approach

- Restack the footer into a clear three-tier hierarchy:
  - **Save image** — `lg` primary (`bg-stone-800`), full-width — unchanged
  - **Share** — `md` outline, full-width on its own row (no longer sharing weight with Print)
  - **Print** — `sm` ghost, centered text link below the primaries
- Bump `--export-footer-height` (8.5rem → 11.5rem mobile, 9.5rem → 12.5rem desktop) so the scroll content above still clears the taller stacked footer.
- Drop the dev-only `setTimeout` console.log.

Two regression tests:
- Visual hierarchy: Save keeps the `bg-stone-800` primary surface, Share keeps the `border-stone-300` outline, Print drops the outline border + shrinks to `text-xs`. Asserted by class signature so behavior, not pixels.
- `Print` still calls `window.print()` after the demotion.

## Why this approach

Demoting Print to a ghost text link is the smallest change that solves the "three equal CTAs" problem without introducing a new overflow-menu pattern or hiding Print behind a `…` button (which would need a new menu primitive). The hierarchy now matches how users actually weigh these on mobile: Save and Share are real choices, Print is a quiet escape hatch for desktop. Stacking all three vertically is consistent with how AddItemModal and other Curio sheets stack their footer actions.

## Risks

Low. Pure presentational change on one modal footer. No data, sync, RLS, auth, AI, or routing touched. The footer-height variable bump is needed only because the new stacked layout is taller; the scroll-area padding tracks the same variable so content still clears. All three actions still wired to the same handlers and the same i18n strings (`saveImage` / `share` / `print` / `saving` / `sharing` — both EN and ZH).

## How to verify

Vercel Preview: auto-published by Vercel on PR open (link appears in PR checks).

Steps:
1. Open any item detail (sample gallery or your own).
2. Tap the export action — the modal opens.
3. On a mobile-width viewport (≤768px), observe:
   - Save image dominates as the primary CTA.
   - Share is a full-width outline below it.
   - Print is a small, quiet ghost link, no longer competing with Share.
4. Tap each in turn — all three still work (save downloads, share opens the share sheet / falls back to download, print opens the print dialog).
5. Sanity check on desktop (≥768px) — same hierarchy, slightly more breathing room.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (42 files, 585 passed, 2 skipped, 1 todo)
- [x] `npm run build`
- [ ] `npm run test:e2e` — **not run**: this remote execution environment's network policy blocks the Playwright browser CDN, so `npx playwright install chromium` cannot fetch the binary (same constraint as #253). The new Vitest cases cover the hierarchy at the unit level; the existing e2e `first-time-user.spec.ts:103` (open export modal from item detail) should continue to pass on CI.

## Screenshot / GIF

Pure layout change on the export modal footer. The visible CTAs go from `[Save image] / [Print | Share]` to `[Save image] / [Share] / Print`. Vercel Preview will render the live diff.

## Linear

Closes CURIO-83

## Rollback plan

Single-commit revert:

```
git revert <commit-sha-of-this-PR-merge>
```

No migrations, env vars, schema, or feature flag changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017q4Z5WXxRkKDrvivnEaEQ7)_