### PR TITLE
[CUR-81] Make StatusBanner tone styles theme-aware

### DIFF
--- a/src/components/StatusBanner.tsx
+++ b/src/components/StatusBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertCircle, Info, AlertTriangle, CheckCircle } from 'lucide-react';
 import { useTheme } from '../theme';
+import { AppTheme } from '../types';
 
 export type BannerTone = 'info' | 'warning' | 'error' | 'success';
 
@@ -12,34 +13,44 @@ interface StatusBannerProps {
   onAction?: () => void;
 }
 
-const toneStyles: Record<
-  BannerTone,
-  { bg: string; text: string; border: string; Icon: React.ComponentType<any> }
-> = {
+// Each tone keeps its semantic hue across themes, with luminance tuned so
+// the banner remains distinct from the surface beneath it (white in Gallery,
+// near-black in Vault, warm cream in Atelier) — sync feedback is one of the
+// few surfaces where users need an at-a-glance signal.
+const toneSurfaceClasses: Record<BannerTone, Record<AppTheme, string>> = {
   info: {
-    bg: 'bg-stone-50',
-    text: 'text-stone-700',
-    border: 'border-stone-200',
-    Icon: Info,
+    gallery: 'bg-stone-50 text-stone-700 border-stone-200',
+    vault: 'bg-white/5 text-stone-300 border-white/10',
+    atelier: 'bg-[#EDE4D3] text-[#3D3530] border-[#D4C9B8]',
   },
   warning: {
-    bg: 'bg-amber-50',
-    text: 'text-amber-800',
-    border: 'border-amber-200',
-    Icon: AlertTriangle,
+    gallery: 'bg-amber-50 text-amber-800 border-amber-200',
+    vault: 'bg-amber-500/10 text-amber-200 border-amber-400/20',
+    atelier: 'bg-amber-100/70 text-amber-900 border-amber-300/60',
   },
   error: {
-    bg: 'bg-red-50',
-    text: 'text-red-700',
-    border: 'border-red-200',
-    Icon: AlertCircle,
+    gallery: 'bg-red-50 text-red-700 border-red-200',
+    vault: 'bg-red-500/10 text-red-300 border-red-400/30',
+    atelier: 'bg-red-100/70 text-red-800 border-red-300/60',
   },
   success: {
-    bg: 'bg-emerald-50',
-    text: 'text-emerald-700',
-    border: 'border-emerald-200',
-    Icon: CheckCircle,
+    gallery: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    vault: 'bg-emerald-500/10 text-emerald-300 border-emerald-400/30',
+    atelier: 'bg-emerald-100/70 text-emerald-800 border-emerald-300/60',
   },
+};
+
+const toneIcons: Record<BannerTone, React.ComponentType<{ size?: number }>> = {
+  info: Info,
+  warning: AlertTriangle,
+  error: AlertCircle,
+  success: CheckCircle,
+};
+
+const actionClasses: Record<AppTheme, string> = {
+  gallery: 'text-amber-700 hover:text-amber-900',
+  vault: 'text-amber-200 hover:text-amber-100',
+  atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]',
 };
 
 export const StatusBanner: React.FC<StatusBannerProps> = ({
@@ -50,16 +61,12 @@ export const StatusBanner: React.FC<StatusBannerProps> = ({
   onAction,
 }) => {
   const { theme } = useTheme();
-  const { bg, text, border, Icon } = toneStyles[tone];
-  const vaultSurface = theme === 'vault' ? 'bg-white/5 text-white/80 border-white/10' : '';
-  const actionClass =
-    theme === 'vault'
-      ? 'text-amber-200 hover:text-amber-100'
-      : 'text-amber-700 hover:text-amber-900';
+  const surface = toneSurfaceClasses[tone][theme];
+  const Icon = toneIcons[tone];
 
   return (
     <div
-      className={`rounded-2xl border px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-3 shadow-sm ${bg} ${text} ${border} ${vaultSurface}`}
+      className={`rounded-2xl border px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-3 shadow-sm ${surface}`}
       role="status"
       aria-live="polite"
     >
@@ -71,7 +78,7 @@ export const StatusBanner: React.FC<StatusBannerProps> = ({
       {actionLabel && onAction && (
         <button
           onClick={onAction}
-          className={`text-xs font-bold uppercase tracking-[0.12em] ${actionClass}`}
+          className={`text-xs font-bold uppercase tracking-[0.12em] ${actionClasses[theme]}`}
         >
           {actionLabel}
         </button>

--- a/tests/components/StatusBanner.test.tsx
+++ b/tests/components/StatusBanner.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * StatusBanner Component Tests
+ *
+ * Sync feedback is one of the highest-trust surfaces in Curio; this suite
+ * locks in that each tone keeps its semantic hue across the three themes.
+ * Previously every tone collapsed to a neutral surface in Vault and the
+ * light-mode hues clashed with the cream background in Atelier (CUR-81).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, setMockTheme, createThemeMock } from '../utils/test-utils';
+import { StatusBanner, BannerTone } from '@/components/StatusBanner';
+import { AppTheme } from '@/types';
+
+// Use the centralized configurable theme mock so we can flip themes per test.
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+const getBanner = () => screen.getByRole('status');
+
+describe('StatusBanner', () => {
+  beforeEach(() => {
+    setMockTheme('gallery');
+  });
+
+  describe('rendering and accessibility', () => {
+    it('renders title and message with status role', () => {
+      renderWithProviders(<StatusBanner title="Saved" message="Synced to cloud" />);
+      const banner = getBanner();
+      expect(banner).toHaveAttribute('aria-live', 'polite');
+      expect(banner).toHaveTextContent('Saved');
+      expect(banner).toHaveTextContent('Synced to cloud');
+    });
+
+    it('renders an optional action button and invokes the handler', async () => {
+      const onAction = vi.fn();
+      const userEvent = (await import('@testing-library/user-event')).default;
+      const user = userEvent.setup();
+      renderWithProviders(
+        <StatusBanner
+          title="Sync issue"
+          message="We could not reach the cloud"
+          tone="error"
+          actionLabel="Retry"
+          onAction={onAction}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: /retry/i }));
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('theme-aware tone surfaces (CUR-81)', () => {
+    // Each entry: [tone, theme, expected class fragments that prove the tone
+    // kept its semantic hue on that theme's surface].
+    const cases: Array<[BannerTone, AppTheme, string[]]> = [
+      ['error', 'gallery', ['bg-red-50', 'text-red-700', 'border-red-200']],
+      ['error', 'vault', ['bg-red-500/10', 'text-red-300']],
+      ['error', 'atelier', ['bg-red-100/70', 'text-red-800']],
+      ['warning', 'gallery', ['bg-amber-50', 'text-amber-800', 'border-amber-200']],
+      ['warning', 'vault', ['bg-amber-500/10', 'text-amber-200']],
+      ['warning', 'atelier', ['bg-amber-100/70', 'text-amber-900']],
+      ['success', 'gallery', ['bg-emerald-50', 'text-emerald-700', 'border-emerald-200']],
+      ['success', 'vault', ['bg-emerald-500/10', 'text-emerald-300']],
+      ['success', 'atelier', ['bg-emerald-100/70', 'text-emerald-800']],
+      ['info', 'gallery', ['bg-stone-50', 'text-stone-700']],
+      ['info', 'vault', ['bg-white/5', 'text-stone-300']],
+      ['info', 'atelier', ['bg-[#EDE4D3]', 'text-[#3D3530]']],
+    ];
+
+    it.each(cases)('%s tone uses theme-appropriate classes in %s', (tone, theme, fragments) => {
+      setMockTheme(theme);
+      renderWithProviders(<StatusBanner title="T" message="M" tone={tone} />);
+      const banner = getBanner();
+      for (const fragment of fragments) {
+        expect(banner).toHaveClass(fragment);
+      }
+    });
+
+    it('does not collapse non-info tones to a neutral surface in Vault', () => {
+      setMockTheme('vault');
+      renderWithProviders(<StatusBanner title="Sync failed" message="Retry needed" tone="error" />);
+      const banner = getBanner();
+      // The pre-fix bug applied bg-white/5 to every tone in Vault, erasing the
+      // semantic red. Guard against that regression explicitly.
+      expect(banner).not.toHaveClass('bg-white/5');
+      expect(banner.className).toMatch(/bg-red-/);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`StatusBanner` (`src/components/StatusBanner.tsx`) defined per-tone styles (`info`, `warning`, `error`, `success`) using hardcoded light-mode tokens like `bg-red-50` / `bg-amber-50` / `bg-emerald-50`. The only theme branch was a single `vaultSurface = 'bg-white/5 text-white/80 border-white/10'` that overrode **every** tone in Vault — so a sync **error** banner was no longer red, an offline **warning** banner was no longer amber, and "saved/synced" success cues were no longer emerald. In Atelier (cream), the untouched light-mode hues either disappeared into the warm background or clashed with it.

This affects exactly the surfaces where trust matters most — sync feedback at the top of the page (sample mode, env config missing, conflict, sync error, offline, pending uploads). It directly undercuts the "Trust before growth" product principle in `docs/PRODUCT_STRATEGY.md`: a user staring at a sync error in Vault couldn't tell at a glance that something was wrong.

## Approach

- Replace the flat `toneStyles` map with `toneSurfaceClasses: Record<BannerTone, Record<AppTheme, string>>`, modeled on `cardSurfaceClasses` in `src/theme.tsx` (the same shape the issue recommended and that CUR-59 / #222 used).
- Remove the blanket `vaultSurface` override.
- Each tone keeps its semantic hue across all three themes, with luminance tuned to the surface beneath it: opaque washes in Gallery, semi-transparent tinted backgrounds with lighter foreground text in Vault, slightly desaturated warm tints in Atelier.
- Extend `actionClasses` to cover Atelier (previously only branched Vault vs everything-else; Atelier inherited Gallery's amber-700 against a cream surface).
- Move `toneIcons` to a separate map — same intent as before, just no longer entangled with the surface styles.

## Why this approach

Mirrors the existing `Record<Theme, ...>` pattern already used across `theme.tsx` and the CUR-59 access-gate fix, so the next person editing tone styling won't have to learn a new pattern. The diff is intentionally surface-only — no API change, no consumer change, no new dependency, no design-token change.

## Risks

Low. Pure Tailwind class rewiring on a single presentational component. The component's public API (`title`, `message`, `tone`, `actionLabel`, `onAction`) is unchanged. No data, sync, RLS, AI, or routing behavior is touched. Gallery rendering is byte-equivalent to the previous theme since the original light-mode tokens were preserved as the Gallery branch.

## How to verify

Vercel Preview: (auto-published on PR open — link appears in PR checks)

Steps:
1. With the Vault theme selected, trigger any non-info banner (the simplest: temporarily render `<StatusBanner tone="error" title="x" message="y" />`, or wait for a sync error). It should read as red, not generic dark neutral.
2. Repeat with `tone="warning"` (amber tint) and `tone="success"` (emerald tint).
3. Switch to Atelier. Tones should sit comfortably on the cream surface — no white wash, no harsh clash.
4. Switch to Gallery. Banners should look identical to before the change.
5. Sanity-check the action button color in each theme: amber-700/900 in Gallery, amber-200/100 in Vault, leather-brown (`#A86F3C` / `#8B5A2B`) in Atelier.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (43 files, 600 passed, 2 skipped, 1 todo — including 15 new `StatusBanner` tests)
- [x] `npm run build`
- [ ] `npm run test:e2e` — **not run** in this remote execution environment: the network policy blocks the Playwright browser CDN (`cdn.playwright.dev` returns 403 "Host not in allowlist"), so `npx playwright install chromium` cannot fetch the v1200 binary required by `@playwright/test ^1.57.0`. Same constraint documented in PR #253. The new Vitest suite covers every tone × theme combination at the unit level, and no e2e spec asserts against the StatusBanner palette.

## Screenshot / GIF

Vault `tone="error"` and Atelier `tone="success"` are the most visible deltas; I recommend reviewing the Vercel preview on those two surfaces.

## Linear

Closes CURIO-81

## Rollback plan

Single-commit revert:

```
git revert 09afdfe
```

No migrations, no env vars, no schema or RLS changes — the revert restores the prior single-map `toneStyles` and the `vaultSurface` override exactly as they were.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAQeer9hTCMWEc6ogtJnQ9)_