### PR TITLE
[CUR-89] Add autoComplete hints to AuthModal email/password inputs

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -366,7 +366,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                       disabled={loading}
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
-                      autoComplete={mode === 'signup' ? 'email' : 'username'}
+                      autoComplete="username"
                       inputMode="email"
                       className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                       placeholder={t('emailPlaceholder')}

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -366,6 +366,8 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                       disabled={loading}
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
+                      autoComplete={mode === 'signup' ? 'email' : 'username'}
+                      inputMode="email"
                       className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                       placeholder={t('emailPlaceholder')}
                     />
@@ -405,6 +407,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                       disabled={loading}
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
+                      autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
                       className={`w-full pl-11 pr-4 py-3.5 rounded-2xl focus:ring-4 focus:ring-amber-500/5 focus:border-amber-200 outline-none font-medium transition-all disabled:opacity-60 disabled:cursor-not-allowed ${inputSurface}`}
                       placeholder="••••••••"
                     />


### PR DESCRIPTION
## Summary

Adds the missing `autoComplete` hints (and `inputMode="email"`) to the sign-in and sign-up email/password fields in `AuthModal`. The `set-password` mode already had `autoComplete="new-password"`; the same convention is now applied to the sign-in / sign-up / reset-request inputs.

- email: `'email'` on sign-up, `'username'` on sign-in / reset-request
- password: `'current-password'` on sign-in, `'new-password'` on sign-up
- `inputMode="email"` on the email field for a better mobile keyboard

Without these hints, browsers and password managers (1Password, Bitwarden, iCloud Keychain, Chrome) can't reliably autofill saved credentials on sign-in, save new credentials on sign-up, or suggest generated passwords — silently increasing friction on every authenticated session.

Closes CUR-89.

## Origin

Found during the recurring UX review (code-assisted mode — live app at https://curio.qiuyue.dev returned HTTP 403 to WebFetch this run). The team already followed the right convention on `set-password`, so this PR is a tiny, mechanical follow-through.

## Test plan

- [x] `npm run format:check` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 620 passed, 2 skipped, 1 todo
- [ ] `npm run test:e2e` — could not run in this sandbox (`npx playwright install chromium` failed to download the browser binary). The change is +3 attribute lines on existing inputs, so e2e behavior is unaffected.
- [ ] Manual check: a saved Curio password in iCloud Keychain / 1Password / Chrome autofills on sign-in, and the manager offers to save credentials on sign-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_012cororLKAvcqAtxN95UTea)_