### PR TITLE
[CUR-84] Make Item Detail action icons visible on Gallery + Atelier

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,7 @@ import {
   accentColorClasses,
   dividerClasses,
   cardHoverClasses,
+  mutedTextClasses,
 } from './theme';
 import { StatusToast, StatusTone } from './components/StatusToast';
 import { StatusBanner } from './components/StatusBanner';
@@ -1969,10 +1970,12 @@ export const AppContent: React.FC = () => {
                     disabled={history.length === 0}
                     aria-label={t('undo')}
                     title={t('undo')}
-                    className={`p-3 sm:p-4 rounded-full transition-colors ${
+                    className={`p-3 sm:p-4 rounded-full transition-colors ${mutedTextClasses[theme]} ${
                       history.length === 0
-                        ? 'text-stone-300 cursor-not-allowed'
-                        : 'text-stone-400 hover:text-stone-700 hover:bg-stone-100'
+                        ? 'opacity-50 cursor-not-allowed'
+                        : theme === 'vault'
+                          ? 'hover:text-white hover:bg-white/10'
+                          : 'hover:text-stone-900 hover:bg-stone-100'
                     }`}
                   >
                     <Undo2 size={18} className="sm:w-5 sm:h-5" />
@@ -1982,10 +1985,12 @@ export const AppContent: React.FC = () => {
                     disabled={future.length === 0}
                     aria-label={t('redo')}
                     title={t('redo')}
-                    className={`p-3 sm:p-4 rounded-full transition-colors ${
+                    className={`p-3 sm:p-4 rounded-full transition-colors ${mutedTextClasses[theme]} ${
                       future.length === 0
-                        ? 'text-stone-300 cursor-not-allowed'
-                        : 'text-stone-400 hover:text-stone-700 hover:bg-stone-100'
+                        ? 'opacity-50 cursor-not-allowed'
+                        : theme === 'vault'
+                          ? 'hover:text-white hover:bg-white/10'
+                          : 'hover:text-stone-900 hover:bg-stone-100'
                     }`}
                   >
                     <Redo2 size={18} className="sm:w-5 sm:h-5" />
@@ -1994,9 +1999,13 @@ export const AppContent: React.FC = () => {
                     onClick={handleDelete}
                     aria-label={t('deleteItem')}
                     title={t('deleteItem')}
-                    className="text-stone-200 hover:text-red-400 transition-colors p-3 sm:p-4 rounded-full hover:bg-red-50 shrink-0"
+                    className={`w-11 h-11 sm:w-12 sm:h-12 flex items-center justify-center rounded-xl border transition-colors shrink-0 ${
+                      theme === 'vault'
+                        ? 'bg-stone-900 border-white/10 text-stone-400 hover:text-red-400 hover:border-red-400/30'
+                        : 'bg-white border-stone-200 text-stone-400 hover:text-red-500 hover:border-red-200'
+                    }`}
                   >
-                    <Trash2 size={20} className="sm:w-6 sm:h-6" />
+                    <Trash2 size={18} className="sm:w-5 sm:h-5" />
                   </button>
                 </div>
               )}
@@ -2084,7 +2093,7 @@ export const AppContent: React.FC = () => {
                       ) : (
                         <textarea
                           ref={detailStoryRef}
-                          className={`w-full p-6 sm:p-8 rounded-2xl sm:rounded-[2.5rem] italic border font-serif text-xl sm:text-2xl leading-relaxed min-h-[200px] sm:min-h-[240px] focus:ring-8 focus:ring-amber-500/30 focus:border-amber-500 outline-none transition-all shadow-inner placeholder:text-stone-200 ${theme === 'vault' ? 'bg-white/5 border-white/5 text-white' : 'bg-stone-50/50 border-stone-100 text-stone-800'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+                          className={`w-full p-6 sm:p-8 rounded-2xl sm:rounded-[2.5rem] italic border font-serif text-xl sm:text-2xl leading-relaxed min-h-[200px] sm:min-h-[240px] focus:ring-8 focus:ring-amber-500/30 focus:border-amber-500 outline-none transition-all shadow-inner placeholder:text-stone-400 ${theme === 'vault' ? 'bg-white/5 border-white/5 text-white' : 'bg-stone-50/50 border-stone-100 text-stone-800'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`}
                           value={item.notes}
                           onChange={(e) => applyItemUpdate({ notes: e.target.value })}
                           placeholder={t('storyPlaceholder')}


### PR DESCRIPTION
## Problem

The three action buttons next to the item title on the Item Detail screen — Undo, Redo, and destructive **Delete** — use hardcoded `text-stone-200`/`-300`/`-400` against the white (Gallery) and `#faf9f6` (Atelier) detail card surface. That gives:

- `text-stone-200` (#e7e5e4) on `#FFFFFF` ≈ **1.1:1**
- `text-stone-300` (#d6d3d1) on `#FFFFFF` ≈ **1.6:1**
- `text-stone-400` (#a8a29e) on `#FFFFFF` ≈ **3.0:1** — borderline at best, hard fail when disabled

The destructive Delete is effectively invisible until hovered (the page near the title reads as negative space). Undo/Redo blend into the card. WCAG 2.1 SC 1.4.11 requires ≥ 3:1 for meaningful UI controls and their states.

This is the trust-critical edge of the Item Detail surface — destructive actions should be quietly visible, not hidden behind a hover discovery. (Protects "Trust before growth" and "Beauty before bureaucracy" — visible, intentional controls beat near-invisible chrome.)

## Approach

`src/App.tsx`, action row at the top of the Item Detail card (~L1965–2002, plus the Story textarea placeholder at L2087):

- **Undo / Redo**: switched from hardcoded stone to `mutedTextClasses[theme]` (gallery `text-stone-500` ≈ 4.6:1, vault `text-stone-300`, atelier `text-[#8C7B6B]` ≈ 4.7:1). Disabled state now uses `opacity-50` so the control stays meaningfully visible (≥ 2.3:1) while clearly reading as "off". Hover state is theme-aware: vault hovers `white/10`, gallery + atelier hover `stone-100` (the previous hover broke under vault).
- **Trash**: now mirrors the existing CollectionScreen delete chip (`src/App.tsx:1228-1239`) — bordered square with theme branches. Destructive intent is visible at rest, hover still reads red.
- **Story textarea placeholder**: lifted `placeholder:text-stone-200` (≈ 1.04:1) to `placeholder:text-stone-400` so the prompt is actually visible while still feeling muted. Listed as a bonus in the CUR-84 description; same root cause, same file.

## Why this approach

Reuses tokens already exported from `src/theme.tsx` and the CollectionScreen delete pattern already shipped in the codebase, so no new design surface. Smallest possible diff: 18 / -9 in one file, no behavior changes, no copy changes, no a11y label changes. Keeps the Undo/Redo circular and only the destructive Trash bordered, matching the issue author's recommendation.

## Risks

Low. Visual-only change to existing buttons; ARIA labels, titles, keyboard activation, and click handlers are untouched. The only behavior visible to tests is the className strings on the buttons, and no existing test asserts on them.

## How to verify

Vercel Preview: (will populate once Vercel finishes building)

Steps:
1. Sign in and open any item in a non-sample collection (so `isReadOnly = false`).
2. In **Gallery** theme, confirm Undo, Redo, and the Trash chip beside the title are all clearly visible at rest, and that the Trash button reads as a bordered chip rather than empty space.
3. Switch to **Atelier** and repeat — same icons should remain readable on the cream card.
4. Switch to **Vault** — icons should look the same or slightly clearer than before; hover should not flash a light stone-100 background.
5. Undo a field edit, then check the disabled state of Redo (after redoing everything) — it should read as "off" via opacity, still legible.
6. Open the Story editor on an empty item and confirm the placeholder text is readable across all three themes.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 620 passed, 2 skipped, 1 todo
- [x] `npm run build` — passed
- [ ] `npm run test:e2e` — could not run in this sandbox (Playwright Chromium download failed against this network policy, same as PR #256). The diff is purely Tailwind class changes on existing buttons with no behavior change, so e2e coverage is unaffected.

## Screenshot / GIF

Not captured this run (sandbox cannot reach a browser). Visual change is bounded to the three icon buttons + Story placeholder on the Item Detail screen.

## Linear

Closes CUR-84

## Rollback plan

Green-tier presentational change; revert the single commit (`git revert 6d29b19`) restores the previous hardcoded stone classes. No data or schema involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6fU47V958LEy4MXB4RWQf)_