### PR TITLE
[CUR-87] Add Esc, focus trap, and safe initial focus to ConflictResolutionModal

### DIFF
--- a/src/components/ConflictResolutionModal.tsx
+++ b/src/components/ConflictResolutionModal.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { X, GitMerge, Cloud, Laptop, ArrowRight } from 'lucide-react';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses } from '../theme';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 export type ConflictEntry = {
   id: string;
@@ -68,6 +69,13 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  // Conflict resolution is destructive — picking a side discards data. Land
+  // initial focus on the dismiss button so keyboard users do not commit a
+  // choice by hitting Enter on the first focusable control.
+  useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: closeButtonRef });
+
   if (!isOpen) return null;
 
   return (
@@ -75,6 +83,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
       className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="conflict-resolution-title"
@@ -94,6 +103,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
             </h2>
           </div>
           <button
+            ref={closeButtonRef}
             onClick={onClose}
             aria-label={t('close')}
             className={`p-2 rounded-full transition-colors ${theme === 'vault' ? 'hover:bg-white/5 text-stone-300 hover:text-white' : 'hover:bg-stone-100 text-stone-400 hover:text-stone-800'}`}

--- a/tests/components/ConflictResolutionModal.test.tsx
+++ b/tests/components/ConflictResolutionModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { ConflictResolutionModal, ConflictEntry } from '@/components/ConflictResolutionModal';
 import { renderWithProviders, setMockTheme } from '../utils/test-utils';
 
@@ -96,5 +96,43 @@ describe('ConflictResolutionModal', () => {
     expect(screen.getByText('较新')).toBeInTheDocument();
     expect(screen.queryByText('Newer')).not.toBeInTheDocument();
     expect(screen.queryByText(/^Changed:/)).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape without committing a destructive choice', () => {
+    const onClose = vi.fn();
+    const onKeepCloud = vi.fn();
+    const onUseLocal = vi.fn();
+    renderWithProviders(
+      <ConflictResolutionModal
+        isOpen
+        conflicts={[itemConflict]}
+        onClose={onClose}
+        onKeepCloud={onKeepCloud}
+        onUseLocal={onUseLocal}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onKeepCloud).not.toHaveBeenCalled();
+    expect(onUseLocal).not.toHaveBeenCalled();
+  });
+
+  it('lands initial focus on the dismiss button so Enter does not commit a side', async () => {
+    renderWithProviders(
+      <ConflictResolutionModal
+        isOpen
+        conflicts={[itemConflict]}
+        onClose={vi.fn()}
+        onKeepCloud={vi.fn()}
+        onUseLocal={vi.fn()}
+      />,
+    );
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    expect(document.activeElement).toBe(closeButton);
   });
 });


### PR DESCRIPTION
## Problem

`ConflictResolutionModal` is the highest-stakes surface in the app — it appears when local and cloud copies of an item or collection have diverged after sync, and it asks the user to discard one side. The modal already declared `role="dialog" aria-modal="true" aria-labelledby="conflict-resolution-title"` and renders a localized title (CUR-77), but the underlying dialog plumbing was never added:

- **No Escape handler** — keyboard users facing a destructive choice could not back out without clicking the small × button.
- **No focus trap** — Tab focus could wander to the page behind the modal, then be impossible to return to with the keyboard alone.
- **No initial focus** — the first focusable control was a side-picker (`Keep cloud` or `Use local`), so a screen-reader / keyboard user could commit a destructive choice by pressing Enter on what they thought was a neutral state.
- **No focus restore on dismiss.**

Protects **Trust before growth** — at the exact moment users are deciding whether to lose work, the UI must not feel like a trap.

## Approach

Reuses the existing `useModalA11y` primitive shipped in CUR-78 (FilterModal, `Delete{Item,Items,Collection}Modal`, EnhanceImageModal) — no new pattern, no new dependency. Two changes in `src/components/ConflictResolutionModal.tsx`:

1. `useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: closeButtonRef })` — Esc, focus trap, focus restore on dismiss.
2. `initialFocusRef` points at the dismiss `×` (the only safe action — there is no separate "Resolve later" in the modal today, and adding one was out of scope for an a11y fix), so Enter on first open dismisses, never commits a side.

Wires the two refs onto the existing dialog container and close button. No copy or behavior changes beyond a11y.

## Why this approach

Matches the established pattern other destructive modals already use, so the diff is small (+12 / -1 source, plus 2 regression tests) and the modal now feels identical to its siblings for keyboard / screen-reader users. The smallest taste-aligned solution: no new UI affordance, no scope creep into the merge UX itself.

## Risks

Low. The change is two refs and one hook call; existing behavior (`onClose`, `onKeepCloud`, `onUseLocal`) is untouched. The localized labels from CUR-77 are not touched. New tests assert the new invariants would not silently regress.

## How to verify

Vercel Preview: _will populate once the build finishes._

Steps:
1. Sign in, open Curio, and trigger a conflict (easiest: mutate an `items.updated_at` row in Supabase Studio while the client has stale state, then trigger a sync).
2. When `ConflictResolutionModal` opens, confirm initial focus is on the close `×` (not on `Keep cloud` / `Use local`).
3. Press **Esc** — the modal closes without committing a side.
4. Reopen, Tab around — focus stays inside the dialog and wraps from the last picker back to the close button.
5. (Optional, screen reader) Confirm the dialog opening still announces with title.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 622 passed | 2 skipped | 1 todo
- [x] `npm run build` — passed
- [ ] `npm run test:e2e` — could not run in this sandbox; `npx playwright install chromium` failed to download the browser binary against the current network policy (same constraint flagged in #256 and #257). The change is purely a11y wiring on an existing modal with no runtime/network behavior; the two new Vitest specs assert the regressions directly.

## Screenshot / GIF

No visual change — purely a11y wiring (focus, keyboard, hook).

## Linear

Closes CUR-87

## Rollback plan

Green-tier presentational/a11y change. `git revert 6d2b51e` removes the hook call and the two refs; no schema, sync, or data behavior involved.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFAjY6JHHYGcdbDBh95nFA)_