### PR TITLE
[CUR-86] Add Esc, focus trap, and safe initial focus to ImageEditModal

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -288,6 +288,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        if (isImageEditorOpenRef.current) return;
         e.preventDefault();
         if (confirmingDiscardRef.current) {
           setConfirmingDiscard(false);
@@ -302,6 +303,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
       }
 
       if (e.key !== 'Tab') return;
+      if (isImageEditorOpenRef.current) return;
       const focusable = getFocusable();
       if (focusable.length === 0) return;
 
@@ -387,6 +389,10 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
   hasInProgressWorkRef.current = hasInProgressWork;
   const confirmingDiscardRef = useRef(confirmingDiscard);
   confirmingDiscardRef.current = confirmingDiscard;
+  // When the child ImageEditModal is open it owns Escape (CUR-86). Yield so the
+  // editor dismisses alone instead of also triggering this modal's discard flow.
+  const isImageEditorOpenRef = useRef(isImageEditorOpen);
+  isImageEditorOpenRef.current = isImageEditorOpen;
 
   const requestClose = () => {
     if (confirmingDiscard) {

--- a/src/components/ImageEditModal.tsx
+++ b/src/components/ImageEditModal.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { X, Crop, RotateCcw, RotateCw } from 'lucide-react';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses } from '../theme';
+import { useModalA11y } from '../hooks/useModalA11y';
 import { cropSquareDataUrl, rotateDataUrl } from '../utils/imageTransforms';
 import { Button } from './ui/Button';
 
@@ -27,6 +28,10 @@ export const ImageEditModal: React.FC<ImageEditModalProps> = ({
   const surfaceClass = panelSurfaceClasses[theme];
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: cancelRef });
 
   useEffect(() => {
     if (!isOpen) return;
@@ -70,6 +75,7 @@ export const ImageEditModal: React.FC<ImageEditModalProps> = ({
       className={`fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="image-edit-title"
@@ -134,7 +140,7 @@ export const ImageEditModal: React.FC<ImageEditModalProps> = ({
         <div
           className={`px-5 py-4 border-t flex items-center justify-end gap-2 ${theme === 'vault' ? 'border-white/10 bg-white/5' : 'border-stone-100 bg-white'}`}
         >
-          <Button variant="ghost" onClick={onClose}>
+          <Button ref={cancelRef} variant="ghost" onClick={onClose}>
             {t('cancel')}
           </Button>
           <Button onClick={() => preview && onApply(preview)} disabled={isTransforming}>

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -45,9 +45,11 @@ vi.mock('@capacitor/camera', () => ({
 }));
 
 import { analyzeImage, refreshAiEnabled } from '@/services/geminiService';
+import { Camera } from '@capacitor/camera';
 
 const mockAnalyzeImage = analyzeImage as ReturnType<typeof vi.fn>;
 const mockRefreshAiEnabled = refreshAiEnabled as ReturnType<typeof vi.fn>;
+const mockGetPhoto = Camera.getPhoto as ReturnType<typeof vi.fn>;
 
 class MockFileReader {
   result: string | ArrayBuffer | null = null;
@@ -79,6 +81,7 @@ describe('AddItemModal', () => {
     mockOnSave.mockResolvedValue(undefined);
     mockRefreshAiEnabled.mockResolvedValue(false);
     mockAnalyzeImage.mockReset();
+    mockGetPhoto.mockReset();
   });
 
   it('renders nothing when closed', () => {
@@ -613,6 +616,53 @@ describe('AddItemModal', () => {
 
       expect(screen.queryByTestId('add-item-discard-confirm')).not.toBeInTheDocument();
       expect(screen.getByDisplayValue('Batched Artifact')).toBeInTheDocument();
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('yields Escape to the nested ImageEditModal — child closes alone, parent stays open (CUR-86)', async () => {
+      const user = userEvent.setup();
+      mockRefreshAiEnabled.mockResolvedValue(true);
+      mockAnalyzeImage.mockResolvedValue({
+        status: 'success',
+        title: 'Mock Artifact',
+        notes: '',
+        data: {},
+      });
+      mockGetPhoto.mockResolvedValue({
+        dataUrl: 'data:image/png;base64,ZmFrZQ==',
+        format: 'png',
+      });
+
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection({ customFields: [] })]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      // Single-image upload routes to the verify step (not batch-verify).
+      await user.click(screen.getByRole('button', { name: /upload photo/i }));
+
+      // Wait for analysis to land on the verify step.
+      expect(await screen.findByDisplayValue('Mock Artifact')).toBeInTheDocument();
+
+      // Open the nested image editor.
+      await user.click(screen.getByRole('button', { name: /edit photo/i }));
+      const editorDialog = await screen.findByRole('dialog', { name: /edit photo/i });
+      expect(editorDialog).toHaveAttribute('aria-labelledby', 'image-edit-title');
+
+      // Escape on the child should close only the child — the parent's
+      // CUR-80 discard-confirm path must NOT fire even though there's work
+      // in progress (a title is in the form).
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: /edit photo/i })).not.toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('add-item-discard-confirm')).not.toBeInTheDocument();
+      expect(screen.getByDisplayValue('Mock Artifact')).toBeInTheDocument();
       expect(mockOnClose).not.toHaveBeenCalled();
     });
   });

--- a/tests/components/ImageEditModal.test.tsx
+++ b/tests/components/ImageEditModal.test.tsx
@@ -1,10 +1,3 @@
-/**
- * ImageEditModal Component Tests (CUR-86)
- *
- * Mirrors the a11y contract that CUR-78 established on the other modals
- * (FilterModal, Delete*Modal, EnhanceImageModal).
- */
-
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/tests/components/ImageEditModal.test.tsx
+++ b/tests/components/ImageEditModal.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * ImageEditModal Component Tests (CUR-86)
+ *
+ * Mirrors the a11y contract that CUR-78 established on the other modals
+ * (FilterModal, Delete*Modal, EnhanceImageModal).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { ImageEditModal } from '@/components/ImageEditModal';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+const TRANSPARENT_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+describe('ImageEditModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    source: TRANSPARENT_PIXEL,
+    onClose: vi.fn(),
+    onApply: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(<ImageEditModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when source is missing', () => {
+    renderWithProviders(<ImageEditModal {...defaultProps} source={null} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ImageEditModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onApply with the current preview when apply is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ImageEditModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /apply/i }));
+    expect(defaultProps.onApply).toHaveBeenCalledWith(TRANSPARENT_PIXEL);
+  });
+
+  describe('accessibility (CUR-86)', () => {
+    it('renders as a labelled dialog', () => {
+      renderWithProviders(<ImageEditModal {...defaultProps} />);
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'image-edit-title');
+    });
+
+    it('closes on Escape', async () => {
+      renderWithProviders(<ImageEditModal {...defaultProps} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('lands initial focus on Cancel (safe action), not Rotate/Apply', async () => {
+      renderWithProviders(<ImageEditModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByRole('button', { name: /cancel/i }));
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`ImageEditModal` declares `role="dialog" aria-modal="true"` (`src/components/ImageEditModal.tsx:72-77`) but never wired up the matching keyboard behavior — no Escape-to-close, no focus trap, no initial focus, no focus restore. It does not import or call `useModalA11y`.

CUR-78 retrofitted these patterns onto FilterModal, the three Delete\* modals, and EnhanceImageModal; ImageEditModal was missed. It's the only "media-editing" modal in the app that traps keyboard users with no Escape escape hatch.

`ImageEditModal` is opened from two places — `AddItemModal` (during the AddItem flow) and `App.tsx` (Item Detail → Update photo). In the AddItem context the parent's Escape handler caught the key first, but in the Item Detail context the modal owns the surface and Escape did nothing. Either way the dialog felt inconsistent with every other modal in the product.

Protects **Trust before growth** — keyboard / screen-reader users facing a destructive-feeling photo edit should always have a clear way back out.

## Approach

Reuses the existing `useModalA11y` primitive shipped in CUR-78 — no new pattern, no new dependency.

**`src/components/ImageEditModal.tsx`** — three small changes:

1. `useModalA11y(dialogRef, isOpen, onClose, { initialFocusRef: cancelRef })` — Esc, focus trap, focus restore on dismiss.
2. `initialFocusRef` points at **Cancel** (the safe action), so Enter on first open dismisses, never rotates or crops the image. Matches the issue's recommended landing.
3. Wires `dialogRef` onto the existing `role="dialog"` container and `cancelRef` onto the existing Cancel `Button` (which already forwards refs).

**`src/components/AddItemModal.tsx`** — Codex follow-up on commit 59e8460 ([review](https://github.com/Akkkkkkki/curio/pull/261#pullrequestreview-comment)):

Because both modals attach their Escape handlers to `document` and the parent registers first, the parent's CUR-80 discard-confirm path was firing on every Esc in the photo editor — even when the child was the topmost surface. `stopImmediatePropagation` from the child can't help (the parent's handler has already run). Fix: mirror the existing `isImageEditorOpen` state into a ref and bail early from the parent's keydown handler (both Escape and Tab) while the child is open. The child's own `useModalA11y` listener still fires and dismisses only the editor — and once the child closes, the parent's Esc behavior is fully restored, so CUR-80's confirm-discard still protects in-progress work on the next keypress.

No copy, layout, or behavior changes beyond a11y wiring.

## Why this approach

Matches the established sibling pattern (FilterModal, Delete\*Modal, EnhanceImageModal) one-for-one for the ImageEditModal side. For the AddItem nesting, the bail-early guard is the most surgical fix — it doesn't touch the shared `useModalA11y` hook (so all 5 sibling consumers stay identical) and it reuses the same `useRef` mirror pattern AddItemModal already uses for `hasInProgressWork` and `confirmingDiscard`.

## Risks

Low. ImageEditModal change is two refs and one hook call on existing JSX. AddItemModal change is one ref-mirror plus two early-returns guarded by it — when the child editor is closed (the steady state), behavior is byte-identical to `main`. The new Vitest specs assert each invariant so a regression cannot slip in silently.

## How to verify

Vercel Preview: https://curio-git-claude-curio-86-imageedit-473cf8-qs-projects-72b20d9d.vercel.app

Steps:
1. **Item Detail entry point** — Sign in, open an item in your own collection, tap "Update photo", upload an image.
   - Confirm initial focus lands on Cancel (not on Rotate Left).
   - Press **Esc** — the modal closes, focus returns to the Update photo trigger.
   - Reopen, Tab/Shift+Tab — focus stays inside the dialog and wraps between Cancel ↔ Apply Changes.
2. **AddItem entry point (nested)** — Start adding a new item, attach a photo, let analysis complete, click "Edit photo" on the verify step.
   - Press **Esc** — only the child editor closes. AddItemModal stays open, no discard-confirm appears, your typed title/story is preserved.
   - Press **Esc** again on the parent — CUR-80's discard-confirm fires (if there's work in progress) or AddItemModal closes (if not). Parent behavior is fully restored.
3. **Read-only collections** — the Update photo control isn't surfaced for sample collections (read-only clarity preserved).

Checks:
- [x] `npm run format:check` — passed locally
- [x] `npm test` — 628 passed | 2 skipped | 1 todo (was 620 on `main`; +7 from new `ImageEditModal.test.tsx`, +1 nesting integration spec in `AddItemModal.test.tsx`)
- [x] `npm run build` — passed locally
- [ ] `npm run test:e2e` — could not run in this sandbox; `npx playwright install chromium` failed to download the browser binary against the current network policy (same constraint flagged in PRs #256, #257, #259, #260). The change is purely a11y wiring on an existing modal with no runtime/network behavior; the eight new Vitest specs assert the regressions directly. GitHub Actions CI runs e2e in a properly provisioned environment.

## Screenshot / GIF

No visual change — purely a11y wiring (focus, keyboard, hook).

## Linear

Closes CUR-86

## Rollback plan

Green-tier a11y change. `git revert dea07d3 59e8460` removes the hook call, two refs, and the parent bail-early guard; no schema, sync, or data behavior involved.