### PR TITLE
[CUR-57] Add Privacy + Terms links and pages to signup flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { SpeedInsights } from '@vercel/speed-insights/react';
 import { Analytics } from '@vercel/analytics/react';
 import { Layout } from './components/Layout';
 import { ExplorePlaceholder } from './components/ExplorePlaceholder';
+import { LegalPage } from './components/LegalPage';
 import { CollectionCard } from './components/CollectionCard';
 import { ItemCard } from './components/ItemCard';
 import { AddItemModal } from './components/AddItemModal';
@@ -2301,7 +2302,8 @@ export const AppContent: React.FC = () => {
   const sampleCollection = useMemo(() => collections.find((c) => c.isPublic), [collections]);
   const showAccessGate = isSupabaseReady && !isAuthenticated && !allowPublicBrowse;
   const isExploreRoute = location.pathname === '/explore';
-  const shouldShowAccessGate = showAccessGate && !isExploreRoute;
+  const isLegalRoute = location.pathname.startsWith('/legal/');
+  const shouldShowAccessGate = showAccessGate && !isExploreRoute && !isLegalRoute;
   const fallbackSampleCollectionId = fallbackSampleCollections[0]?.id ?? null;
   // Only expose a sample collection id that is actually present in `collections`.
   // The fallback sample is not part of merged cloud state for an authenticated
@@ -2620,6 +2622,7 @@ export const AppContent: React.FC = () => {
                   />
                 }
               />
+              <Route path="/legal/:doc" element={<LegalPage />} />
               <Route
                 path="/collection/:id"
                 element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,7 +101,6 @@ import {
   accentColorClasses,
   dividerClasses,
   cardHoverClasses,
-  mutedTextClasses,
 } from './theme';
 import { StatusToast, StatusTone } from './components/StatusToast';
 import { StatusBanner } from './components/StatusBanner';

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -506,6 +506,45 @@ export const AuthModal: React.FC<AuthModalProps> = ({
             </Button>
           )}
 
+          {mode === 'signup' && (
+            <p
+              className={`text-[11px] leading-relaxed text-center ${mutedText}`}
+              data-testid="signup-legal-consent"
+            >
+              {t('signupLegalConsentLead')}
+              <a
+                href="#/legal/terms"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`font-semibold underline-offset-2 hover:underline transition-colors ${
+                  theme === 'vault'
+                    ? 'text-[#D4A574] hover:text-[#E0B585]'
+                    : theme === 'atelier'
+                      ? 'text-[#A86F3C] hover:text-[#8B5A2B]'
+                      : 'text-amber-700 hover:text-amber-800'
+                }`}
+              >
+                {t('termsOfService')}
+              </a>
+              {t('signupLegalConsentAnd')}
+              <a
+                href="#/legal/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`font-semibold underline-offset-2 hover:underline transition-colors ${
+                  theme === 'vault'
+                    ? 'text-[#D4A574] hover:text-[#E0B585]'
+                    : theme === 'atelier'
+                      ? 'text-[#A86F3C] hover:text-[#8B5A2B]'
+                      : 'text-amber-700 hover:text-amber-800'
+                }`}
+              >
+                {t('privacyPolicy')}
+              </a>
+              {t('signupLegalConsentTail')}
+            </p>
+          )}
+
           <div className="text-center pt-2">
             {mode === 'signin' || mode === 'signup' ? (
               <button

--- a/src/components/LegalPage.tsx
+++ b/src/components/LegalPage.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, ScrollText, ShieldCheck } from 'lucide-react';
+import { useTranslation } from '../i18n';
+import { useTheme, mutedTextClasses, panelSurfaceClasses, typographyClasses } from '../theme';
+
+type LegalDoc = 'privacy' | 'terms';
+
+interface Section {
+  titleKey: string;
+  bodyKey: string;
+}
+
+const PRIVACY_SECTIONS: Section[] = [
+  { titleKey: 'legalPrivacyDataTitle', bodyKey: 'legalPrivacyDataBody' },
+  { titleKey: 'legalPrivacyAiTitle', bodyKey: 'legalPrivacyAiBody' },
+  { titleKey: 'legalPrivacyAnalyticsTitle', bodyKey: 'legalPrivacyAnalyticsBody' },
+  { titleKey: 'legalPrivacyDeleteTitle', bodyKey: 'legalPrivacyDeleteBody' },
+];
+
+const TERMS_SECTIONS: Section[] = [
+  { titleKey: 'legalTermsYourContentTitle', bodyKey: 'legalTermsYourContentBody' },
+  { titleKey: 'legalTermsAcceptableTitle', bodyKey: 'legalTermsAcceptableBody' },
+  { titleKey: 'legalTermsAvailabilityTitle', bodyKey: 'legalTermsAvailabilityBody' },
+];
+
+const isLegalDoc = (value: string | undefined): value is LegalDoc =>
+  value === 'privacy' || value === 'terms';
+
+export const LegalPage: React.FC = () => {
+  const { doc } = useParams<{ doc: string }>();
+  const { t } = useTranslation();
+  const { theme } = useTheme();
+
+  const resolvedDoc: LegalDoc = isLegalDoc(doc) ? doc : 'privacy';
+  const isPrivacy = resolvedDoc === 'privacy';
+
+  const titleKey = isPrivacy ? 'privacyPolicy' : 'termsOfService';
+  const introKey = isPrivacy ? 'legalPrivacyIntro' : 'legalTermsIntro';
+  const sections = isPrivacy ? PRIVACY_SECTIONS : TERMS_SECTIONS;
+  const Icon = isPrivacy ? ShieldCheck : ScrollText;
+
+  const surfaceClass = panelSurfaceClasses[theme];
+  const mutedClass = mutedTextClasses[theme];
+  const badgeClass =
+    theme === 'vault'
+      ? 'bg-white/5 text-stone-300 border-white/10'
+      : theme === 'atelier'
+        ? 'bg-[#EDE4D3] text-[#6B5344] border-[#D4C9B8]'
+        : 'bg-stone-100 text-stone-600 border-stone-200';
+  const dividerBorder =
+    theme === 'vault'
+      ? 'border-white/10'
+      : theme === 'atelier'
+        ? 'border-[#D4C9B8]'
+        : 'border-stone-100';
+  const linkClass =
+    theme === 'vault'
+      ? 'text-[#D4A574] hover:text-[#E0B585]'
+      : theme === 'atelier'
+        ? 'text-[#A86F3C] hover:text-[#8B5A2B]'
+        : 'text-amber-700 hover:text-amber-800';
+
+  return (
+    <div className="px-4 py-12 sm:py-16" data-testid={`legal-page-${resolvedDoc}`}>
+      <div
+        className={`max-w-2xl mx-auto rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl border ${surfaceClass}`}
+      >
+        <div className="mb-8 flex flex-col gap-4">
+          <Link
+            to="/"
+            className={`inline-flex items-center gap-2 self-start text-xs font-semibold uppercase tracking-[0.16em] ${mutedClass} hover:opacity-100 opacity-80 transition-opacity`}
+          >
+            <ArrowLeft size={14} aria-hidden="true" />
+            {t('legalBackToCurio')}
+          </Link>
+          <div className="flex items-center gap-3">
+            <Icon size={20} aria-hidden="true" className={mutedClass} />
+            <span
+              className={`text-[10px] font-bold uppercase tracking-[0.16em] px-2.5 py-1 rounded-full border ${badgeClass}`}
+            >
+              {t('legalDraftBadge')}
+            </span>
+          </div>
+          <h1 className={typographyClasses.titleLarge}>{t(titleKey)}</h1>
+          <p className={`${typographyClasses.body} ${mutedClass}`}>{t(introKey)}</p>
+        </div>
+
+        <div className={`border-t ${dividerBorder} pt-8 space-y-8`}>
+          {sections.map(({ titleKey: sTitle, bodyKey: sBody }) => (
+            <section key={sTitle} className="space-y-2">
+              <h2 className={`${typographyClasses.title} font-serif`}>{t(sTitle)}</h2>
+              <p className={`${typographyClasses.body} ${mutedClass}`}>{t(sBody)}</p>
+            </section>
+          ))}
+
+          <section className="space-y-2">
+            <h2 className={`${typographyClasses.title} font-serif`}>{t('legalContactTitle')}</h2>
+            <p className={`${typographyClasses.body} ${mutedClass}`}>{t('legalContactBody')}</p>
+          </section>
+
+          <div className={`pt-6 border-t ${dividerBorder} flex items-center gap-4 text-sm`}>
+            <Link
+              to={isPrivacy ? '/legal/terms' : '/legal/privacy'}
+              className={`font-semibold transition-colors ${linkClass}`}
+            >
+              {isPrivacy ? t('termsOfService') : t('privacyPolicy')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -444,6 +444,42 @@ export const translations = {
     deleteCollectionFailed: 'Failed to delete collection',
     // Sample badge
     sampleBadge: 'Sample',
+    // Legal pages and signup consent
+    privacyPolicy: 'Privacy Policy',
+    termsOfService: 'Terms of Service',
+    signupLegalConsentLead: 'By creating an account, you agree to our ',
+    signupLegalConsentAnd: ' and ',
+    signupLegalConsentTail: '.',
+    legalBackToCurio: 'Back to Curio',
+    legalDraftBadge: 'Beta — plain-language summary',
+    legalPrivacyIntro:
+      'Curio is in early development. A formal policy will arrive before general availability. In the meantime, here is what we actually do with your data today.',
+    legalPrivacyDataTitle: 'What we store',
+    legalPrivacyDataBody:
+      'When you create an account, Supabase stores your email and an encrypted password. The items, collections, and photos you save are stored under your account in Supabase and Supabase Storage. We do not sell, rent, or share your data with advertisers.',
+    legalPrivacyAiTitle: 'AI metadata extraction',
+    legalPrivacyAiBody:
+      'When you add an item, the photo you upload may be sent to Google Gemini to suggest a title and fields. AI suggestions stay editable and are never required to save an item. Curio does not send your story text or notes to Gemini.',
+    legalPrivacyAnalyticsTitle: 'Analytics',
+    legalPrivacyAnalyticsBody:
+      'Curio uses Vercel Speed Insights and Vercel Analytics to understand performance and aggregate page views. These do not identify you personally.',
+    legalPrivacyDeleteTitle: 'Deleting your data',
+    legalPrivacyDeleteBody:
+      'You can sign out at any time. To delete your account and the data associated with it, email the maintainer at the contact address below and we will remove it.',
+    legalTermsIntro:
+      'Curio is provided as-is during early development. Use it to collect and share things you care about. Please respect the rules below so the museum stays a calm, beautiful place.',
+    legalTermsYourContentTitle: 'Your content',
+    legalTermsYourContentBody:
+      'You keep ownership of the photos and stories you upload. By uploading, you confirm you have the right to use that content. Do not upload anything you would not be comfortable being responsible for.',
+    legalTermsAcceptableTitle: 'Acceptable use',
+    legalTermsAcceptableBody:
+      'Do not use Curio to store or share content that is illegal, infringes on others, or is intended to harass. We may suspend accounts that abuse the service or compromise other users.',
+    legalTermsAvailabilityTitle: 'Availability and changes',
+    legalTermsAvailabilityBody:
+      'Curio is offered without warranty during beta. Features may change, and we may pause the service to investigate problems. We will give reasonable notice before changes that affect saved data.',
+    legalContactTitle: 'Questions',
+    legalContactBody:
+      'For questions about your data, deletion requests, or anything else legal-related, reach the maintainer through the project repository.',
   },
   zh: {
     appTitle: '珍藏',
@@ -877,6 +913,41 @@ export const translations = {
     deleteCollectionFailed: '删除收藏集失败',
     // Sample badge
     sampleBadge: '示例',
+    // Legal pages and signup consent
+    privacyPolicy: '隐私政策',
+    termsOfService: '服务条款',
+    signupLegalConsentLead: '创建账号即表示您同意我们的',
+    signupLegalConsentAnd: '与',
+    signupLegalConsentTail: '。',
+    legalBackToCurio: '返回 Curio',
+    legalDraftBadge: '测试版 · 简明说明',
+    legalPrivacyIntro:
+      'Curio 仍在早期开发阶段，正式政策将在公开发布前推出。这里先说明我们目前如何处理您的数据。',
+    legalPrivacyDataTitle: '我们保存什么',
+    legalPrivacyDataBody:
+      '注册账号时，Supabase 会保存您的邮箱地址和加密后的密码。您保存的藏品、收藏集与照片都存放在您账号下的 Supabase 与 Supabase Storage 中。我们不会出售、出租或与广告商共享您的数据。',
+    legalPrivacyAiTitle: 'AI 元数据提取',
+    legalPrivacyAiBody:
+      '添加藏品时，您上传的照片可能会发送给 Google Gemini，用于自动生成标题与字段建议。AI 建议始终可编辑，绝不阻塞保存流程。Curio 不会将您撰写的故事或备注发送给 Gemini。',
+    legalPrivacyAnalyticsTitle: '使用统计',
+    legalPrivacyAnalyticsBody:
+      'Curio 通过 Vercel Speed Insights 与 Vercel Analytics 了解性能与页面访问量，这些统计不会识别您个人。',
+    legalPrivacyDeleteTitle: '删除您的数据',
+    legalPrivacyDeleteBody:
+      '您可以随时登出。如需删除账号及相关数据，请通过下方联系方式与维护者沟通，我们会进行删除。',
+    legalTermsIntro:
+      'Curio 在早期开发阶段按"现状"提供，欢迎用它收藏与分享您珍视的物件。请遵守以下规则，让这个博物馆始终安静而美好。',
+    legalTermsYourContentTitle: '您的内容',
+    legalTermsYourContentBody:
+      '您始终保留所上传照片与故事的所有权。上传内容即表示您拥有相应使用权。请不要上传您本人无法承担责任的内容。',
+    legalTermsAcceptableTitle: '可接受的使用',
+    legalTermsAcceptableBody:
+      '请不要使用 Curio 存储或分享违法、侵权或意图骚扰的内容。对滥用服务或危及他人的账号，我们可能会暂停其使用。',
+    legalTermsAvailabilityTitle: '可用性与变更',
+    legalTermsAvailabilityBody:
+      '测试版本不提供任何形式的担保。功能可能调整，必要时我们也可能暂停服务以排查问题。涉及已保存数据的变更，我们会提前合理告知。',
+    legalContactTitle: '咨询',
+    legalContactBody: '关于数据、删除请求或其他法律问题，欢迎通过项目仓库联系维护者。',
   },
 };
 

--- a/tests/components/AuthModal.test.tsx
+++ b/tests/components/AuthModal.test.tsx
@@ -212,6 +212,42 @@ describe('AuthModal', () => {
       await user.click(screen.getByText(/Already have an account/i));
       expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
     });
+
+    it('shows a consent line with Terms and Privacy Policy links in signup mode (CUR-57)', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AuthModal {...defaultProps} />);
+
+      // Consent line is hidden in sign-in mode.
+      expect(screen.queryByTestId('signup-legal-consent')).not.toBeInTheDocument();
+
+      // Switch to sign up.
+      await user.click(screen.getByText(/Don't have an account/i));
+
+      const consent = screen.getByTestId('signup-legal-consent');
+      expect(consent).toBeInTheDocument();
+      expect(consent.textContent).toMatch(/By creating an account/i);
+
+      const termsLink = screen.getByRole('link', { name: /terms of service/i });
+      const privacyLink = screen.getByRole('link', { name: /privacy policy/i });
+
+      expect(termsLink).toHaveAttribute('href', '#/legal/terms');
+      expect(termsLink).toHaveAttribute('target', '_blank');
+      expect(termsLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+      expect(privacyLink).toHaveAttribute('href', '#/legal/privacy');
+      expect(privacyLink).toHaveAttribute('target', '_blank');
+      expect(privacyLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+
+    it('hides the consent line outside signup mode', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AuthModal {...defaultProps} />);
+
+      expect(screen.queryByTestId('signup-legal-consent')).not.toBeInTheDocument();
+
+      // Forgot password flow should also not show the consent.
+      await user.click(screen.getByRole('button', { name: /forgot password/i }));
+      expect(screen.queryByTestId('signup-legal-consent')).not.toBeInTheDocument();
+    });
   });
 
   describe('Form Validation', () => {

--- a/tests/components/LegalPage.test.tsx
+++ b/tests/components/LegalPage.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { LanguageProvider } from '@/i18n';
+import { ThemeProvider } from '@/theme';
+import { LegalPage } from '@/components/LegalPage';
+
+function renderAtPath(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <LanguageProvider>
+        <ThemeProvider>
+          <Routes>
+            <Route path="/legal/:doc" element={<LegalPage />} />
+          </Routes>
+        </ThemeProvider>
+      </LanguageProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('LegalPage (CUR-57)', () => {
+  it('renders the Privacy Policy at /legal/privacy with all summary sections', () => {
+    renderAtPath('/legal/privacy');
+
+    expect(screen.getByTestId('legal-page-privacy')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /privacy policy/i })).toBeInTheDocument();
+    // A few section headings we promised in the EN copy.
+    expect(screen.getByRole('heading', { name: /what we store/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /ai metadata extraction/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /deleting your data/i })).toBeInTheDocument();
+    // Beta badge so users do not mistake this for a finalized policy.
+    expect(screen.getByText(/beta — plain-language summary/i)).toBeInTheDocument();
+  });
+
+  it('renders the Terms of Service at /legal/terms and links over to Privacy', () => {
+    renderAtPath('/legal/terms');
+
+    expect(screen.getByTestId('legal-page-terms')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 1, name: /terms of service/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /your content/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /acceptable use/i })).toBeInTheDocument();
+
+    // Cross-link to the sibling doc.
+    const sibling = screen.getByRole('link', { name: /privacy policy/i });
+    expect(sibling).toHaveAttribute('href', '/legal/privacy');
+  });
+
+  it('always provides a Back to Curio link out of the legal pages', () => {
+    renderAtPath('/legal/privacy');
+    const back = screen.getByRole('link', { name: /back to curio/i });
+    expect(back).toHaveAttribute('href', '/');
+  });
+
+  it('falls back to the Privacy doc when the param is unknown', () => {
+    renderAtPath('/legal/something-else');
+    expect(screen.getByTestId('legal-page-privacy')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

`AuthModal` collected email + password but offered no links to a Privacy Policy or Terms of Service. Privacy-conscious users had to create an account without any visibility into how their data is handled — a trust gap, and a compliance gap (GDPR/CCPA) the project doesn't need to carry into beta. `grep -rn "privacy\|terms\|policy" src/` confirmed there were zero such links anywhere in the app.

Protects **Trust before growth** from `docs/PRODUCT_STRATEGY.md`: users should know what Curio does with their data before they hand any over.

## Approach

- **AuthModal**: added a small consent line below the submit button that only renders in `signup` mode:
  > "By creating an account, you agree to our **Terms of Service** and **Privacy Policy**."
  Both links open the in-app legal pages in a new tab via `target="_blank" rel="noopener noreferrer"`. Link colors use the existing theme accent tokens (amber-700 / `#D4A574` / `#A86F3C`) — no new design tokens.
- **`src/components/LegalPage.tsx`** (new): one component, two docs (`/legal/privacy`, `/legal/terms`). Theme-aware surfaces, mono uppercase labels, serif headings — same shell vocabulary as `ExplorePlaceholder`. Each page has a visible **"Beta — plain-language summary"** badge so users don't mistake the interim copy for a finalized policy. Each page cross-links to its sibling and provides an explicit "Back to Curio" affordance.
- **Routes**: `App.tsx` registers `Route path="/legal/:doc"` and exempts `/legal/*` from the access gate the same way `/explore` is exempted (`isLegalRoute = location.pathname.startsWith('/legal/')`). Legal pages must be reachable pre-login — they're the consent target, opening from the signup screen.
- **i18n**: 18 new keys covering EN + ZH (consent line lead/and/tail so word order works in both languages, section titles, body copy, cross-doc labels, "back to Curio").
- **Tests**:
  - `tests/components/AuthModal.test.tsx` — two new cases (consent only in signup mode; both links carry the expected hash href, target, rel).
  - `tests/components/LegalPage.test.tsx` — privacy + terms render their promised sections, beta badge is present, cross-link points to the sibling doc, "Back to Curio" goes home, unknown `:doc` param falls back to privacy.

The page content describes today's actual behavior (Supabase + Supabase Storage data model, Gemini receives photos only, Vercel Speed Insights/Analytics for telemetry, deletion via maintainer contact, content ownership, acceptable use, beta availability). Nothing about fictional features.

## Why this approach

Smallest change that satisfies every acceptance criterion:
- in-app pages, not GitHub README redirects, so the user never leaves Curio mid-signup;
- one component for both docs, driven by a `:doc` route param, so adding a third doc later is a section array entry;
- theme tokens reused from `theme.tsx` (`panelSurfaceClasses`, `mutedTextClasses`, `typographyClasses`), not new design tokens — no risk to the design system;
- consent text reuses the existing `t(...)` pattern; word-order seams (`lead` / `and` / `tail`) make ZH grammatical without forcing a placeholder-substitution helper.

## Risks

Low (Green tier). New presentational pages + one consent line + one route + one access-gate exemption. No data flow, AI, sync, RLS, storage, or auth-behavior changes. The exemption only **allows** access pre-login; nothing weakens auth requirements for create/save flows (those continue to gate at the `AccessGate` and at write-time prompts). Existing tests for AuthModal, access-gate routing, and sample-mode all stay green.

## How to verify

Vercel Preview: _auto-deployed on PR_

Steps:
1. Open the app signed out. Trigger the AuthModal (Add your first item / profile icon).
2. Switch to **Sign up**. Confirm the consent line is visible below the Create Account button and the two links open `#/legal/terms` and `#/legal/privacy` in new tabs.
3. In each legal tab, confirm: serif title, mono "BETA" badge, the section headings (What we store / AI metadata extraction / Analytics / Deleting your data, or Your content / Acceptable use / Availability and changes), Questions section, and a working cross-link to the sibling doc and "Back to Curio".
4. Switch the app theme between **Gallery**, **Vault**, **Atelier** and reload `/legal/privacy`. Surface, text, badge, and link colors should match each theme.
5. Switch language to **ZH**. Reload the legal page and re-open the signup consent line. Copy should be in Chinese throughout.
6. Switch to sign-in mode in the modal — the consent line must disappear.
7. Reset-password and set-password modes — consent line must stay hidden.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 48 files, 638 passed, 2 skipped, 1 todo (incl. 6 new tests for CUR-57)
- [x] `npm run build` — passed (vite 6.4.1, 1815 modules)
- [ ] `npm run test:e2e` — **not run** in this remote execution environment. Playwright 1.57 needs browser build v1200; the only Chromium preinstalled in the sandbox is v1194, and `npx playwright install chromium` is blocked by the network allowlist (`403 Host not in allowlist` from both `cdn.playwright.dev` and `playwright.download.prss.microsoft.com`). Same documented limitation as in #226, #237, #244, #253, #255. CI will run e2e. The diff is presentational (one new component, one route, one consent line, copy), with no spec selectors changed.

## Screenshot / GIF

Not captured in-sandbox (no headless browser available — see e2e note). Verifiable on the Vercel preview via the steps above. The new test IDs (`signup-legal-consent`, `legal-page-privacy`, `legal-page-terms`) make follow-up e2e coverage straightforward.

## Linear

Closes CUR-57

## Rollback plan

Single-commit revert:

```
git revert 194e05f
```

No schema, RLS, storage, env-var, or feature-flag changes — the revert restores the prior AuthModal and removes the two new routes/pages exactly as they were.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeTrKH67Vagw6UWVd1rBQq)_