### PR TITLE
Fix duplicate mutedTextClasses import breaking dev server (and e2e CI)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,6 @@ import {
   accentColorClasses,
   dividerClasses,
   cardHoverClasses,
-  mutedTextClasses,
 } from './theme';
 import { StatusToast, StatusTone } from './components/StatusToast';
 import { StatusBanner } from './components/StatusBanner';


### PR DESCRIPTION
## Problem

Investigating the e2e CI failures on #263 (24/24 e2e specs failing twice with identical "collections-grid never appears" / "invalid route doesn't redirect" errors, unrelated to that PR's StatusToast diff).

The CI job log for #263 shows the actual root cause, repeated on every dev-server restart:

```
[WebServer] [vite] Internal server error: /home/runner/work/curio/curio/src/App.tsx: Identifier 'mutedTextClasses' has already been declared. (103:2)
```

`src/App.tsx` has had a duplicate named import of `mutedTextClasses` from `./theme` since **#260 (CUR-85)** was merged — it was already imported by **#257 (CUR-84)**, and #260 added a second copy:

```ts
import {
  ...
  labelColorClasses,
  mutedTextClasses,   // added by #257 (CUR-84)
  inputClasses,
  accentColorClasses,
  dividerClasses,
  cardHoverClasses,
  mutedTextClasses,   // duplicate added by #260 (CUR-85)
} from './theme';
```

- **`npm run build`** (Rollup) silently tolerates the duplicate — it still reports "✓ 1814 modules transformed" — so this slipped through CI undetected.
- **`npm run dev`** (Vite dev server / esbuild+Babel parser) throws a hard syntax error and serves a 500 for the entire `App.tsx` module, leaving the whole app blank.
- **Playwright e2e** boots the dev server, so every test that loads the app (anything going through `ensureSampleBrowse`, all of `accessibility.spec.ts`, etc.) hits the blank page and times out waiting for `collections-grid`, headings, the catch-all redirect, etc.

This currently breaks `npm run dev` (and therefore e2e CI) on `main` HEAD for **every** PR, not just #263.

## Fix

Remove the duplicate `mutedTextClasses` entry from the import (one-line change, `src/App.tsx`).

## Verification

- `npm run format:check` — passed
- `npm test` — 47 files, 632 passed, 2 skipped, 1 todo
- `npm run build` — passed (vite 6.4.1, 1814 modules)
- `npm run test:e2e` — **36 passed, 10 skipped** (chromium + mobile-chrome). Confirmed `npm run dev` now serves `App.tsx` with HTTP 200 (was 500 before the fix), and the two specs that were failing on #263 (`should redirect invalid routes back to home`, `should allow exploring sample collections without authentication`) now pass.

## Risk

Trivial (Green tier). Single-line removal of a duplicate import; `mutedTextClasses` remains imported once and all 4 existing usages are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH5auQ4o4v6ntSLyRWsa2C)_