### PR TITLE
[CUR-98] Item Detail rating: theme-aware empty stars on Vault

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import {
   ListOrdered,
   Undo2,
   Redo2,
+  Star,
 } from 'lucide-react';
 import { Button } from './components/ui/Button';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
@@ -101,6 +102,8 @@ import {
   accentColorClasses,
   dividerClasses,
   cardHoverClasses,
+  ratingColorClasses,
+  ratingEmptyClasses,
 } from './theme';
 import { StatusToast, StatusTone } from './components/StatusToast';
 import { StatusBanner } from './components/StatusBanner';
@@ -1943,13 +1946,14 @@ export const AppContent: React.FC = () => {
                       className={`p-2 min-w-[48px] min-h-[48px] flex items-center justify-center transition-transform ${isReadOnly ? 'cursor-not-allowed opacity-70' : 'hover:scale-125'}`}
                       disabled={isReadOnly}
                     >
-                      <span className="text-2xl sm:text-4xl">
-                        {star <= item.rating ? (
-                          <span className="text-amber-500">★</span>
-                        ) : (
-                          <span className="text-amber-500/20">★</span>
-                        )}
-                      </span>
+                      <Star
+                        className={`w-6 h-6 sm:w-9 sm:h-9 ${
+                          star <= item.rating
+                            ? `${ratingColorClasses[theme]} fill-current`
+                            : ratingEmptyClasses[theme]
+                        }`}
+                        strokeWidth={1.5}
+                      />
                     </button>
                   ))}
                   <span


### PR DESCRIPTION
## Problem

On Item Detail, the 5-star rating was rendered with hardcoded `text-amber-500` (filled) and `text-amber-500/20` (empty) on every theme. On **Vault** (near-black surface), the 20%-opacity unicode `★` collapsed into a barely visible glyph — the "5 stars total" affordance disappeared, and a user with rating 0 or 1 had no signal that they could tap further. Inconsistent too with the canonical theme-aware pattern already used by `ItemCard` and `components/ui/Rating`, which route through `ratingColorClasses` / `ratingEmptyClasses`.

Protects **Beauty before bureaucracy** and **Trust before growth** from `docs/PRODUCT_STRATEGY.md`: the rating is one of the most-touched controls on Item Detail, and Vault is one of three first-class themes.

Sibling-fix to the same Item Detail theme-polish thread as CUR-73, CUR-84, CUR-85.

## Approach

- `src/App.tsx`: replace the inline unicode-star + hardcoded amber classes with Lucide's outline `Star` icon, sized `w-6 h-6 sm:w-9 sm:h-9` to visually match the prior `text-2xl sm:text-4xl` footprint.
- Filled stars use `${ratingColorClasses[theme]} fill-current`; empty stars use `ratingEmptyClasses[theme]`. Both maps already exist in `src/theme.tsx` and are unit-tested in `tests/unit/theme.test.ts`.
- Tap target (`min-w-[48px] min-h-[48px]`), hover scale, `aria-label`, `aria-pressed`, `title`, and `disabled`/read-only behaviour are all preserved unchanged.
- Adds `Star` to the existing lucide-react import block and `ratingColorClasses` / `ratingEmptyClasses` to the existing `./theme` import block — no new dependencies.

## Why this approach

Smallest change that satisfies every acceptance criterion. Reuses tokens already trusted elsewhere (ItemCard, ui/Rating) so the three themes feel like one design system. Switching to the outline `Star` icon also makes the empty state read as an outline shape rather than a faded glyph, so the affordance survives even on the darkest surfaces and on assistive zoom.

## Risks

Low (Green tier, 11 +/7 - LOC). Pure presentational change on a single rating control. No data flow, sync, auth, AI, RLS, routing, or read-only-permission changes. Filled-star colour on Gallery is byte-identical (`text-amber-500`); Vault and Atelier filled colours move from `amber-500` to the established brass / leather tokens that the rest of the app already uses for stars (ItemCard, ui/Rating, AddItemModal batch verify).

## How to verify

Vercel Preview: _auto-deployed on PR_

Steps:
1. Open Curio in **Vault** theme. Open any item with rating 0 or 1. The unrated stars should now read as a row of brass outlines that clearly indicate "5 total", not as a near-invisible dim glyph.
2. Tap an empty star — `aria-pressed` updates and the star fills with brass `#D4A574`. Tap the existing filled star to decrease — still works.
3. Switch to **Atelier**. Empty stars render as leather-brown outlines on cream; filled stars are `#A86F3C`.
4. Switch to **Gallery**. Filled stars are `amber-500`; empty stars are `amber-500/30` outlines (very close to prior look, just 30% opacity outline instead of 20% solid glyph).
5. Sample (read-only) item: cursor is `not-allowed`, opacity 70%, no change on click — same as before.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 48 files, 656 passed / 2 skipped / 1 todo
- [x] `npm run build` — passed (vite 6.4.1, 1815 modules)
- [ ] `npm run test:e2e` — **not run** in this sandbox. Same documented limitation as PRs #226 / #237 / #244 / #253 / #255 / #262 / #263: Playwright 1.57 needs Chromium build v1200; only v1194 is preinstalled and `cdn.playwright.dev` + `playwright.download.prss.microsoft.com` are blocked by the network allowlist. Tracked separately in CUR-90. CI will run e2e. The diff is presentational with no e2e selectors changed (the rating button still exposes `aria-label={t('rateStars', { count })}` and `aria-pressed`).

## Screenshot / GIF

Not captured in-sandbox (no headless browser — see e2e note). Verifiable on the Vercel preview via the steps above.

## Linear

Closes CUR-98

## Rollback plan

Single-commit revert — no schema, RLS, storage, env-var, or feature-flag changes:

```
git revert 2e1e59e
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xao9AnwZzKYP8xG7KJwUvH)_