### PR TITLE
[CUR-99] Decouple exported card resolution from viewport width

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -23,6 +23,11 @@ type TemplateStyle = 'minimal' | 'full' | 'retro';
 type AspectRatio = '1:1' | '3:4' | '9:16';
 type ImageFit = 'cover' | 'contain';
 
+// CUR-99: rasterize the card at a fixed minimum short-edge resolution
+// (1080px) instead of inheriting the viewport-dependent preview size, so
+// a phone export reads as sharp as a desktop export when re-shared.
+const EXPORT_TARGET_SHORT_EDGE_PX = 1080;
+
 export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item, fields }) => {
   const { t } = useTranslation();
   const [style, setStyle] = useState<TemplateStyle>('minimal');
@@ -153,8 +158,14 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
           }),
       ),
     );
+    // Width is the short edge for every supported aspect ratio (1:1, 3:4, 9:16),
+    // so scaling pixelRatio off offsetWidth is enough. Floor at 2 so retina
+    // desktop exports keep their current quality.
+    const previewWidth = node.offsetWidth;
+    const pixelRatio =
+      previewWidth > 0 ? Math.max(2, EXPORT_TARGET_SHORT_EDGE_PX / previewWidth) : 2;
     return toBlob(node, {
-      pixelRatio: 2,
+      pixelRatio,
       backgroundColor: '#ffffff',
     });
   }, []);

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -3,6 +3,7 @@ import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../utils/test-utils';
 import { ExportModal } from '@/components/ExportModal';
 import type { CollectionItem, FieldDefinition } from '@/types';
+import { toBlob } from 'html-to-image';
 
 vi.mock('@/services/db', () => ({
   extractCurioAssetPath: vi.fn().mockReturnValue(null),
@@ -124,5 +125,63 @@ describe('ExportModal — CUR-83 footer CTA hierarchy', () => {
     } finally {
       window.print = originalPrint;
     }
+  });
+});
+
+describe('ExportModal — CUR-99 fixed export resolution', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  const stubOffsetWidth = (width: number) => {
+    const card = document.getElementById('card-preview') as HTMLElement | null;
+    expect(card).not.toBeNull();
+    Object.defineProperty(card!, 'offsetWidth', { configurable: true, value: width });
+    return card!;
+  };
+
+  const triggerSave = async () => {
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /save image/i }));
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('bumps pixelRatio so a narrow phone preview still rasterises at ≥1080px short edge', async () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+    stubOffsetWidth(331); // 390px viewport × 85vw ≈ 331px
+
+    await triggerSave();
+
+    expect(toBlob).toHaveBeenCalledTimes(1);
+    const [, options] = (toBlob as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.pixelRatio).toBeGreaterThanOrEqual(1080 / 331);
+    expect(331 * options.pixelRatio).toBeGreaterThanOrEqual(1080);
+  });
+
+  it('keeps pixelRatio at 2 on desktop where the preview is already wide enough', async () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+    stubOffsetWidth(560); // desktop cap from min(85vw, 560px)
+
+    await triggerSave();
+
+    const [, options] = (toBlob as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.pixelRatio).toBe(2);
+  });
+
+  it('falls back to pixelRatio 2 if the preview width is unmeasurable', async () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+    stubOffsetWidth(0);
+
+    await triggerSave();
+
+    const [, options] = (toBlob as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.pixelRatio).toBe(2);
   });
 });


### PR DESCRIPTION
## Problem

The export card is rasterized from the on-screen preview node, so the saved/shared PNG's resolution is a function of the user's viewport, not a fixed output size.

- `src/components/ExportModal.tsx:287` — preview width is `min(85vw, 560px)`
- `src/components/ExportModal.tsx:156-159` — `toBlob(node, { pixelRatio: 2 })` rasterizes that same node

On desktop the card exports at ~1120px wide. On a 390px-wide phone (85vw ≈ 331px) the same card exports at ~660px — and phones are exactly where Save Image / Share will be used most. Text on the card (serif title, mono footer) renders noticeably soft when the PNG is viewed or re-shared on social platforms, which undermines the "proudly share" core loop.

It also means the same item produces different-quality artifacts depending on device, so a user who shares from phone and later from desktop gets inconsistent results.

Protects **Sharing before social complexity** from `docs/PRODUCT_STRATEGY.md`: the export card is the share artifact, so it should look like a finished thing on every device.

## Approach

`src/components/ExportModal.tsx`:

- Introduce `EXPORT_TARGET_SHORT_EDGE_PX = 1080` as the minimum short-edge resolution of the rasterized PNG.
- In `renderCardToBlob`, replace the hardcoded `pixelRatio: 2` with a value computed off the live preview width: `Math.max(2, EXPORT_TARGET_SHORT_EDGE_PX / node.offsetWidth)`.
- Floor at 2 so retina desktop exports keep their current quality (the 560px desktop cap × 2 = 1120px is already above target).
- Guard the divide so a 0/unmeasurable `offsetWidth` falls back to pixelRatio 2 instead of `Infinity`.

For every supported aspect ratio (1:1, 3:4, 9:16) the width is the short edge, so scaling pixelRatio off `offsetWidth` is enough — the rasterized height scales proportionally because html-to-image scales the whole node.

`tests/components/ExportModal.test.tsx`:

- Three new Vitest cases under `CUR-99 fixed export resolution` pinning the phone (~331px), desktop (560px), and unmeasurable (0px) branches. Each stubs `cardRef.current.offsetWidth`, triggers Save Image, and asserts the `pixelRatio` passed to `toBlob`.

## Why this approach

Smallest taste-aligned fix: one constant + one expression in a single callback. No new render path, no off-screen hidden node, no layout change, no new dependencies. Reusing html-to-image's existing `pixelRatio` knob means font sizes/borders scale proportionally — the rasterized output stays a pixel-true upscale of the visible preview, just sharper. Phone and desktop now produce the same artifact size from the same item.

## Risks

Low (Green tier, +71/-1 LOC). Pure rasterization-quality change in a single callback.

- The desktop branch is byte-identical: `Math.max(2, 1080/560)` resolves to `2`.
- The phone branch increases pixelRatio from 2 to ~3.26 on a 331px-wide preview, raising the output to ~1080×1440 at 3:4 instead of ~660×880. Output is a regular PNG canvas (≤ ~8MB raw at 9:16 1080×1920), well within mobile memory budgets.
- No data flow, sync, auth, AI, RLS, storage, routing, read-only-permission, or design-token changes.

## How to verify

Vercel Preview: *auto-deployed on PR*

Steps:
1. On a phone (or 390px-wide desktop window), open any item in the sample gallery → tap Print/Export → tap **Save image**.
2. Inspect the saved PNG. Short edge should be ≥1080px (e.g. 1080×1440 for 3:4) regardless of the device viewport.
3. Repeat on a desktop window where the preview hits the 560px cap. Output is ~1120×… (unchanged from before).
4. Switch aspect ratio to 1:1 and 9:16, repeat — both still produce ≥1080px short edge.
5. Confirm the layout is identical to the preview — just sharper text and edges.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 48 files, 672 passed / 2 skipped / 1 todo (3 new under "CUR-99 fixed export resolution")
- [x] `npm run build` — passed (vite 6.4.1, 1815 modules)
- [ ] `npm run test:e2e` — **not run** in this remote execution environment. Same documented limitation as recent PRs (#266, #267, #268) and tracked in CUR-90: Playwright 1.57 needs Chromium build v1200; only v1194 is preinstalled in the sandbox, and `npx playwright install chromium` is blocked by the network allowlist (`Failed to download Chromium 143.0.7499.4 (playwright build v1200)`). CI will run e2e. The diff does not touch any e2e selectors or routes.

## Screenshot / GIF

Not captured in-sandbox (no headless browser — see e2e note). Verifiable on the Vercel preview by saving the export card on a phone and confirming the PNG's pixel dimensions.

## Linear

Closes CUR-99

## Rollback plan

Single-commit revert restores `pixelRatio: 2`:

```
git revert 7daee19
```

No schema, RLS, storage, env-var, or feature-flag changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcPeugD9tPwnoMzYhX1DTA)_