### PR TITLE
[CUR-107] Make ui/Button theme-aware so outline/ghost stay legible on Vault/Atelier

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -545,6 +545,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
             </p>
           )}
           <Button
+            theme="gallery"
             className="w-full"
             size="lg"
             onClick={handleSaveImage}
@@ -560,6 +561,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
             {exportAction === 'save' ? t('saving') : t('saveImage')}
           </Button>
           <Button
+            theme="gallery"
             variant="outline"
             className="w-full"
             onClick={handleShare}
@@ -576,6 +578,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
           </Button>
           <div className="flex justify-center">
             <Button
+              theme="gallery"
               variant="ghost"
               size="sm"
               onClick={() => window.print()}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,24 +1,57 @@
 import React from 'react';
+import { useTheme } from '@/theme';
+import { AppTheme } from '@/types';
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'outline';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'ghost' | 'outline';
+  variant?: Variant;
   size?: 'sm' | 'md' | 'lg';
   icon?: React.ReactNode;
+  /**
+   * Override the theme used to style this button. Useful for buttons that
+   * sit on a surface whose color is pinned regardless of the app theme
+   * (e.g. the white export sheet in ExportModal).
+   */
+  theme?: AppTheme;
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { children, variant = 'primary', size = 'md', className = '', icon, ...props },
-  ref,
-) {
-  const baseStyles =
-    'inline-flex items-center justify-center font-medium transition-all duration-200 ease-out focus:outline-none focus:ring-2 focus:ring-offset-1 rounded-full disabled:opacity-50 disabled:cursor-not-allowed motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 motion-safe:active:scale-[0.98]';
-
-  const variants = {
+const variantClasses: Record<AppTheme, Record<Variant, string>> = {
+  gallery: {
     primary: 'bg-stone-800 text-stone-50 hover:bg-stone-700 shadow-sm',
     secondary: 'bg-amber-100 text-amber-900 hover:bg-amber-200',
     outline: 'border border-stone-300 text-stone-700 hover:bg-stone-50',
     ghost: 'text-stone-600 hover:bg-stone-100/50 hover:text-stone-900',
-  };
+  },
+  vault: {
+    primary: 'bg-[#D4A574] text-stone-900 hover:bg-[#E0B585] shadow-vault',
+    secondary: 'bg-[#D4A574]/15 text-[#E0B585] hover:bg-[#D4A574]/25',
+    outline: 'border border-white/20 text-white hover:bg-white/5',
+    ghost: 'text-stone-300 hover:bg-white/5 hover:text-white',
+  },
+  atelier: {
+    primary: 'bg-[#A86F3C] text-white hover:bg-[#8B5A2B] shadow-atelier',
+    secondary: 'bg-[#A86F3C]/15 text-[#8B5A2B] hover:bg-[#A86F3C]/25',
+    outline: 'border border-[#D4C9B8] text-[#3D3530] hover:bg-[#EDE4D3]',
+    ghost: 'text-[#8C7B6B] hover:bg-[#EDE4D3]/60 hover:text-[#3D3530]',
+  },
+};
+
+const focusRingClasses: Record<AppTheme, string> = {
+  gallery: 'focus:ring-amber-500/40',
+  vault: 'focus:ring-[#D4A574]/40',
+  atelier: 'focus:ring-[#A86F3C]/40',
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { children, variant = 'primary', size = 'md', className = '', icon, theme: themeProp, ...props },
+  ref,
+) {
+  const { theme: contextTheme } = useTheme();
+  const theme = themeProp ?? contextTheme;
+
+  const baseStyles =
+    'inline-flex items-center justify-center font-medium transition-all duration-200 ease-out focus:outline-none focus:ring-2 focus:ring-offset-1 rounded-full disabled:opacity-50 disabled:cursor-not-allowed motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 motion-safe:active:scale-[0.98]';
 
   const sizes = {
     sm: 'text-xs px-4 py-2 gap-1.5',
@@ -29,7 +62,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function 
   return (
     <button
       ref={ref}
-      className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`}
+      className={`${baseStyles} ${focusRingClasses[theme]} ${variantClasses[theme][variant]} ${sizes[size]} ${className}`}
       {...props}
     >
       {icon && (

--- a/tests/components/ui/Button.test.tsx
+++ b/tests/components/ui/Button.test.tsx
@@ -1,11 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from '../../utils/test-utils';
+import { renderWithProviders, setMockTheme } from '../../utils/test-utils';
 import { Button } from '@/components/ui/Button';
 import { Camera, Plus } from 'lucide-react';
 
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../../utils/test-utils');
+  return createThemeMock();
+});
+
 describe('Button', () => {
+  beforeEach(() => {
+    setMockTheme('gallery');
+  });
+
   describe('Basic Rendering', () => {
     it('renders button with text content', () => {
       renderWithProviders(<Button>Click me</Button>);
@@ -192,6 +201,93 @@ describe('Button', () => {
       expect(button).toHaveClass('inline-flex');
       expect(button).toHaveClass('items-center');
       expect(button).toHaveClass('justify-center');
+    });
+  });
+
+  describe('Theme-aware variants (CUR-107)', () => {
+    // Each variant must carry its theme's accent so outline/ghost stay legible
+    // on Vault/Atelier surfaces instead of inheriting Gallery-only tokens.
+
+    describe('Vault', () => {
+      beforeEach(() => {
+        setMockTheme('vault');
+      });
+
+      it('primary uses brass on dark', () => {
+        renderWithProviders(<Button>Primary</Button>);
+        const button = screen.getByRole('button');
+        expect(button).toHaveClass('bg-[#D4A574]');
+        expect(button).toHaveClass('text-stone-900');
+        expect(button).not.toHaveClass('bg-stone-800');
+      });
+
+      it('outline stays legible on dark surfaces', () => {
+        renderWithProviders(<Button variant="outline">Outline</Button>);
+        const button = screen.getByRole('button');
+        expect(button).toHaveClass('border-white/20');
+        expect(button).toHaveClass('text-white');
+        expect(button).not.toHaveClass('text-stone-700');
+      });
+
+      it('ghost uses light text instead of stone-600', () => {
+        renderWithProviders(<Button variant="ghost">Ghost</Button>);
+        const button = screen.getByRole('button');
+        expect(button).toHaveClass('text-stone-300');
+        expect(button).not.toHaveClass('text-stone-600');
+      });
+
+      it('focus ring picks up the brass accent', () => {
+        renderWithProviders(<Button>Focus</Button>);
+        expect(screen.getByRole('button')).toHaveClass('focus:ring-[#D4A574]/40');
+      });
+    });
+
+    describe('Atelier', () => {
+      beforeEach(() => {
+        setMockTheme('atelier');
+      });
+
+      it('primary uses leather brown on cream', () => {
+        renderWithProviders(<Button>Primary</Button>);
+        const button = screen.getByRole('button');
+        expect(button).toHaveClass('bg-[#A86F3C]');
+        expect(button).toHaveClass('text-white');
+        expect(button).not.toHaveClass('bg-stone-800');
+      });
+
+      it('outline uses the warm border', () => {
+        renderWithProviders(<Button variant="outline">Outline</Button>);
+        const button = screen.getByRole('button');
+        expect(button).toHaveClass('border-[#D4C9B8]');
+        expect(button).toHaveClass('text-[#3D3530]');
+      });
+
+      it('ghost uses sepia text instead of cool stone', () => {
+        renderWithProviders(<Button variant="ghost">Ghost</Button>);
+        expect(screen.getByRole('button')).toHaveClass('text-[#8C7B6B]');
+      });
+
+      it('focus ring picks up the leather accent', () => {
+        renderWithProviders(<Button>Focus</Button>);
+        expect(screen.getByRole('button')).toHaveClass('focus:ring-[#A86F3C]/40');
+      });
+    });
+
+    describe('theme prop override', () => {
+      it('pins styling to the supplied theme regardless of context', () => {
+        // Mimics ExportModal: a forced-light sheet that must keep Gallery
+        // tokens even when the surrounding app is in Vault.
+        setMockTheme('vault');
+        renderWithProviders(
+          <Button theme="gallery" variant="outline">
+            Save
+          </Button>,
+        );
+        const button = screen.getByRole('button');
+        expect(button).toHaveClass('border-stone-300');
+        expect(button).toHaveClass('text-stone-700');
+        expect(button).not.toHaveClass('text-white');
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

The shared `Button` component (`src/components/ui/Button.tsx`) defined all four variants with Gallery-only `stone`/`amber` tokens and had no theme awareness:

```tsx
outline: 'border border-stone-300 text-stone-700 hover:bg-stone-50',
ghost:   'text-stone-600 hover:bg-stone-100/50 hover:text-stone-900',
```

On **Vault**, `text-stone-700` on a near-black surface was effectively invisible and the ghost hover (`text-stone-900`) made things worse. On **Atelier**, the cool stone palette clashed with the cream/leather direction in `DESIGN.md`. Per-call-site `className` patches kept reappearing because the root cause lived in `Button`. The focus ring also relied on Tailwind's default (blue) — at odds with Curio's "no blue anywhere" rule.

This is the upstream fix several individually-reported contrast issues kept pointing at, and it protects **Beauty before bureaucracy** and **Trust before growth** (controls have to look usable on every theme).

## Approach

- `src/components/ui/Button.tsx`: read `useTheme()` and map each variant to per-theme tokens taken from `DESIGN.md`/`theme.tsx`:
  - **Gallery**: unchanged (`bg-stone-800` primary, `border-stone-300` outline, `text-stone-600` ghost, amber secondary).
  - **Vault**: brass-on-dark primary (`#D4A574` → `#E0B585`), brass-tinted secondary, `border-white/20`/`text-white` outline, `text-stone-300` ghost.
  - **Atelier**: aged-leather primary (`#A86F3C` → `#8B5A2B`), warm border on outline, sepia `#8C7B6B` ghost.
  - Focus ring now follows the theme accent (amber-500, brass, leather) instead of Tailwind's default blue.
- New optional `theme` prop on `Button`. When set, it pins styling regardless of context — used for surfaces whose color is forced (the white `ExportModal` sheet).
- `src/components/ExportModal.tsx`: the three footer buttons on the forced-light export sheet now pin `theme="gallery"` so they stay contrast-correct even when the app is in Vault/Atelier.
- `tests/components/ui/Button.test.tsx`: switches to the shared `createThemeMock`/`setMockTheme` pattern and adds coverage for Vault + Atelier variants (primary, outline, ghost), the theme-aware focus ring, and the `theme`-prop override.

## Why this approach

Centralising the variant maps in `Button` is the smallest fix that removes the root cause — every call site already passes `variant="outline"`/`"ghost"`, so no call-site changes were needed beyond `ExportModal`'s deliberate pin. The new `theme` prop is a one-line override that keeps the API minimal and matches the existing pattern of accepting a `theme` value (see `cardSurfaceClasses[theme]`). No new dependencies, no token changes, no design-system rewrite.

## Risks

Low (Green).

- `Button` is used in many places, so a visual regression on a missed surface is the main risk. The new variant maps were derived directly from existing theme-aware classes in `theme.tsx` (`cardSurfaceClasses`, `accentBgClasses`, `mutedTextClasses`, `dividerClasses`, `accentColorClasses`), so they're consistent with the rest of the app.
- `ExportModal` opts out via `theme="gallery"` because its sheet is forced-light in all themes — this is called out explicitly in the issue.
- Default theme when no `ThemeProvider` is present is still `gallery`, so existing snapshot/class assertions on Gallery palettes continue to pass.

## How to verify

Vercel Preview: _(Vercel will attach on PR open)_

Steps:

1. In `gallery`, open Item Detail and the Add Item flow — primary, outline, ghost CTAs match prior look (charcoal primary, amber/stone outlines).
2. Switch to `vault`. Open Add Item and Item Detail: primary CTAs read as warm brass on dark, outline buttons show a faint white border with white text, ghost buttons render in light stone text on hover. Focus ring on tab is brass, not blue.
3. Switch to `atelier`. Same surfaces: primary CTAs read as leather brown on cream, outline/ghost use sepia/aged-wood tones from `DESIGN.md`.
4. Open Export from any item in `vault` and `atelier`. The forced-white export sheet still shows charcoal "Save image", outlined "Share", and ghost "Print" — the buttons inside the sheet keep Gallery styling.
5. Tab through any modal in each theme — focus rings now match the theme accent.

Checks:

- [x] `npm run format:check` — passed
- [x] `npm test` — passed (48 files, 681 tests; new Vault/Atelier/`theme`-prop coverage included)
- [x] `npm run build` — passed
- [ ] `npm run test:e2e` — **not run locally**: the sandbox blocks the Playwright Chromium download (`cdn.playwright.dev` and `playwright.download.prss.microsoft.com` are not on the host allowlist, see CUR-90). CI will run the suite.

## Screenshot / GIF

Not captured in-sandbox — no headless browser available (see e2e note). Vercel preview will show the three themes side-by-side.

## Linear

Closes CUR-107
https://linear.app/qiuyue/issue/CUR-107

## Rollback plan

Revert the single commit:

```
git revert d0ef038
```

No schema, RLS, storage, or feature-flag changes — UI-only. Reverting restores the previous (Gallery-only) `Button` and the un-pinned `ExportModal` buttons.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnVugPMjScHuHGVBo8LkS7)_