### PR TITLE
[CUR-100] Disable Print in ExportModal while the card photo is still loading

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -582,7 +582,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
               variant="ghost"
               size="sm"
               onClick={() => window.print()}
-              disabled={exportAction !== null}
+              disabled={exportAction !== null || isLoadingImage}
               icon={<Printer size={14} />}
             >
               {t('print')}

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../utils/test-utils';
 import { ExportModal } from '@/components/ExportModal';
 import type { CollectionItem, FieldDefinition } from '@/types';
 import { toBlob } from 'html-to-image';
+import { getAsset, getEnhancedAsset } from '@/services/db';
 
 vi.mock('@/services/db', () => ({
   extractCurioAssetPath: vi.fn().mockReturnValue(null),
@@ -125,6 +126,44 @@ describe('ExportModal — CUR-83 footer CTA hierarchy', () => {
     } finally {
       window.print = originalPrint;
     }
+  });
+});
+
+describe('ExportModal — CUR-100 Print disabled while photo loading', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables Print, Save, and Share until the card photo finishes loading', async () => {
+    let resolveAsset: (value: Blob | null) => void = () => {};
+    const loadingPromise = new Promise<Blob | null>((resolve) => {
+      resolveAsset = resolve;
+    });
+    vi.mocked(getEnhancedAsset).mockReturnValueOnce(loadingPromise);
+    vi.mocked(getAsset).mockResolvedValue(null);
+
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    // While the photo fetch is in flight, Print must be disabled so it cannot
+    // snapshot the loading spinner / empty placeholder.
+    expect(screen.getByRole('button', { name: /^print$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /save image/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^share$/i })).toBeDisabled();
+
+    await act(async () => {
+      resolveAsset(null);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^print$/i })).not.toBeDisabled();
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

In `src/components/ExportModal.tsx`, **Save Image** and **Share** are disabled with `exportAction !== null || isLoadingImage` while the item photo is fetched from IndexedDB / Supabase (asset fallback chain: enhanced → original → display). **Print** only checked `exportAction !== null` and ignored `isLoadingImage`.

If the user taps Print during the asset-fetch window, `window.print()` snapshots the card in its loading state — the visible `Loader2` spinner or the empty "No Photo" placeholder — and the user prints a broken card.

Protects **Trust before growth** (printing must produce the card the user sees finished, not the in-flight state) on a primary share surface.

## Approach

`src/components/ExportModal.tsx` (1 line):

```diff
-              disabled={exportAction !== null}
+              disabled={exportAction !== null || isLoadingImage}
```

Aligns the Print button's disabled condition with the existing Save Image and Share buttons (both already use the same gate). No new state, no new helpers, no copy changes.

`tests/components/ExportModal.test.tsx` adds a regression test that holds the photo fetch open with a controllable Promise, asserts all three actions are disabled while loading, resolves the loader, and confirms Print becomes enabled. This test would have failed on the prior code.

## Why this approach

Smallest change that satisfies the acceptance criterion — Print uses the same readiness signal Save Image and Share already trust. Matches the existing pattern in the same component, so there is nothing new for a future reader to learn. Falls back gracefully if asset loading completes with no photo: the "No Photo" placeholder is intentional content and prints cleanly.

## Risks

Low (Green tier). One line in a single component; pure disable-condition change on an existing button. No data, sync, AI, auth, routing, or layout changes. The previously-enabled "Print during load" path was the bug being closed, so no users should miss it.

## How to verify

Vercel Preview: https://curio-git-claude-curio-100-disable-c857dc-qs-projects-72b20d9d.vercel.app

Steps:
1. Open an item whose photo is not yet cached in IndexedDB (or first-load after sign-in).
2. Tap the export icon to open the Export Card modal.
3. While the card preview shows the spinner, observe that **Save Image**, **Share**, and **Print** are all disabled.
4. Once the photo finishes loading, all three actions become enabled.
5. (Optional) For an item that has no photo at all: after the fetch resolves, the "No Photo" placeholder card prints cleanly — that path is intentional content, not a spinner.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 682 passed | 2 skipped | 1 todo (was 681; +1 = new CUR-100 regression)
- [x] `npm run build` — passed
- [ ] `npm run test:e2e` — **not run locally**: same pre-existing sandbox limitation called out by CUR-90 / PRs #260, #270 etc. The sandbox has Playwright Chromium build 1194 pre-installed, but Playwright 1.57 expects build 1200, and `playwright.download.prss.microsoft.com` is blocked by the host allowlist. CI ("Format / Unit / Build / E2E") covers it. The diff is one disabled-prop change on an existing button — no routing, selector, or layout impact.

## Screenshot / GIF

Not captured in-sandbox (no headless browser available — see E2E note). The visual change is bounded to the disabled state of the Print button on the Export Card sheet during the asset-fetch window.

## Linear

Closes CUR-100
https://linear.app/qiuyue/issue/CUR-100/ux-print-button-stays-enabled-while-the-card-photo-is-still-loading

## Rollback plan

Revert the single commit:

```
git revert 31c3e58
```

No schema, RLS, storage, feature-flag, or env-var changes — UI-only fix in one component plus one new Vitest regression.
