### PR TITLE
fix(sync): stop initial load from stranding users on "Restoring the archives…"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -559,24 +559,49 @@ export const AppContent: React.FC = () => {
     }
     setIsLoading(true);
     setLoadError(null);
+
+    // Persistent storage is best-effort; never let it block or fail the load.
     try {
       await withTimeout(requestPersistence(), 4000, 'Persistence request timed out');
+    } catch (e) {
+      console.warn('Persistent storage request failed (continuing):', e);
+    }
 
-      const localCollections = await loadLocalCollectionsWithTimeout();
-      let cloudCollections: UserCollection[] = [];
-      try {
-        cloudCollections = await loadCloudCollectionsWithTimeout(user?.id ?? null);
-      } catch (e) {
-        console.warn('Supabase cloud fetch failed:', e);
-        setHasLocalImport(false);
+    // Local cache is a fallback; a slow/corrupt read must not abort the load.
+    let localCollections: UserCollection[] = [];
+    try {
+      localCollections = await loadLocalCollectionsWithTimeout();
+    } catch (e) {
+      console.warn('Local cache load failed (continuing):', e);
+    }
+
+    let cloudCollections: UserCollection[] = [];
+    try {
+      cloudCollections = await loadCloudCollectionsWithTimeout(user?.id ?? null);
+    } catch (e) {
+      console.warn('Supabase cloud fetch failed:', e);
+      setHasLocalImport(false);
+      setConflicts([]);
+      setIsConflictModalOpen(false);
+      // Prefer showing whatever we already have (cached or sample) over a
+      // blocking error screen. Only hard-block when there is genuinely nothing
+      // to display so the user can retry.
+      if (localCollections.length > 0) {
         setCollections(localCollections);
+        setLoadError(null);
+      } else if (!user) {
+        setCollections(fallbackSampleCollections);
+        setLoadError(null);
+      } else {
+        setCollections([]);
         setLoadError(tRef.current('loadErrorCloudFetch'));
-        setConflicts([]);
-        setIsConflictModalOpen(false);
-        showStatusRef.current(tRef.current('statusSyncPaused'), 'error');
-        return;
       }
+      showStatusRef.current(tRef.current('statusSyncPaused'), 'error');
+      setIsLoading(false);
+      return;
+    }
 
+    try {
       cloudCollections = await maybeSeedCollections({
         user,
         isAdmin,
@@ -615,34 +640,50 @@ export const AppContent: React.FC = () => {
 
       setHasLocalImport(resolvedHasLocalImport);
 
-      if (shouldPersist) {
-        await saveAllCollections(mergedCollections);
-      }
-
+      // Render the result and clear loading immediately. Cache persistence and
+      // pending-sync flushing run in the background so a slow IndexedDB write or
+      // a stalled upload can never keep the user stuck on the loading screen.
       setCollections(resolvedCollections);
+      setLoadError(null);
+      setIsLoading(false);
       if (showSyncedStatus) {
         showStatusRef.current(tRef.current('statusSynced'), 'success');
       }
-      if (user && navigator.onLine) {
-        const synced = await syncPendingChanges();
-        if (synced > 0) {
-          showStatusRef.current(
-            tRef.current('statusPendingSynced').replace('{count}', String(synced)),
-            'success',
-          );
+
+      void (async () => {
+        try {
+          if (shouldPersist) {
+            await saveAllCollections(mergedCollections);
+          }
+          if (user && navigator.onLine) {
+            const synced = await syncPendingChanges();
+            if (synced > 0) {
+              showStatusRef.current(
+                tRef.current('statusPendingSynced').replace('{count}', String(synced)),
+                'success',
+              );
+            }
+            await syncPendingAssetUploads();
+            await syncPendingDeletes();
+            void refreshPendingAssetUploads();
+          }
+        } catch (e) {
+          console.warn('Background cache persistence/sync failed:', e);
         }
-        await syncPendingAssetUploads();
-        await syncPendingDeletes();
-        void refreshPendingAssetUploads();
-      }
+      })();
     } catch (e) {
       console.error('Initialization failed:', e);
-      setLoadError(tRef.current('loadErrorGeneric'));
-      showStatusRef.current(tRef.current('statusSyncPaused'), 'error');
       setConflicts([]);
       setIsConflictModalOpen(false);
-      setCollections([]);
-    } finally {
+      // Fall back to cached data rather than blanking the UI when possible.
+      if (localCollections.length > 0) {
+        setCollections(localCollections);
+        setLoadError(null);
+      } else {
+        setCollections([]);
+        setLoadError(tRef.current('loadErrorGeneric'));
+      }
+      showStatusRef.current(tRef.current('statusSyncPaused'), 'error');
       setIsLoading(false);
     }
   }, [

--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -182,40 +182,65 @@ export const useCollections = ({
     }
     setIsLoading(true);
     setLoadError(null);
+
+    // Persisting storage is best-effort; never let it block or fail the load.
     try {
       await withTimeout(requestPersistence(), 4000, 'Persistence request timed out');
+    } catch (e) {
+      console.warn('Persistent storage request failed (continuing):', e);
+    }
 
-      const localCollections = await withTimeout(
+    // Local cache is a fallback; a slow/corrupt read must not block the load.
+    let localCollections: UserCollection[] = [];
+    try {
+      localCollections = await withTimeout(
         getLocalCollections(),
         4000,
         'Local cache load timed out',
       );
-      let cloudCollections: UserCollection[] = [];
-      try {
-        cloudCollections = await withTimeout(
-          fetchCloudCollections({ userId: user?.id ?? null, includePublic: true }),
-          12000,
-          'Cloud fetch timed out',
-        );
-      } catch (e) {
-        console.warn('Supabase cloud fetch failed:', e);
-        setHasLocalImport(false);
+    } catch (e) {
+      console.warn('Local cache load failed (continuing):', e);
+    }
+
+    let cloudCollections: UserCollection[] = [];
+    try {
+      cloudCollections = await withTimeout(
+        fetchCloudCollections({ userId: user?.id ?? null, includePublic: true }),
+        12000,
+        'Cloud fetch timed out',
+      );
+    } catch (e) {
+      console.warn('Supabase cloud fetch failed:', e);
+      setHasLocalImport(false);
+      // Prefer showing whatever we already have cached over a blocking error
+      // screen. Only hard-block when there is genuinely nothing to display.
+      if (localCollections.length > 0) {
         setCollections(localCollections);
+        setLoadError(null);
+      } else if (!user) {
+        setCollections(fallbackSampleCollections);
+        setLoadError(null);
+      } else {
+        setCollections([]);
         setLoadError('Unable to sync with Supabase. Check your connection and Supabase settings.');
-        showStatus(t('statusSyncPaused'), 'error');
-        return;
       }
+      showStatus(t('statusSyncPaused'), 'error');
+      setIsLoading(false);
+      return;
+    }
 
-      if (!user) {
-        setHasLocalImport(false);
-        if (cloudCollections.length === 0 && localCollections.length === 0) {
-          setCollections(fallbackSampleCollections);
-        } else {
-          setCollections(cloudCollections);
-        }
-        return;
+    if (!user) {
+      setHasLocalImport(false);
+      if (cloudCollections.length === 0 && localCollections.length === 0) {
+        setCollections(fallbackSampleCollections);
+      } else {
+        setCollections(cloudCollections);
       }
+      setIsLoading(false);
+      return;
+    }
 
+    try {
       const localOnly = hasLocalOnlyData(localCollections, cloudCollections);
       setHasLocalImport(localOnly);
 
@@ -245,27 +270,44 @@ export const useCollections = ({
         pendingDeletes,
       });
 
-      await saveAllCollections(mergedCollections);
+      // Render the merged result immediately and stop the loading state. Cache
+      // persistence and pending-sync flushing run in the background so a slow
+      // IndexedDB write or a stalled upload can never keep the user stuck on the
+      // "Restoring the archives..." screen.
       setCollections(mergedCollections);
+      setLoadError(null);
+      setIsLoading(false);
       if (cloudCollections.length + localCollections.length > 0) {
         showStatus(t('statusSynced'), 'success');
       }
 
-      // Sync any pending changes from previous offline session (only when online and logged in)
-      if (user && navigator.onLine) {
-        const synced = await syncPendingChanges();
-        if (synced > 0) {
-          showStatus(t('statusPendingSynced').replace('{count}', String(synced)), 'success');
+      void (async () => {
+        try {
+          await saveAllCollections(mergedCollections);
+          // Sync any pending changes from a previous offline session.
+          if (navigator.onLine) {
+            const synced = await syncPendingChanges();
+            if (synced > 0) {
+              showStatus(t('statusPendingSynced').replace('{count}', String(synced)), 'success');
+            }
+            await syncPendingAssetUploads();
+            await syncPendingDeletes();
+          }
+        } catch (e) {
+          console.warn('Background cache persistence/sync failed:', e);
         }
-        await syncPendingAssetUploads();
-        await syncPendingDeletes();
-      }
+      })();
     } catch (e) {
       console.error('Initialization failed:', e);
-      setLoadError('Failed to load collections. Please try again.');
+      // Fall back to cached data rather than blanking the UI when possible.
+      if (localCollections.length > 0) {
+        setCollections(localCollections);
+        setLoadError(null);
+      } else {
+        setCollections([]);
+        setLoadError('Failed to load collections. Please try again.');
+      }
       showStatus(t('statusSyncPaused'), 'error');
-      setCollections([]);
-    } finally {
       setIsLoading(false);
     }
   }, [fallbackSampleCollections, isAdmin, isSupabaseReady, showStatus, t, user, withTimeout]);

--- a/tests/hooks/useCollections.test.ts
+++ b/tests/hooks/useCollections.test.ts
@@ -84,12 +84,13 @@ describe('hooks/useCollections.ts (Phase 3.3)', () => {
     showStatus.mockClear();
   });
 
-  it('offline: when cloud fetch fails, falls back to local collections and exposes a sync-paused error', async () => {
+  it('offline: when cloud fetch fails but cache exists, shows cached collections without blocking on an error', async () => {
     /**
      * Verifies offline behavior:
      * - Cloud fetch failure does not blank the UI
-     * - Local IndexedDB cache is used
-     * - loadError is set and showStatus is called with an error tone
+     * - Local IndexedDB cache is used and rendered (not hidden behind a
+     *   full-screen error)
+     * - The sync problem is surfaced via a non-blocking status toast
      */
     const local = [minimalCollection({ id: 'local' })];
     dbMocks.getLocalCollections.mockResolvedValue(local);
@@ -109,6 +110,33 @@ describe('hooks/useCollections.ts (Phase 3.3)', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.collections).toEqual(local);
+    expect(result.current.loadError).toBeNull();
+    expect(showStatus).toHaveBeenCalledWith('statusSyncPaused', 'error');
+  });
+
+  it('offline: when cloud fetch fails and there is no cache, surfaces a blocking sync-paused error', async () => {
+    /**
+     * Verifies the genuine dead-end case:
+     * - No local cache AND cloud unreachable for a signed-in user
+     * - A blocking error is shown so the user can retry
+     */
+    dbMocks.getLocalCollections.mockResolvedValue([]);
+    dbMocks.fetchCloudCollections.mockRejectedValue(new Error('Network down'));
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'u1' } as any,
+        isAdmin: false,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.collections).toEqual([]);
     expect(result.current.loadError).toContain('Unable to sync with Supabase');
     expect(showStatus).toHaveBeenCalledWith('statusSyncPaused', 'error');
   });

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -354,6 +354,36 @@ describe('App Integration Tests', () => {
     expect(vi.mocked(db.fetchCloudCollections).mock.calls.length).toBe(fetchCallsAfterLoad);
   });
 
+  it('shows cached collections instead of a blocking error when the cloud fetch fails (signed in)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Signed-in user with a cached collection. A transient cloud-fetch failure
+    // must not strand the user on the "Sync paused" screen — the cached
+    // collection should still render (regression guard for the launch-stuck fix).
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: 'user1' } } },
+    } as never);
+    vi.mocked(db.getLocalCollections).mockResolvedValue([mockCollection]);
+    vi.mocked(db.fetchCloudCollections).mockRejectedValue(new Error('Network down'));
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    // Cached collection renders rather than the full-screen sync-paused error.
+    // (A non-blocking "Sync paused" status toast may still appear, so we assert
+    // on the blocking error screen's Retry button rather than its text.)
+    await waitFor(() => {
+      expect(screen.getAllByText('Test Collection')[0]).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
+
   it('renders Item Detail field labels and placeholders with theme-aware contrast (CUR-85)', async () => {
     const { ThemeProvider } = await import('@/theme');
     const collectionWithField = {


### PR DESCRIPTION
## What you reported

The app gets stuck at launch on **"Restoring the archives…"** (you described it as "recovering my collections"), and the home/dashboard keeps loading and sometimes drops to a **"Sync paused"** error — across multiple networks, with Supabase reporting healthy.

## Root cause

This is a **resilience bug in the initial load** (`src/hooks/useCollections.ts` → `refreshCollections`), not a network or Supabase outage. Two distinct failure modes:

1. **Perpetual spinner.** After fetching from the cloud, the load `await`ed `saveAllCollections()` and then the pending-sync flush (`syncPendingChanges` / `syncPendingAssetUploads` / `syncPendingDeletes`) — IndexedDB writes + network calls with **no timeout** — *before* `isLoading` was cleared in `finally`. The cloud fetch itself is time-bounded (12s), but these post-fetch steps are not, so a stalled upload or slow write keeps the "Restoring the archives…" screen up indefinitely.

2. **Dead-end on a transient cloud hiccup.** On a cloud-fetch failure the hook set a blocking `loadError` *and* `collections = localCollections`, but `HomeScreen` renders the `loadError` screen **before** it ever renders collections — so already-cached data is hidden behind "Sync paused", and Retry just re-runs the same slow, un-paginated full fetch (`fetchCloudCollections` pulls *all* collections + *all* items via `select('*')`, which is slow on a heavily-used account like the shared test login).

## Fix

- Render the merged result and clear `isLoading` **as soon as data is available**; move cache persistence and pending-sync to a background task so they can never hold the UI hostage.
- On a cloud failure, **fall back to cached collections** (or sample collections for signed-out users) with a non-blocking status toast, and only show the blocking retry screen when there is genuinely nothing to display.
- Make local-cache and persistent-storage reads best-effort (a slow/corrupt local read no longer aborts the whole load).

## Tests

- Updated the offline test to assert cached data is shown without a blocking error, and added a test for the genuine no-cache dead-end (still shows the retry screen).
- `npm run format:check`, `npm test` (686 passing), and `npm run build` all pass.
- e2e (`npm run test:e2e`) could not run in this container — the Chromium binary download is blocked by the environment's network policy. The change is logic-only within the data-load hook.

## Note

The underlying slowness (one un-paginated `select('*')` for every collection + item under a 12s ceiling) is worth a follow-up — paginating the items fetch would make large accounts load faster and more reliably. Happy to open a separate issue/PR for that if you'd like.

https://claude.ai/code/session_01Ejs3o7f24P5XvPcWet79Aa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ejs3o7f24P5XvPcWet79Aa)_