### PR TITLE
[CUR-114] On This Day: expand inline instead of routing to the first item

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -61,6 +61,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const historyPreview = historyItems.slice(0, 3);
   const historyOverflow = historyItems.length - historyPreview.length;
   const primaryHistoryItem = historyItems[0];
+  const [historyExpanded, setHistoryExpanded] = useState(false);
+  const visibleHistoryItems = historyExpanded ? historyItems : historyPreview;
   const hasPrivateCollections = collections.some((c) => !c.isPublic);
   const shouldShowOnboarding = showOnboarding && !hasPrivateCollections;
 
@@ -256,51 +258,54 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                 </h4>
               </div>
               <div className="space-y-3">
-                <div className="space-y-2">
-                  {historyPreview.map((item) => {
+                <ul id="on-this-day-list" className="space-y-2">
+                  {visibleHistoryItems.map((item) => {
                     const itemYear = new Date(item.createdAt).getFullYear();
                     return (
-                      <button
-                        key={item.id}
-                        type="button"
-                        onClick={() => navigate(`/collection/${item.collectionId}/item/${item.id}`)}
-                        className={`w-full text-left rounded-xl border px-3 py-2 text-xs sm:text-sm shadow-sm transition ${theme === 'vault' ? 'border-white/10 bg-white/5 hover:border-[#D4A574]/30 hover:bg-white/10' : theme === 'atelier' ? 'border-[#D4C9B8]/60 bg-[#EDE4D3]/70 hover:border-[#A86F3C]/30 hover:bg-[#EDE4D3]' : 'border-stone-200/60 bg-white/70 hover:border-amber-200 hover:bg-amber-50/60'}`}
-                      >
-                        <div className="flex items-center justify-between gap-2">
-                          <span
-                            className={`truncate font-medium ${theme === 'vault' ? 'text-white' : theme === 'atelier' ? 'text-[#3D3530]' : 'text-stone-700'}`}
-                          >
-                            {item.title}
-                          </span>
-                          <span
-                            className={`text-[11px] uppercase tracking-wide ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
-                          >
-                            {itemYear}
-                          </span>
-                        </div>
-                      </button>
+                      <li key={item.id}>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            navigate(`/collection/${item.collectionId}/item/${item.id}`)
+                          }
+                          className={`w-full text-left rounded-xl border px-3 py-2 text-xs sm:text-sm shadow-sm transition ${theme === 'vault' ? 'border-white/10 bg-white/5 hover:border-[#D4A574]/30 hover:bg-white/10' : theme === 'atelier' ? 'border-[#D4C9B8]/60 bg-[#EDE4D3]/70 hover:border-[#A86F3C]/30 hover:bg-[#EDE4D3]' : 'border-stone-200/60 bg-white/70 hover:border-amber-200 hover:bg-amber-50/60'}`}
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <span
+                              className={`truncate font-medium ${theme === 'vault' ? 'text-white' : theme === 'atelier' ? 'text-[#3D3530]' : 'text-stone-700'}`}
+                            >
+                              {item.title}
+                            </span>
+                            <span
+                              className={`text-[11px] uppercase tracking-wide ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+                            >
+                              {itemYear}
+                            </span>
+                          </div>
+                        </button>
+                      </li>
                     );
                   })}
-                </div>
-                {historyOverflow > 0 && (
-                  <p
-                    className={`text-xs ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
-                  >
-                    {t('onThisDayMore', { count: historyOverflow })}
-                  </p>
+                </ul>
+                {historyOverflow > 0 && !historyExpanded && (
+                  <>
+                    <p
+                      className={`text-xs ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+                    >
+                      {t('onThisDayMore', { count: historyOverflow })}
+                    </p>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="w-full"
+                      onClick={() => setHistoryExpanded(true)}
+                      aria-expanded={false}
+                      aria-controls="on-this-day-list"
+                    >
+                      {t('onThisDaySeeAll', { count: historyItems.length })}
+                    </Button>
+                  </>
                 )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full"
-                  onClick={() =>
-                    navigate(
-                      `/collection/${primaryHistoryItem.collectionId}/item/${primaryHistoryItem.id}`,
-                    )
-                  }
-                >
-                  {t('viewHistory')}
-                </Button>
               </div>
             </div>
           </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -201,8 +201,7 @@ export const translations = {
     onThisDay: 'On This Day',
     historyTitle: 'Archive Archeology',
     onThisDayMore: 'And {count} more',
-    // Added viewHistory key to resolve App.tsx type error
-    viewHistory: 'Relive Memory',
+    onThisDaySeeAll: 'See all {count} memories',
     themeSelection: 'App Aesthetic',
     themeGallery: 'The Gallery (Airy)',
     themeVault: 'The Vault (Moody)',
@@ -680,8 +679,7 @@ export const translations = {
     onThisDay: '档案考古',
     historyTitle: '历史上的今天',
     onThisDayMore: '还有 {count} 项',
-    // Added viewHistory key to resolve App.tsx type error
-    viewHistory: '重温记忆',
+    onThisDaySeeAll: '查看全部 {count} 条记忆',
     themeSelection: '应用美学主题',
     themeGallery: '画廊（通透白）',
     themeVault: '保险库（深邃黑）',

--- a/tests/components/HomeScreen.test.tsx
+++ b/tests/components/HomeScreen.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderWithProviders, screen, fireEvent, waitFor } from '../utils/test-utils';
+import { renderWithProviders, screen, fireEvent, waitFor, within } from '../utils/test-utils';
 import { HomeScreen } from '@/components/HomeScreen';
 import { UserCollection } from '@/types';
 
@@ -109,5 +109,71 @@ describe('HomeScreen', () => {
     renderWithProviders(<HomeScreen {...defaultProps} loadError="Failed to load" />);
     expect(screen.getByText(/sync paused/i)).toBeInTheDocument();
     expect(screen.getByText('Failed to load')).toBeInTheDocument();
+  });
+
+  describe('On This Day', () => {
+    const makeHistoryItem = (id: string, title: string, year: number) => ({
+      id,
+      title,
+      data: {},
+      rating: 0,
+      notes: '',
+      photoUrl: '',
+      createdAt: new Date(year, 0, 1).toISOString(),
+      updatedAt: '',
+      collectionId: 'col1',
+      userId: 'user1',
+    });
+
+    it('hides the "See all" CTA when every memory already fits in the preview', () => {
+      const historyItems = [
+        makeHistoryItem('h1', 'First memory', 2020),
+        makeHistoryItem('h2', 'Second memory', 2021),
+        makeHistoryItem('h3', 'Third memory', 2022),
+      ];
+      const { container } = renderWithProviders(
+        <HomeScreen {...defaultProps} stats={{ ...defaultProps.stats, historyItems }} />,
+      );
+
+      const list = container.querySelector('#on-this-day-list') as HTMLElement;
+      expect(list).toBeTruthy();
+      historyItems.forEach((item) => {
+        expect(within(list).getByText(item.title)).toBeInTheDocument();
+      });
+      expect(screen.queryByRole('button', { name: /See all/i })).not.toBeInTheDocument();
+      expect(screen.queryByText(/And \d+ more/)).not.toBeInTheDocument();
+    });
+
+    it('reveals every memory inline when "See all" is pressed', () => {
+      const historyItems = [
+        makeHistoryItem('h1', 'First memory', 2018),
+        makeHistoryItem('h2', 'Second memory', 2019),
+        makeHistoryItem('h3', 'Third memory', 2020),
+        makeHistoryItem('h4', 'Fourth memory', 2021),
+        makeHistoryItem('h5', 'Fifth memory', 2022),
+      ];
+      const { container } = renderWithProviders(
+        <HomeScreen {...defaultProps} stats={{ ...defaultProps.stats, historyItems }} />,
+      );
+
+      const list = () => container.querySelector('#on-this-day-list') as HTMLElement;
+      expect(within(list()).getByText('First memory')).toBeInTheDocument();
+      expect(within(list()).getByText('Second memory')).toBeInTheDocument();
+      expect(within(list()).getByText('Third memory')).toBeInTheDocument();
+      expect(within(list()).queryByText('Fourth memory')).not.toBeInTheDocument();
+      expect(within(list()).queryByText('Fifth memory')).not.toBeInTheDocument();
+      expect(screen.getByText('And 2 more')).toBeInTheDocument();
+
+      const seeAll = screen.getByRole('button', { name: /See all 5 memories/i });
+      expect(seeAll).toHaveAttribute('aria-expanded', 'false');
+      expect(seeAll).toHaveAttribute('aria-controls', 'on-this-day-list');
+
+      fireEvent.click(seeAll);
+
+      expect(within(list()).getByText('Fourth memory')).toBeInTheDocument();
+      expect(within(list()).getByText('Fifth memory')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /See all/i })).not.toBeInTheDocument();
+      expect(screen.queryByText(/And \d+ more/)).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Problem

On HomeScreen, the "On This Day" bento card always showed a `Relive Memory` (`viewHistory`) button at the bottom whose `onClick` navigated to `primaryHistoryItem` — the exact same destination as tapping the hero image or the first preview row.

Two failure modes:

- **Overflow case** (`historyOverflow > 0`). The user reads "+5 more" and reasonably expects the CTA to surface those memories. Instead they land on a single item detail. The remaining 5 memories are unreachable from the card.
- **No-overflow case** (`historyOverflow === 0`). The button is a redundant duplicate of the row above it.

Either way the CTA promises something it doesn't deliver, which directly undermines Curio's *trust before growth* principle — and "View History" copy elsewhere becomes suspect once a user learns it lies.

## Approach

Inline expansion, no new route or modal:

- Add `historyExpanded` local state in `HomeScreen`. The preview now renders `visibleHistoryItems = historyExpanded ? historyItems : historyPreview`.
- When `historyOverflow > 0 && !historyExpanded`, render a ghost button labelled `t('onThisDaySeeAll', { count: historyItems.length })` ("See all 7 memories" / "查看全部 7 条记忆") that flips state to expanded.
- When no overflow exists, omit the button entirely — every memory is already visible above it.
- Wrap the rows in a `<ul id="on-this-day-list">` and give the toggle button `aria-expanded` / `aria-controls` so screen readers see a real disclosure region.
- Drop the now-unused `viewHistory` i18n key (its single caller is gone).

The preview rows still navigate per-item, so every on-this-day memory remains reachable from the same surface that promised them.

## Why this approach

Smallest reasonable fix that satisfies every acceptance criterion without expanding product surface area: no new route, no new modal, no focus-trap plumbing, no second i18n control string. It also preserves the contemplative feel of the card — a popup or full-screen drilldown would interrupt a quiet "memory" moment in a way a quiet inline expansion does not.

## Risks

Low. The change is contained to one component, one i18n key swap, and one new piece of local state. The data shape (`stats.historyItems`) is unchanged. The expanded list grows the bento card vertically, which is already its default flow direction. Mitigations:

- Vitest covers both the overflow and no-overflow CTA paths (see below).
- `aria-expanded` / `aria-controls` validated in the new test.
- No design tokens, theme classes, or styling regressions — preview row classes are byte-identical.

## How to verify

Vercel Preview: _populated by the Vercel bot when this PR opens_.

Steps:

1. Sign in with an account that has **≥ 4** items created on the current month/day in prior years. Open `/`.
2. The "On This Day" card shows 3 preview rows, "And N more", and a "See all M memories" ghost button.
3. Tap "See all M memories". The list expands to show every memory. Both the overflow text and the CTA disappear. Each row still navigates to its item.
4. Sign in with an account that has **≤ 3** matching items. Open `/`. The card renders only the rows — no "And N more", no CTA.
5. Toggle to ZH and confirm the button reads "查看全部 N 条记忆".
6. (a11y) Inspect the toggle: `aria-expanded="false"`, `aria-controls="on-this-day-list"`.

Checks:

- [x] `npm run format:check` — pass
- [x] `npm test` — 687 passed (2 added)
- [x] `npm run build` — pass
- [ ] `npm run test:e2e` — **not run** in this remote session. `npx playwright install chromium` fails because the Playwright browser download endpoint is blocked by the environment's outbound network policy ([CUR-90](https://linear.app/qiuyue/issue/CUR-90)). Change is presentational/logic — the existing e2e suite did not exercise the misleading CTA, so the fix is covered by the new vitest cases. CI will run the full e2e suite on this PR.

## Screenshot / GIF

_To attach after the Vercel preview comes up — the visual change is the button label going from "Relive Memory" to "See all N memories" when overflow exists, and disappearing entirely otherwise._

## Linear

Closes CUR-114

## Rollback plan

`git revert 24da854` — single commit, no migrations, no env changes. The pre-revert behavior (button always navigating to `primaryHistoryItem`) is what the issue described.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8enjqEkVE1Y9T9vR6im3N)_