### PR TITLE
[CUR-90] Pin Playwright to 1.56.x so E2E runs offline in web sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ When making UX/product changes, preserve these constraints:
 2. Run: `npm run format:check` (must pass)
 3. Run: `npm test` (must pass)
 4. Run: `npm run build` (must pass)
-5. Run: `npm run test:e2e` (must pass; first-time setup may require `npx playwright install chromium`)
+5. Run: `npm run test:e2e` (must pass). The `@playwright/test` version is pinned to the `1.56.x` line so it matches the Chromium build pre-baked into Claude Code web sessions (`/opt/pw-browsers`); the suite runs offline with no browser download. On other machines, first-time setup may still require `npx playwright install chromium`.
 6. Ensure: `git diff` and `git status --porcelain` are clean (no formatting leftovers / untracked artifacts)
 
 If you cannot run commands, you MUST:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -93,5 +93,6 @@ npm run server
   - `npm run format:check` (verifies formatting)
 
 - Playwright will start (or reuse) the dev server automatically (see `playwright.config.ts`).
+- `@playwright/test` is pinned to the `1.56.x` line on purpose: it matches the Chromium build pre-baked into Claude Code web sessions (`/opt/pw-browsers`, build 1194), so `npm run test:e2e` runs offline there without downloading a browser. Keep the client version and the available browser build in sync when upgrading (CI installs browsers fresh via `npx playwright install`).
 - Unit tests use mocked Supabase; do **not** rely on a local Supabase instance.
 - `tests/README.md` is intentionally short and points back here to avoid duplicate guidance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@capacitor/assets": "^3.0.5",
         "@capacitor/cli": "^8.0.1",
         "@capacitor/core": "^8.0.1",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "~1.56.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -2062,13 +2062,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9147,13 +9147,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9166,9 +9166,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^8.0.1",
     "@capacitor/core": "^8.0.1",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "~1.56.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Fixes [CUR-90](https://linear.app/qiuyue/issue/CUR-90).

## Problem

`npm run test:e2e` could not run inside Claude Code web/remote sessions, making the mandatory pre-finish checklist in `CLAUDE.md` impossible to satisfy and causing the recurring "problem installing Playwright" reports across PRs.

Root cause was a version mismatch:

- The lockfile resolved `@playwright/test` to **1.57.0**, which requires **Chromium build 1200** (`chrome-headless-shell-1200`).
- The web sandbox pre-bakes a browser at `PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`, but it is **build 1194** (the 1.56.x line).
- `npx playwright install chromium` fails because the browser CDNs are not in the network allowlist (403 `Host not in allowlist`).

Observed failure: `browserType.launch: Executable doesn't exist at /opt/pw-browsers/chromium_headless_shell-1200/...`.

## Fix

Pin `@playwright/test` to the `~1.56.0` line (Chromium build 1194), matching the pre-baked browser. The suite now runs offline in web sessions with no browser download, and the client version stays consistent with the available browser build. CI is unaffected — it installs browsers fresh via `npx playwright install`.

Also updated `CLAUDE.md` and `docs/TESTING.md` to document the version-alignment rationale.

## Verification

- `npm run test:e2e` runs **fully offline** in a web session — **36 passed, 10 skipped, 0 failed**. The Chromium executable resolves to `/opt/pw-browsers/chromium-1194/...` (no download attempted).
- `npm run format:check`, `npm test` (689 passed), and `npm run build` all pass.

## Acceptance criteria

- [x] A fresh Claude Code web session can run `npm run test:e2e` without attempting a network browser download.
- [x] Playwright client version and the available browser build are consistent.

https://claude.ai/code/session_01GQRNzXtgv4p4DD2ecysx8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQRNzXtgv4p4DD2ecysx8J)_