### PR TITLE
[CUR-37] Prevent cloud refresh from overwriting unsynced local collections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -584,17 +584,23 @@ export const AppContent: React.FC = () => {
         cloudCollections,
       });
 
+      // Re-read local state AFTER the slow, network-bound cloud fetch (and any
+      // seeding) so that collections/items the user created or edited while the
+      // round-trip was in flight are included in the merge. Merging against the
+      // pre-fetch snapshot would let saveAllCollections() overwrite — and
+      // effectively delete — that just-written local data. (CUR-37)
+      const freshLocalCollections = await loadLocalCollectionsWithTimeout();
       const [pendingSyncIds, pendingDeletes] = await Promise.all([
         getPendingSyncIds(),
         getPendingDeletes(),
       ]);
-      const mergedCollections = mergeCollections(localCollections, cloudCollections, {
+      const mergedCollections = mergeCollections(freshLocalCollections, cloudCollections, {
         includeLocalOnly: (collection) =>
           !collection.ownerId || pendingSyncIds.includes(collection.id),
         pendingDeletes,
       });
 
-      const detectedConflicts = detectConflicts(localCollections, cloudCollections);
+      const detectedConflicts = detectConflicts(freshLocalCollections, cloudCollections);
       const unresolvedConflicts = detectedConflicts.filter(
         (conflict) => !resolvedConflictIdsRef.current.has(conflict.id),
       );
@@ -607,7 +613,7 @@ export const AppContent: React.FC = () => {
         showSyncedStatus,
       } = resolveCollectionsForUser({
         user,
-        localCollections,
+        localCollections: freshLocalCollections,
         cloudCollections,
         fallbackSampleCollections,
         mergedCollections,

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1842,19 +1842,30 @@ export const loadCollections = async (): Promise<UserCollection[]> => {
 
   if (isSupabaseConfigured() && supabase) {
     try {
-      const [pendingSyncIds, pendingDeletes] = await Promise.all([
-        getPendingSyncIds(),
-        getPendingDeletes(),
-      ]);
       const {
         data: { user },
       } = await supabase.auth.getUser();
       const cloudCollections = await fetchCloudCollections();
+
+      // Re-read local state AFTER the (slow, network-bound) cloud fetch.
+      // The cloud round-trip can take seconds, and the user may create or
+      // edit collections/items while it is in flight — those writes land in
+      // IndexedDB directly. If we merged against the stale snapshot taken
+      // before the fetch, `saveAllCollections(merged)` would overwrite (and
+      // effectively delete) that just-written local data. Snapshotting local
+      // state, pending-sync ids, and pending deletes here — immediately
+      // before the merge — closes that race window. (CUR-37)
+      const [freshLocalCollections, pendingSyncIds, pendingDeletes] = await Promise.all([
+        loadLocalCollections(),
+        getPendingSyncIds(),
+        getPendingDeletes(),
+      ]);
+
       if (!user && cloudCollections.length === 0) {
-        return localCollections;
+        return freshLocalCollections;
       }
 
-      const merged = mergeCollections(localCollections, cloudCollections, {
+      const merged = mergeCollections(freshLocalCollections, cloudCollections, {
         includeLocalOnly: (collection) =>
           !collection.ownerId || pendingSyncIds.includes(collection.id),
         pendingDeletes,

--- a/tests/services/db.loadCollections.test.ts
+++ b/tests/services/db.loadCollections.test.ts
@@ -31,13 +31,18 @@ afterAll(() => {
   });
 });
 
-const makeQuery = (data: any[]) => {
+const makeQuery = (data: any[], onAwait?: () => Promise<void>) => {
   const query: any = {};
   query.select = vi.fn().mockReturnValue(query);
   query.or = vi.fn().mockReturnValue(query);
   query.eq = vi.fn().mockReturnValue(query);
   query.in = vi.fn().mockReturnValue(query);
-  query.then = (resolve: (value: any) => any) => Promise.resolve(resolve({ data, error: null }));
+  query.then = async (resolve: (value: any) => any) => {
+    // Allow tests to simulate work that happens while the (awaited) cloud
+    // query is in flight — e.g. a user creating a collection mid-fetch.
+    if (onAwait) await onAwait();
+    return resolve({ data, error: null });
+  };
   return query;
 };
 
@@ -45,13 +50,15 @@ function createSupabaseMock({
   collections,
   items,
   userId = 'user-123',
+  itemsOnAwait,
 }: {
   collections: any[];
   items: any[];
   userId?: string | null;
+  itemsOnAwait?: () => Promise<void>;
 }) {
   const collectionsQuery = makeQuery(collections);
-  const itemsQuery = makeQuery(items);
+  const itemsQuery = makeQuery(items, itemsOnAwait);
   const from = vi.fn((table: string) => (table === 'collections' ? collectionsQuery : itemsQuery));
   return {
     supabase: {
@@ -271,5 +278,64 @@ describe('Phase 2.1 — services/db.ts loadCollections merge behavior', () => {
 
     expect(merged).toHaveLength(1);
     expect(merged[0].name).toBe('Local Name');
+  });
+
+  it('preserves a local-only collection created while the cloud fetch is in flight (CUR-37)', async () => {
+    const cloudCollections = [
+      {
+        id: 'col-1',
+        user_id: 'user-123',
+        template_id: 'vinyl',
+        name: 'Cloud Collection',
+        icon: '☁️',
+        is_public: false,
+        updated_at: new Date('2024-01-03T00:00:00Z').toISOString(),
+      },
+    ];
+    const cloudItems: any[] = [];
+
+    // Declared up front so the mock's mid-fetch hook can reach the db module.
+    let dbMod: typeof import('@/services/db');
+
+    const { supabase } = createSupabaseMock({
+      collections: cloudCollections,
+      items: cloudItems,
+      // Simulate the user creating a brand-new collection offline while the
+      // (slow) cloud round-trip is still in flight. Before the fix this write
+      // landed after loadCollections had already snapshotted local state, so
+      // saveAllCollections(merged) clobbered it.
+      itemsOnAwait: async () => {
+        await dbMod.saveCollection(
+          baseCollection({
+            id: 'col-created-mid-fetch',
+            name: 'Created During Sync',
+            ownerId: undefined, // unsynced, local-only
+            updatedAt: new Date('2024-06-01T00:00:00Z').toISOString(),
+          }),
+        );
+      },
+    });
+
+    dbMod = await importDbModuleFresh(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    // Start from a clean local cache that only has the cloud-backed collection.
+    await dbMod.saveAllCollections([
+      baseCollection({ id: 'col-1', name: 'Local Collection', ownerId: 'user-123' }),
+    ]);
+
+    const merged = await dbMod.loadCollections();
+
+    const ids = merged.map((c) => c.id).sort();
+    expect(ids).toContain('col-created-mid-fetch');
+    expect(ids).toContain('col-1');
+
+    // And it must actually be persisted (not just returned), so a subsequent
+    // load without a cloud round-trip still sees it.
+    const persisted = await dbMod.loadCollections();
+    expect(persisted.map((c) => c.id)).toContain('col-created-mid-fetch');
   });
 });


### PR DESCRIPTION
Fixes [CUR-37](https://linear.app/qiuyue/issue/CUR-37).

## Problem

`loadCollections()` snapshotted local state (collections, pending-sync ids, pending deletes) **before** the slow, network-bound `fetchCloudCollections()` call. A cloud round-trip can take seconds, and any collection/item the user creates or edits while it is in flight writes straight to IndexedDB. The merge, however, ran against the **stale pre-fetch snapshot**, so `saveAllCollections(merged)` overwrote — and effectively deleted — that just-written local data. This is the race window called out in the issue.

## Fix

Re-read local collections, pending-sync ids, and pending deletes **after** the cloud fetch resolves, immediately before the merge. This closes the dominant race window (network latency) so concurrent local writes are included in the merge instead of being clobbered.

Existing merge semantics are unchanged: cloud remains the source of truth for existence, cloud deletions are still respected, and local-only / newer-local data is preserved via `mergeCollections` (`includeLocalOnly`, timestamp resolution).

```diff
-      const [pendingSyncIds, pendingDeletes] = await Promise.all([...]);
-      const { data: { user } } = await supabase.auth.getUser();
-      const cloudCollections = await fetchCloudCollections();
-      const merged = mergeCollections(localCollections, cloudCollections, {...});
+      const { data: { user } } = await supabase.auth.getUser();
+      const cloudCollections = await fetchCloudCollections();
+      // Re-snapshot AFTER the network fetch, immediately before the merge.
+      const [freshLocalCollections, pendingSyncIds, pendingDeletes] = await Promise.all([
+        loadLocalCollections(), getPendingSyncIds(), getPendingDeletes(),
+      ]);
+      const merged = mergeCollections(freshLocalCollections, cloudCollections, {...});
```

## Test

Adds a regression test in `tests/services/db.loadCollections.test.ts` that simulates a local-only collection being created while the cloud items query is in flight (via an injected mid-fetch hook on the mocked query). Verified it **fails against the pre-fix code** and **passes with the fix**, and that the collection is actually persisted (survives a second load).

## Acceptance criteria

- [x] Local-only collections/items survive a cloud refresh
- [x] Concurrent local edits during cloud sync are not lost
- [x] Merge strategy is deterministic and testable
- [x] Integration test covering: create item mid-sync → cloud refresh → item persists

## Verification

- `npm run format:check`, `npm test` (690 passed), `npm run build`, and `npm run test:e2e` (36 passed, 0 failed) all pass.

https://claude.ai/code/session_01GQRNzXtgv4p4DD2ecysx8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQRNzXtgv4p4DD2ecysx8J)_