### PR TITLE
[#110] Lift Vault label/placeholder contrast to WCAG AA

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1106,14 +1106,22 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
         </div>
       </div>
       <div>
-        <h3 className="text-xl sm:text-2xl font-serif font-bold text-stone-900 mb-1 sm:mb-2">
+        <h3
+          className={`text-xl sm:text-2xl font-serif font-bold mb-1 sm:mb-2 ${
+            theme === 'vault'
+              ? 'text-white'
+              : theme === 'atelier'
+                ? 'text-[#3D3530]'
+                : 'text-stone-900'
+          }`}
+        >
           {t('analyzingPhoto')}
         </h3>
-        <p className="text-sm sm:text-base text-stone-500 italic font-serif">
+        <p className={`text-sm sm:text-base italic font-serif ${mutedText}`}>
           {t('geminiExtracting')}
         </p>
         {batchProgress && batchProgress.total > 1 && (
-          <p className="text-xs text-stone-400 mt-2">
+          <p className={`text-xs mt-2 ${mutedText}`}>
             {t('batchProgress', {
               current: batchProgress.current,
               total: batchProgress.total,

--- a/src/components/ConflictResolutionModal.tsx
+++ b/src/components/ConflictResolutionModal.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { X, GitMerge, Cloud, Laptop, ArrowRight } from 'lucide-react';
 import { useTranslation } from '../i18n';
-import { useTheme, panelSurfaceClasses, overlaySurfaceClasses } from '../theme';
+import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
 import { useModalA11y } from '../hooks/useModalA11y';
 
 export type ConflictEntry = {
@@ -68,6 +68,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
   const surfaceClass = panelSurfaceClasses[theme];
   const overlayClass = `${overlaySurfaceClasses[theme]} motion-overlay`;
   const borderClass = theme === 'vault' ? 'border-white/10' : 'border-stone-100';
+  const mutedText = mutedTextClasses[theme];
 
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -117,7 +118,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
             {t('conflictDesc')}
           </p>
           {conflicts.length === 0 && (
-            <div className="text-sm text-stone-500">{t('conflictEmpty')}</div>
+            <div className={`text-sm ${mutedText}`}>{t('conflictEmpty')}</div>
           )}
           {conflicts.map((conflict) => {
             const localTime = new Date(conflict.localUpdatedAt || 0).getTime();
@@ -166,7 +167,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
                         {t('conflictNewerBadge')}
                       </div>
                     )}
-                    <div className="flex items-center gap-2 mb-2 text-stone-500">
+                    <div className={`flex items-center gap-2 mb-2 ${mutedText}`}>
                       <Cloud size={14} />
                       <span className="text-xs font-semibold">{t('cloudVersion')}</span>
                     </div>
@@ -194,7 +195,7 @@ export const ConflictResolutionModal: React.FC<ConflictResolutionModalProps> = (
                         {t('conflictNewerBadge')}
                       </div>
                     )}
-                    <div className="flex items-center gap-2 mb-2 text-stone-500">
+                    <div className={`flex items-center gap-2 mb-2 ${mutedText}`}>
                       <Laptop size={14} />
                       <span className="text-xs font-semibold">{t('localVersion')}</span>
                     </div>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -159,10 +159,11 @@ export const typographyClasses = {
   quote: 'font-serif italic text-lg leading-relaxed',
 } as const;
 
-// Theme-aware label colors
+// Theme-aware label colors. Vault uses stone-400 (#A8A29E) to match DESIGN.md's
+// "Text Muted" token — stone-500 fails WCAG AA on stone-900 surfaces.
 export const labelColorClasses: Record<AppTheme, string> = {
   gallery: 'text-stone-400',
-  vault: 'text-stone-500',
+  vault: 'text-stone-400',
   atelier: 'text-[#8C7B6B]', // Sepia-toned labels
 };
 
@@ -282,7 +283,7 @@ export const inputClasses: Record<AppTheme, string> = {
   gallery:
     'bg-white border-stone-200 text-stone-900 placeholder:text-stone-300 focus:ring-amber-500/10 focus:border-amber-200',
   vault:
-    'bg-stone-900 border-white/10 text-white placeholder:text-stone-500 focus:ring-[#D4A574]/10 focus:border-[#D4A574]/30',
+    'bg-stone-900 border-white/10 text-white placeholder:text-stone-400 focus:ring-[#D4A574]/10 focus:border-[#D4A574]/30',
   atelier:
     'bg-[#F5EFE4] border-[#D4C9B8] text-[#3D3530] placeholder:text-[#8C7B6B] focus:ring-[#A86F3C]/10 focus:border-[#A86F3C]/30',
 };

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { renderWithProviders } from '../utils/test-utils';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
 import { AddItemModal } from '@/components/AddItemModal';
 import { createMockCollection } from '../utils/fixtures/collections';
 
@@ -82,6 +82,7 @@ describe('AddItemModal', () => {
     mockRefreshAiEnabled.mockResolvedValue(false);
     mockAnalyzeImage.mockReset();
     mockGetPhoto.mockReset();
+    setMockTheme('gallery');
   });
 
   it('renders nothing when closed', () => {
@@ -436,6 +437,33 @@ describe('AddItemModal', () => {
       collection.id,
       expect.objectContaining({ title: 'Artifact A' }),
     );
+  });
+
+  it('renders the analyzing step with theme-aware copy on Vault (#110)', async () => {
+    const user = userEvent.setup();
+    setMockTheme('vault');
+    mockRefreshAiEnabled.mockResolvedValue(true);
+    // Pending promise — keep the modal on the analyzing step so we can inspect it.
+    mockAnalyzeImage.mockReturnValue(new Promise<never>(() => {}));
+
+    const collection = createMockCollection({ name: 'Artifacts', customFields: [] });
+    renderWithProviders(
+      <AddItemModal isOpen onClose={mockOnClose} collections={[collection]} onSave={mockOnSave} />,
+    );
+
+    const file = new File(['a'], 'a.png', { type: 'image/png' });
+    const input = screen.getByTestId('add-item-batch-input') as HTMLInputElement;
+    await user.upload(input, file);
+
+    // Heading must use the theme's foreground; text-stone-900 would disappear on the dark Vault panel.
+    const heading = await screen.findByRole('heading', { name: 'Analyzing photo...' });
+    expect(heading.className).toContain('text-white');
+    expect(heading.className).not.toContain('text-stone-900');
+
+    // Helper copy ("Gemini is extracting…") must stay above WCAG AA on stone-900,
+    // i.e. it must not regress to stone-500 (~3.77:1).
+    const helper = screen.getByText('Gemini is extracting details for your collection.');
+    expect(helper.className).not.toContain('text-stone-500');
   });
 
   it('fades the verify-step scroll edge while fields remain below the fold (CUR-45)', async () => {

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -89,6 +89,12 @@ describe('Theme Utilities', () => {
       expect(labelColorClasses.vault).toContain('text-stone');
       expect(labelColorClasses.atelier).toContain('text-[#8C7B6B]');
     });
+
+    // stone-500 (#78716c) fails WCAG AA on the Vault stone-900 surface
+    // (~3.77:1); DESIGN.md sets Vault textMuted to stone-400 (#A8A29E).
+    it('keeps Vault labels at or above stone-400 contrast', () => {
+      expect(labelColorClasses.vault).toBe('text-stone-400');
+    });
   });
 
   describe('cardSurfaceClasses', () => {
@@ -225,6 +231,11 @@ describe('Theme Utilities', () => {
       expect(inputClasses.gallery).toContain('placeholder:');
       expect(inputClasses.vault).toContain('placeholder:');
       expect(inputClasses.atelier).toContain('placeholder:');
+    });
+
+    // Mirrors labelColorClasses contrast guarantee — see comment above.
+    it('uses stone-400 placeholders on Vault for WCAG AA contrast', () => {
+      expect(inputClasses.vault).toContain('placeholder:text-stone-400');
     });
   });
 });


### PR DESCRIPTION
## Problem

Closes #110.

`DESIGN.md` sets Vault's "Text Muted" token to `#A8A29E` (stone-400), but two
shared tokens still used stone-500:

- `labelColorClasses.vault` — propagates to Item Detail "Technical Spec"
  headings, HomeScreen "On This Day", etc.
- `inputClasses.vault` placeholder.

stone-500 (`#78716C`) on the Vault stone-900 panel measures ~3.77:1, which
fails WCAG AA for normal text. On top of that:

- `ConflictResolutionModal` had three non-themed `text-stone-500` spans (the
  empty-state line and both Cloud/Local labels) that sat on the dark Vault
  panel and were nearly unreadable.
- `AddItemModal`'s "Analyzing photo…" step hardcoded `text-stone-900` for
  the heading and `text-stone-500` for the helper line — invisible /
  unreadable on Vault.

This is the trust-eroding "feels half-finished on dark theme" surface that
issue #110 calls out for Add Item and New Archive flows.

## Approach

- `src/theme.tsx`: shift `labelColorClasses.vault` and `inputClasses.vault`
  placeholder from `stone-500` to `stone-400`, matching DESIGN.md's
  documented textMuted token. Light themes untouched.
- `src/components/ConflictResolutionModal.tsx`: route the three hardcoded
  muted spans through `mutedTextClasses[theme]` — gallery still gets
  stone-500, vault now gets stone-300, atelier gets the sepia token.
- `src/components/AddItemModal.tsx`: make the `renderAnalyzing` heading and
  helper text theme-aware (white / sepia / stone-900 + `mutedText` helper).
- Tests: pin the new contrast guarantee in `tests/unit/theme.test.ts`, and
  add a regression in `tests/components/AddItemModal.test.tsx` that mounts
  the analyzing step in Vault and asserts the heading is readable
  (`text-white`, not `text-stone-900`) and the helper text isn't `stone-500`.

## Why this approach

Lifting the token itself is one change that cascades to every consumer, and
it aligns the code with `DESIGN.md` instead of inventing a new value. The
two component-local edits are confined to genuinely non-themed strings
that bypass the token system. No new components, no new dependencies, no
behavior changes — purely a presentational alignment that protects trust
on Vault.

## Risks

Low. Diff is ~60 LOC, presentational, and tracked by both unit and
component tests. Side benefit: the same token shift also makes Item
Detail's "Technical Spec" header and HomeScreen "On This Day" label more
readable on Vault — these read as improvements rather than regressions
against DESIGN.md.

## How to verify

Vercel Preview: _(generated by CI)_

1. Switch theme to **The Vault** in the header.
2. Open **Add Item** → upload a photo → confirm the "Analyzing photo…"
   heading and Gemini helper copy are clearly readable on the dark panel.
3. Trigger a sync conflict (or open the Conflict Resolution modal via a
   dev path) → confirm the "Cloud version / Local version" sub-labels and
   the empty-state copy are readable.
4. Visit any Item Detail page → confirm the "Technical Spec" label and
   custom-field labels are readable, not faded.

Checks:

- [x] `npm run format:check`
- [x] `npm test` (698 passed, 2 skipped, 1 todo)
- [x] `npm run build`
- [x] `npm run test:e2e` (36 passed, 10 skipped — including the
  existing `vault theme should have readable contrast` accessibility test)

## Rollback plan

`git revert <merge-sha>` — the change is isolated to two design tokens and
a handful of inline class strings, all reversible.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B7vR32Gp3g3PthiM6eppG9)_