### PR TITLE
[#187] Remove stale Museum Guide references from docs and types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,6 @@ VITE_API_BASE_URL=http://localhost:8787
 VITE_AI_ENABLED=true
 VITE_AI_METADATA_ENABLED=true
 VITE_AI_IMAGE_EDIT_ENABLED=true
-VITE_VOICE_GUIDE_ENABLED=false
 ```
 
 The Gemini proxy expects:
@@ -154,7 +153,7 @@ GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 **Services:**
 
 - `services/db.ts` - IndexedDB operations, Supabase sync logic, and merge strategies
-- `services/geminiService.ts` - Image analysis and audio guide AI integration
+- `services/geminiService.ts` - Image analysis (vision-based metadata extraction)
 - `services/supabase.ts` - Authentication (email/password) and client configuration
 - `services/imageProcessor.ts` - Image resizing and optimization (original + display)
 - `src/services/seedCollections.ts` - Public sample data (Vinyl Vault with 4 items)
@@ -172,7 +171,6 @@ GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 
 - `components/Layout.tsx` - Header with sync status, auth menu, theme/language toggles
 - `components/AddItemModal.tsx` - Multi-step item creation with AI analysis
-- `components/MuseumGuide.tsx` - Real-time audio conversation with Gemini
 - `components/ExhibitionView.tsx` - Fullscreen slideshow mode
 - `components/ui/Button.tsx` - Reusable button component
 - `components/ui/Divider.tsx` - Theme-aware horizontal/vertical dividers
@@ -185,7 +183,7 @@ GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
   Collections grid, search, "on this day" history
 
 /collection/:id → CollectionScreen
-  Item grid/waterfall, filters, exhibition mode, museum guide
+  Item grid/waterfall, filters, exhibition mode
 
 /collection/:id/item/:itemId → ItemDetailScreen
   Full item view with editable fields, rating, notes, export
@@ -207,7 +205,7 @@ GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 **Main App State** (AppContent component):
 
 - `collections: UserCollection[]` - All collections and items
-- Modal states for add item, create collection, museum guide
+- Modal states for add item, create collection
 - `saveTimeoutRef` - Debounce timer for cloud sync
 
 ### Gemini AI Integration
@@ -220,10 +218,9 @@ GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 - Returns structured metadata (title, field values)
 - AI-generated descriptions are treated as hidden metadata; the visible narrative (Story) is human-authored
 
-**Museum Guide (deferred):**
+**Museum Guide / voice companion (deferred):**
 
-- Feature-flagged by `VITE_VOICE_GUIDE_ENABLED` (disabled by default)
-- Museum Guide / voice companion is a deferred feature per `docs/PRODUCT_STRATEGY.md`
+- Not built. The component, its UI entry points, and runtime state were removed; the deferred status is tracked in `docs/PRODUCT_STRATEGY.md`.
 
 **AI Image Enhancement (deferred):**
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -16,7 +16,7 @@ Object.defineProperty(window, 'matchMedia', {
   })),
 });
 
-// Mock navigator.mediaDevices (for audio guide/museum guide)
+// Mock navigator.mediaDevices (used by components that probe media capabilities)
 Object.defineProperty(navigator, 'mediaDevices', {
   writable: true,
   value: {

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -4,7 +4,6 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL?: string;
   readonly VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY?: string;
   readonly VITE_SUPABASE_SYNC_TIMESTAMPS?: string;
-  readonly VITE_VOICE_GUIDE_ENABLED?: string;
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_AI_ENABLED?: string;
   readonly VITE_AI_METADATA_ENABLED?: string;


### PR DESCRIPTION
## Problem

The Museum Guide / voice companion is a deferred feature per `docs/PRODUCT_STRATEGY.md`, and its component, UI entry points, and runtime state were already removed from the codebase. But three stale references still claimed it existed:

- `CLAUDE.md` listed `components/MuseumGuide.tsx` under Components, mentioned "museum guide" in the `/collection/:id` route description and in App's modal-state list, documented `VITE_VOICE_GUIDE_ENABLED` as an env var, and devoted a "Museum Guide (deferred)" subsection of Gemini AI Integration to a feature flag that points at nothing. It also described `services/geminiService.ts` as containing "audio guide AI integration" code that isn't there.
- `vite-env.d.ts` declared `VITE_VOICE_GUIDE_ENABLED?: string` on `ImportMetaEnv`, advertising a flag with no consumer.
- `tests/setup.ts` had a comment "// Mock navigator.mediaDevices (for audio guide/museum guide)" naming a deleted feature.

Per Curio's "trust before growth" principle and CLAUDE.md's own documentation rules ("Keep docs aligned with reality. If documentation contradicts the codebase, fix or remove it."), these claims need to go.

## Approach

- `CLAUDE.md`: drop the `MuseumGuide.tsx` component bullet, the `VITE_VOICE_GUIDE_ENABLED` env-var line, the "museum guide" mentions in the routing and App-state sections, and rewrite the deferred subsection to state the feature is not built (still pointing readers to `docs/PRODUCT_STRATEGY.md` for the rationale). Correct the `services/geminiService.ts` description to drop the phantom audio-guide reference.
- `vite-env.d.ts`: drop the unused `VITE_VOICE_GUIDE_ENABLED` field on `ImportMetaEnv`.
- `tests/setup.ts`: rephrase the `mediaDevices` mock comment to describe what it still does, without naming a removed feature.

Principle-level mentions of Museum Guide as a deferred distraction in `CLAUDE.md` (line 53), `README.md`, `docs/PRODUCT_STRATEGY.md`, and `docs/PRODUCT_DESIGN.md` are accurate and intentionally kept — they protect the "defer distractions" guardrail rather than claim the feature ships.

## Why this approach

Smallest change that closes the issue cleanly: it removes the false claims without re-litigating where Museum Guide stands as a product idea, and it keeps the deferred-feature signal where it actually does work (product strategy + principles). No code paths shift; only docs and an unused type field are touched.

## Risks

Low. The removed env field had no consumer (`grep` returns zero hits across `src/`, `server/`, and tests). Doc changes are descriptive, not behavioral.

## How to verify

Vercel Preview: provided automatically by the Vercel integration (visible on the PR check).

Steps:
1. `grep -ri "VITE_VOICE_GUIDE_ENABLED\|MuseumGuide\|museum guide" .` returns matches only in `docs/PRODUCT_STRATEGY.md`, `docs/PRODUCT_DESIGN.md`, `docs/reviews/2026-05-23-uiux-review.md`, `README.md`, and `CLAUDE.md`'s deferred-feature principle line — all intentional.
2. `npm install && npm test && npm run build && npm run test:e2e` — all pass locally on this branch.

Checks:
- [x] `npm run format:check`
- [x] `npm test` — 698 passed, 2 skipped, 1 todo
- [x] `npm run build` — clean
- [x] `npm run test:e2e` — 36 passed, 10 intentionally skipped

## Screenshot / GIF

No user-visible UI change.

## Linear / Issues

Closes #187

## Rollback plan

`git revert d4d8564` — single-commit revert restores the prior docs and the unused env-flag declaration. No data or runtime behavior to roll back.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ryb8bk5HzuSc4rQfLo5fCU)_