### PR TITLE
[#109] Tighten toast durations and add swipe-down dismiss on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,7 +104,7 @@ import {
   ratingColorClasses,
   ratingEmptyClasses,
 } from './theme';
-import { StatusToast, StatusTone } from './components/StatusToast';
+import { StatusToast, StatusTone, getStatusToastDurationMs } from './components/StatusToast';
 import { StatusBanner } from './components/StatusBanner';
 import { LanguageToggle } from './components/LanguageToggle';
 import { ConflictResolutionModal } from './components/ConflictResolutionModal';
@@ -219,7 +219,7 @@ export const AppContent: React.FC = () => {
         actionLabel: options?.actionLabel,
         onAction: options?.onAction,
       });
-      const durationMs = options?.durationMs ?? (options?.actionLabel ? 6000 : 2400);
+      const durationMs = getStatusToastDurationMs(tone, options);
       statusTimeoutRef.current = window.setTimeout(() => setStatus(null), durationMs);
     },
     [],

--- a/src/components/StatusToast.tsx
+++ b/src/components/StatusToast.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { CheckCircle, AlertTriangle, Info, AlertCircle } from 'lucide-react';
 import { useTranslation } from '../i18n';
 import { useTheme } from '../theme';
@@ -13,6 +13,29 @@ interface StatusToastProps {
   actionLabel?: string;
   onAction?: () => void;
 }
+
+// Minimum vertical travel before a swipe is treated as dismiss intent — keeps
+// a passive read or accidental brush from clearing the toast.
+const SWIPE_DISMISS_DISTANCE = 48;
+
+// Toast on-screen time. Trust-bearing tones (Saved / Synced / Will sync / Sync
+// error) need at least ~3s on mobile so users can read them; info recovery
+// notes can clear faster (CUR-109). Action toasts stay longest so the user
+// can actually reach the button.
+export const STATUS_TOAST_DURATIONS = {
+  withAction: 6000,
+  trust: 3500,
+  info: 2400,
+} as const;
+
+export const getStatusToastDurationMs = (
+  tone: StatusTone,
+  options?: { actionLabel?: string; durationMs?: number },
+): number => {
+  if (options?.durationMs != null) return options.durationMs;
+  if (options?.actionLabel != null) return STATUS_TOAST_DURATIONS.withAction;
+  return tone === 'info' ? STATUS_TOAST_DURATIONS.info : STATUS_TOAST_DURATIONS.trust;
+};
 
 // Toast tones keep their semantic hue across the three themes, with luminance
 // tuned so each surface sits clearly above the page beneath it (white in
@@ -72,13 +95,52 @@ export const StatusToast: React.FC<StatusToastProps> = ({
   const { theme } = useTheme();
   const surface = toneSurfaceClasses[tone][theme];
   const Icon = toneIcons[tone];
+  const touchStartYRef = useRef<number | null>(null);
+  const [dragOffset, setDragOffset] = useState(0);
+
+  // Mobile swipe-to-dismiss: toast sits at the bottom of the screen, so a
+  // downward drag is the natural "push away" gesture. We track vertical travel
+  // and only commit a dismiss past SWIPE_DISMISS_DISTANCE — anything less
+  // springs back so a near-tap doesn't clear feedback the user is still
+  // reading. No-ops if there's no onDismiss handler.
+  const handleTouchStart = (e: React.TouchEvent) => {
+    if (!onDismiss) return;
+    touchStartYRef.current = e.touches[0].clientY;
+  };
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (touchStartYRef.current == null) return;
+    const delta = e.touches[0].clientY - touchStartYRef.current;
+    setDragOffset(delta > 0 ? delta : 0);
+  };
+  const handleTouchEnd = () => {
+    if (touchStartYRef.current == null) return;
+    const committed = dragOffset >= SWIPE_DISMISS_DISTANCE;
+    touchStartYRef.current = null;
+    setDragOffset(0);
+    if (committed) onDismiss?.();
+  };
+  const handleTouchCancel = () => {
+    touchStartYRef.current = null;
+    setDragOffset(0);
+  };
+
+  const isDragging = dragOffset > 0;
+  const dragStyle = isDragging
+    ? { transform: `translateY(${dragOffset}px)`, transition: 'none' as const }
+    : undefined;
+
   return (
     <div
       data-testid="status-toast"
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      className={`pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-2xl border shadow-lg ${surface} motion-pop`}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchCancel}
+      style={dragStyle}
+      className={`pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-2xl border shadow-lg touch-pan-x select-none ${surface} ${isDragging ? '' : 'motion-pop'}`}
     >
       <Icon size={18} />
       <span className="text-sm font-semibold leading-tight" data-testid="status-toast-message">

--- a/tests/components/StatusToast.test.tsx
+++ b/tests/components/StatusToast.test.tsx
@@ -11,7 +11,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderWithProviders, screen, setMockTheme, createThemeMock } from '../utils/test-utils';
 import userEvent from '@testing-library/user-event';
-import { StatusToast, StatusTone } from '@/components/StatusToast';
+import { fireEvent } from '@testing-library/react';
+import {
+  StatusToast,
+  StatusTone,
+  getStatusToastDurationMs,
+  STATUS_TOAST_DURATIONS,
+} from '@/components/StatusToast';
 import { AppTheme } from '@/types';
 
 vi.mock('@/theme', async () => {
@@ -89,6 +95,56 @@ describe('StatusToast', () => {
       expect(toast.className).toMatch(/bg-red-500\/10/);
     });
 
+    it('dismisses on a downward swipe past the commit threshold (CUR-109)', () => {
+      const onDismiss = vi.fn();
+      renderWithProviders(<StatusToast message="Saved" tone="success" onDismiss={onDismiss} />);
+      const toast = getToast();
+
+      // Travel of 60px (> 48px threshold) → commit dismiss.
+      fireEvent.touchStart(toast, { touches: [{ clientX: 100, clientY: 100 }] });
+      fireEvent.touchMove(toast, { touches: [{ clientX: 100, clientY: 160 }] });
+      fireEvent.touchEnd(toast);
+
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('springs back on a downward drag under the commit threshold', () => {
+      const onDismiss = vi.fn();
+      renderWithProviders(<StatusToast message="Saved" tone="success" onDismiss={onDismiss} />);
+      const toast = getToast();
+
+      // Travel of 20px (< 48px threshold) → no dismiss, transform clears.
+      fireEvent.touchStart(toast, { touches: [{ clientX: 100, clientY: 100 }] });
+      fireEvent.touchMove(toast, { touches: [{ clientX: 100, clientY: 120 }] });
+      fireEvent.touchEnd(toast);
+
+      expect(onDismiss).not.toHaveBeenCalled();
+      expect(toast.style.transform).toBe('');
+    });
+
+    it('ignores upward swipes so the toast can be re-read but not yanked', () => {
+      const onDismiss = vi.fn();
+      renderWithProviders(<StatusToast message="Saved" tone="success" onDismiss={onDismiss} />);
+      const toast = getToast();
+
+      fireEvent.touchStart(toast, { touches: [{ clientX: 100, clientY: 200 }] });
+      fireEvent.touchMove(toast, { touches: [{ clientX: 100, clientY: 80 }] });
+      fireEvent.touchEnd(toast);
+
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('does not track swipes when no onDismiss is provided', () => {
+      // Without a handler the gesture is meaningless — make sure we don't
+      // leave a translate on the surface, which would look broken to the user.
+      renderWithProviders(<StatusToast message="Read-only" tone="info" />);
+      const toast = getToast();
+      fireEvent.touchStart(toast, { touches: [{ clientX: 100, clientY: 100 }] });
+      fireEvent.touchMove(toast, { touches: [{ clientX: 100, clientY: 200 }] });
+      fireEvent.touchEnd(toast);
+      expect(toast.style.transform).toBe('');
+    });
+
     it('keeps action and dismiss buttons readable across themes', () => {
       const onAction = vi.fn();
       const onDismiss = vi.fn();
@@ -106,6 +162,38 @@ describe('StatusToast', () => {
       // dismiss were too dim against the dark page — confirm they upgraded.
       expect(screen.getByRole('button', { name: /retry/i })).toHaveClass('text-amber-200');
       expect(screen.getByRole('button', { name: /close/i }).className).toMatch(/text-stone-/);
+    });
+  });
+
+  describe('getStatusToastDurationMs (CUR-109)', () => {
+    it('keeps trust-bearing tones on screen at least 3 seconds', () => {
+      // Critical Saved / Synced / Will sync / Sync error feedback used to share
+      // the 2400ms info default and disappeared before users could read it.
+      expect(getStatusToastDurationMs('success')).toBeGreaterThanOrEqual(3000);
+      expect(getStatusToastDurationMs('error')).toBeGreaterThanOrEqual(3000);
+      expect(getStatusToastDurationMs('warning')).toBeGreaterThanOrEqual(3000);
+      expect(getStatusToastDurationMs('success')).toBe(STATUS_TOAST_DURATIONS.trust);
+    });
+
+    it('lets info tones auto-dismiss faster', () => {
+      expect(getStatusToastDurationMs('info')).toBe(STATUS_TOAST_DURATIONS.info);
+      expect(STATUS_TOAST_DURATIONS.info).toBeLessThan(STATUS_TOAST_DURATIONS.trust);
+    });
+
+    it('extends to the action-toast duration when a button is offered', () => {
+      // A user can't tap a button they didn't see — actionable toasts get the
+      // longest lifetime regardless of tone.
+      expect(getStatusToastDurationMs('success', { actionLabel: 'Retry' })).toBe(
+        STATUS_TOAST_DURATIONS.withAction,
+      );
+      expect(getStatusToastDurationMs('info', { actionLabel: 'Retry' })).toBe(
+        STATUS_TOAST_DURATIONS.withAction,
+      );
+    });
+
+    it('respects an explicit durationMs override', () => {
+      expect(getStatusToastDurationMs('success', { durationMs: 9999 })).toBe(9999);
+      expect(getStatusToastDurationMs('info', { durationMs: 100 })).toBe(100);
     });
   });
 });


### PR DESCRIPTION
## Problem

The status toast is Curio's most frequent trust surface — every **Saved**, **Synced**, **Will sync**, and **Sync error** lands here, especially on mobile where it sits at the bottom of the screen. Two gaps showed up against the **Trust before growth** principle:

1. The shared 2400ms default was too short for trust-bearing tones. A user who looks down to confirm "did my item save?" can miss the toast before they read it.
2. There was no swipe-to-dismiss. The only way out was the small close button, which is fiddly on a phone.

`docs/PRODUCT_DESIGN.md` § Mobile development guidelines already lists "swipe-to-dismiss for bottom sheets" as a durable rule; the same intuition applies to the toast, which is the bottom-anchored feedback surface.

## Approach

Per-tone durations + a downward swipe gesture, both gated by intent so they can't backfire:

- **`getStatusToastDurationMs(tone, options)`** in `StatusToast.tsx` — pure helper with three lifetimes:
  - `withAction: 6000ms` (unchanged) — the user has to reach a button.
  - `trust: 3500ms` for **success / warning / error** — clears the 3s acceptance-criteria minimum on mobile.
  - `info: 2400ms` (unchanged) — passive recovery notes can dismiss faster.
  - `durationMs` overrides still win for callers that need a specific value.
- `App.tsx` `showStatus` calls the helper instead of inlining the duration math, so the durations live next to the toast component they govern.
- **Swipe-down dismiss** on `StatusToast`. Track only vertical travel from `onTouchStart`; commit a dismiss past `SWIPE_DISMISS_DISTANCE = 48px`; anything under that resets transform so a near-tap doesn't clear feedback the user is still reading. Upward swipes are ignored. Gesture is a no-op when no `onDismiss` is provided, so read-only renders stay still.

## Why this approach

It's the smallest change that satisfies the issue without touching any of the 40+ `showStatus(...)` call sites. The duration logic moves into a named helper so the next person reading the code sees Curio's intent ("trust tones get 3.5s") instead of a ternary, and so the constants can be locked in by a unit test. The swipe lives entirely inside `StatusToast` — no parent container changes — so existing layouts in `App.tsx` and modal stacks are untouched. No data flow, sync, AI, RLS, storage, or routing changes.

## Risks

Low (green-tier). Purely presentational + a constant tweak. Touch handlers no-op without `onDismiss`. The swipe transform applies only while the finger is down, so static toasts and screen readers see the same DOM as before — `role="status"`, `aria-live="polite"`, message text, and tone classes are unchanged. Pre-login sample, AI fallback, and read-only paths are unaffected.

## How to verify

Vercel Preview: auto-deployed on this PR.

Steps:
1. On a mobile viewport (or DevTools 375×667), trigger any save in a writable collection. The "Saved" toast should remain visible for ~3.5s instead of disappearing in under 3.
2. Trigger a sync error (offline → reload). The error toast should stay long enough to read; tapping **Retry** still works.
3. With a toast on screen, drag it downward ~60px and release — toast clears immediately.
4. Drag it ~20px and release — toast snaps back, still on screen.
5. Drag upward — nothing changes; toast stays put.
6. Switch language to ZH and repeat — same lifetimes apply (i18n unchanged).
7. Across gallery / vault / atelier themes, the tone palettes and the close-button look the same.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 706 passed, 2 skipped, 1 todo (49 files; 4 new tests in `tests/components/StatusToast.test.tsx`)
- [x] `npm run build` — passed (vite 6.4.1, 1816 modules)
- [x] `npm run test:e2e` — 36 passed, 10 intentionally skipped

## Screenshot / GIF

Not captured in the headless web sandbox (no display). The behavior is locked in by the new tests:
- `dismisses on a downward swipe past the commit threshold (CUR-109)`
- `springs back on a downward drag under the commit threshold`
- `ignores upward swipes so the toast can be re-read but not yanked`
- `does not track swipes when no onDismiss is provided`
- `keeps trust-bearing tones on screen at least 3 seconds`
- `lets info tones auto-dismiss faster`
- `extends to the action-toast duration when a button is offered`
- `respects an explicit durationMs override`

## Linear / Issues

Closes #109

## Rollback plan

Single-commit revert restores the prior shared 2400ms / 6000ms default and removes the swipe handlers:

```
git revert 41bcaf5
```

No schema, RLS, storage, env-var, or feature-flag changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HRKxdobDXVueDpR6fRbiry)_