### PR TITLE
[#284] Make batch-import remove button visible on touch devices

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1005,7 +1005,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
                   <button
                     onClick={() => removeBatchItem(item.id)}
                     aria-label={t('remove')}
-                    className="absolute top-1 right-1 bg-white/90 p-1.5 rounded-full text-red-500 shadow-sm opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity"
+                    className="absolute top-1 right-1 bg-white/90 p-1.5 rounded-full text-red-500 shadow-sm transition-colors hover:bg-white"
                   >
                     <Trash2 size={12} />
                   </button>

--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1005,7 +1005,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
                   <button
                     onClick={() => removeBatchItem(item.id)}
                     aria-label={t('remove')}
-                    className="absolute top-1 right-1 bg-white/80 p-1 rounded-full text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="absolute top-1 right-1 bg-white/90 p-1.5 rounded-full text-red-500 shadow-sm opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity"
                   >
                     <Trash2 size={12} />
                   </button>


### PR DESCRIPTION
## Summary

- The remove (trash) icon on each batch-verify photo row was rendered with `opacity-0 group-hover:opacity-100`, which **never** appears on touch devices. The only way a mobile user could drop a single bad photo from a batch was to cancel the entire modal, losing work on the other photos.
- Switch to always-visible on the default (mobile) breakpoint while preserving the existing desktop hover-reveal behaviour (`sm:opacity-0 sm:group-hover:opacity-100`). Also added `sm:group-focus-within:opacity-100` so keyboard users on desktop see the affordance.
- Bumped padding from `p-1` → `p-1.5` and background opacity from `bg-white/80` → `bg-white/90`, plus a `shadow-sm`, so the control reads as a real button against busy thumbnails.

Fixes #284.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm test` — 699 passed
- [x] `npm run build` — succeeded
- [x] `npm run test:e2e` — 36 passed (no regressions)
- [ ] Manual: open Add Item on a mobile viewport, select multiple photos, confirm the trash icon is visible on each row and removes the correct photo on tap
- [ ] Manual: open Add Item on desktop, hover a batch row, confirm the trash icon still reveals on hover and on keyboard focus

## Context

Found by recurring UI/UX product review (Mode B — code-assisted; the live app is unreachable from this sandbox due to network egress allowlisting). See the routine summary comment for the rest of the findings filed as issues #285, #286, #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195GbgJ7BVCtnNu67n8mFpx

---
_Generated by [Claude Code](https://claude.ai/code/session_0195GbgJ7BVCtnNu67n8mFpx)_