### PR TITLE
[#287] Deep-link access-gate "Explore sample" into the sample collection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,6 +181,7 @@ export const AppContent: React.FC = () => {
   const [conflicts, setConflicts] = useState<ReturnType<typeof detectConflicts>>([]);
   const [isConflictModalOpen, setIsConflictModalOpen] = useState(false);
   const location = useLocation();
+  const navigate = useNavigate();
   const [pendingAuthAction, setPendingAuthAction] = useState<
     'add-item' | 'create-collection' | null
   >(null);
@@ -2445,6 +2446,18 @@ export const AppContent: React.FC = () => {
 
   const handleExploreSamples = () => {
     setAllowPublicBrowse(true);
+    // Deep-link straight into the sample exhibition when one is resolvable, so
+    // the access-gate "Explore sample" CTA honors the single-path first-run
+    // contract instead of dropping the visitor on an intermediate home grid.
+    // When the sample isn't resolvable yet (network race) we keep the existing
+    // refresh-and-stay-on-home fallback. Skipping refreshCollections() in the
+    // navigate path mirrors handleExploreFromNav: a transient cloud failure
+    // during that click-time refresh could replace `collections` with
+    // local-only data and bounce the user off the just-opened collection.
+    if (sampleCollectionId) {
+      navigate(`/collection/${sampleCollectionId}`);
+      return;
+    }
     if (isSupabaseReady) {
       refreshCollections();
     }

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -543,4 +543,75 @@ describe('App Integration Tests', () => {
       window.localStorage.removeItem('curio_language');
     }
   });
+
+  it('deep-links the access-gate "Explore sample" CTA into the sample collection (#287)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Signed-out visitor, Supabase configured, with a public sample loaded.
+    // Clicking "Explore sample" on the access gate must land the user *on*
+    // the sample collection, not on an intermediate home grid — the
+    // single-path first-run contract calls for one tap from the gate into
+    // the gallery preview.
+    const publicSample = {
+      id: 'sample-vinyl',
+      name: 'The Vinyl Vault',
+      templateId: 'vinyl',
+      icon: '🎵',
+      customFields: [],
+      items: [
+        {
+          id: 'sample-item-1',
+          collectionId: 'sample-vinyl',
+          title: 'Kind of Blue',
+          rating: 5,
+          data: {},
+          photoUrl: '',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          notes: '',
+        },
+      ],
+      isPublic: true,
+      updatedAt: new Date().toISOString(),
+    };
+    vi.mocked(supabaseService.isSupabaseConfigured).mockReturnValue(true);
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as never);
+    vi.mocked(db.getLocalCollections).mockResolvedValue([]);
+    vi.mocked(db.fetchCloudCollections).mockResolvedValue([publicSample]);
+    vi.mocked(db.mergeCollections).mockImplementation((local, cloud) =>
+      cloud.length ? cloud : local,
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('access-gate')).toBeInTheDocument();
+    });
+    // Wait for the initial cloud load so sampleCollectionId is resolvable
+    // by the time the CTA fires (matches the real-world timing — by the
+    // time a visitor reads the gate and clicks, the load has finished).
+    await waitFor(() => {
+      expect(vi.mocked(db.fetchCloudCollections)).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByTestId('cta-secondary-explore-sample'));
+
+    // Access gate clears AND we land on the sample collection itself —
+    // items-grid is unique to CollectionScreen, so its presence (plus the
+    // absence of collections-grid) is positive proof of the deep-link.
+    await waitFor(() => {
+      expect(screen.queryByTestId('access-gate')).not.toBeInTheDocument();
+    });
+    expect(await screen.findByTestId('items-grid')).toBeInTheDocument();
+    expect(screen.queryByTestId('collections-grid')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Problem

On the unauthenticated access gate, the secondary CTA **Explore sample** (`src/App.tsx`) only toggled `setAllowPublicBrowse(true)` and triggered `refreshCollections()` — it didn't navigate. Signed-out visitors landed on the home grid and had to tap the sample collection card again to actually reach the exhibition.

This violates the **single-path first run** constraint in `CLAUDE.md` (one primary CTA "Add your first item" + one secondary CTA "Explore sample" that lands inside the sample experience). It also dilutes the strongest pre-auth conversion moment in the **delight before auth** loop.

## Approach

`handleExploreSamples` now navigates straight to the sample collection when one is resolvable, and otherwise keeps the prior `refresh-and-stay-on-home` fallback intact:

```ts
const handleExploreSamples = () => {
  setAllowPublicBrowse(true);
  if (sampleCollectionId) {
    navigate(`/collection/${sampleCollectionId}`);
    return;
  }
  if (isSupabaseReady) {
    refreshCollections();
  }
};
```

Skipping `refreshCollections()` on the navigate path deliberately mirrors `handleExploreFromNav` (CUR-67 review): a transient cloud failure during a click-time refresh would replace `collections` with local-only data and bounce the user off the just-opened collection.

## Why this approach

- It is the smallest change that satisfies the acceptance criteria — one `useNavigate()` hook on `AppContent` (which already calls `useLocation()` at the same layer) and a six-line guard in the existing handler.
- It reuses the already-computed `sampleCollectionId`, which is itself gated against dead links (it returns `null` unless the sample is actually present in `collections`, so the CTA can never link to a collection `CollectionScreen` cannot find).
- It does not touch the bottom-nav `Explore` link, the `<Link>` in the header, the access-gate copy/markup, any sync logic, RLS, AI, or storage. No new product surface.

## Risks

Low → moderate. The CTA changes its post-click route from `/` to `/collection/:id` when a sample is resolvable, so the e2e helper for first-run flows could in principle pick up a different terminal state. Verified safely:

- The current Playwright environment runs without `VITE_SUPABASE_*` env vars, so the access gate never shows; `ensureSampleBrowse(...)` skips the Explore click and the existing tests are unaffected. All **36/36 e2e tests pass.**
- When the sample is not yet loaded (network race), behavior is unchanged — `refreshCollections()` still fires and the user stays on home. Acceptance-criterion fallback preserved.
- No RLS, schema, sync, auth, storage, or env changes.

## How to verify

Vercel Preview: auto-deployed on this PR.

Steps (in a Supabase-configured env, signed out):

1. Visit `/` in a fresh browser. The access gate appears with `Add your first item` and `Explore sample`.
2. Click `Explore sample`.
3. The URL changes to `#/collection/<sample-id>` and the sample exhibition renders directly — no intermediate home stop.
4. Repeat with a throttled network: if the initial cloud load is still in flight, clicking `Explore sample` falls back to the prior behavior (lands on home; sample card visible).
5. From the bottom-nav `Explore` tab and the header `Explore sample` chip, behavior is unchanged (already navigated via `<Link>`).

Checks (all run locally on this branch):

- [x] `npm run format:check` — All matched files use Prettier code style!
- [x] `npm test` — 700 passed | 2 skipped | 1 todo (49 files; 1 new test in `tests/integration/AppNavigation.test.tsx`)
- [x] `npm run build` — vite 6.4.1, 1816 modules, succeeded in 5.47s
- [x] `npm run test:e2e` — 36 passed, 10 intentionally skipped (Supabase-only paths)

The new integration test (`deep-links the access-gate "Explore sample" CTA into the sample collection (#287)`) was confirmed to fail against `main` (it times out waiting for `items-grid` because the visitor remains on the home grid) and pass on this branch.

## Screenshot / GIF

Not captured: the headless web sandbox has no display server and cannot reach a Supabase environment to render the access gate. The behavior is locked in by the integration test, which positively asserts both `access-gate` disappearance AND `items-grid` presence after the click.

## Linear / Issues

Closes #287

## Rollback plan

Single-commit revert restores the prior `setAllowPublicBrowse + refreshCollections` behavior with no schema, RLS, storage, env-var, or feature-flag changes:

```
git revert b508d53
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsAdXbpLbm4XavwpjpttCM)_