### PR TITLE
[#286] Home search: add inline X clear button + empty-state action

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { AlertCircle, Sparkles, Calendar, Search, Plus, Loader2 } from 'lucide-react';
+import { AlertCircle, Sparkles, Calendar, Search, Plus, Loader2, X } from 'lucide-react';
 import { useTranslation } from '../i18n';
 import {
   useTheme,
@@ -323,8 +323,19 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             placeholder={t('searchPlaceholder')}
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            className={`w-full pl-12 sm:pl-14 pr-6 sm:pr-8 py-3.5 sm:py-4 rounded-[1.5rem] sm:rounded-[1.75rem] border focus:ring-4 focus:ring-amber-500/5 outline-none transition-all shadow-lg text-sm sm:text-base font-serif italic placeholder:text-stone-300 ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
+            className={`w-full pl-12 sm:pl-14 pr-12 sm:pr-14 py-3.5 sm:py-4 rounded-[1.5rem] sm:rounded-[1.75rem] border focus:ring-4 focus:ring-amber-500/5 outline-none transition-all shadow-lg text-sm sm:text-base font-serif italic placeholder:text-stone-300 ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
           />
+          {searchInput.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setSearchInput('')}
+              aria-label={t('clearSearch')}
+              title={t('clearSearch')}
+              className={`absolute right-3 sm:right-4 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full flex items-center justify-center transition-colors ${theme === 'vault' ? 'text-stone-300 hover:bg-white/10' : 'text-stone-400 hover:bg-stone-100 hover:text-stone-600'}`}
+            >
+              <X size={18} />
+            </button>
+          )}
         </div>
       </div>
 
@@ -357,6 +368,11 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             <p className={typographyClasses.labelMuted}>
               {t('searchNoResultsBody', { query: searchInput.trim() })}
             </p>
+            <div className="mt-6 flex justify-center">
+              <Button variant="outline" size="sm" onClick={() => setSearchInput('')}>
+                {t('clearSearch')}
+              </Button>
+            </div>
           </div>
         )}
 

--- a/tests/components/HomeScreen.test.tsx
+++ b/tests/components/HomeScreen.test.tsx
@@ -100,6 +100,44 @@ describe('HomeScreen', () => {
     });
   });
 
+  it('exposes an inline clear button on the search input only when it has a value', async () => {
+    renderWithProviders(<HomeScreen {...defaultProps} />);
+
+    expect(screen.queryByRole('button', { name: /clear search/i })).not.toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'Vinyl' } });
+
+    const clearButton = await screen.findByRole('button', { name: /clear search/i });
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(searchInput.value).toBe('');
+      expect(screen.queryByRole('button', { name: /clear search/i })).not.toBeInTheDocument();
+      expect(screen.getAllByText('Stamps')[0]).toBeInTheDocument();
+    });
+  });
+
+  it('offers a Clear search action in the empty-results card', async () => {
+    renderWithProviders(<HomeScreen {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i) as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'zzzzz' } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/no matches found/i)).toBeInTheDocument();
+    });
+
+    const clearButtons = screen.getAllByRole('button', { name: /clear search/i });
+    fireEvent.click(clearButtons[clearButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(searchInput.value).toBe('');
+      expect(screen.queryByText(/no matches found/i)).not.toBeInTheDocument();
+      expect(screen.getAllByText('Vinyl Records')[0]).toBeInTheDocument();
+    });
+  });
+
   it('shows loading state', () => {
     renderWithProviders(<HomeScreen {...defaultProps} isLoading={true} />);
     expect(screen.getByText('Restoring the archives...')).toBeInTheDocument();


### PR DESCRIPTION
## Problem

The home-screen collection search input (`HomeScreen.tsx`) had no inline clear control, and its empty-results card had no "Clear search" affordance. A user who typed a query that returned nothing landed on a dead-end card with no obvious next step — particularly painful on mobile where backspacing a long query is slow. The collection-level search already offers a "Clear search" recovery (`App.tsx:1437-1440`), so home was also out of parity.

Touches the **trust before growth** and **Single-path first run** principles: the home screen is the first surface a returning user sees, and a search that strands them undermines confidence.

## Approach

- Render an inline `X` button at the right edge of the search input whenever `searchInput.length > 0`. Tapping it empties the value and the button disappears.
- Reserve matching right padding (`pr-12 sm:pr-14`) on the input so the layout doesn't jump when the button shows up.
- Add a `Button variant="outline" size="sm"` labelled `t('clearSearch')` to the empty-results card — same pattern already used in `CollectionScreen`.
- Both affordances reuse the existing `clearSearch` i18n key (EN/ZH already translated).
- 2 new Vitest cases lock in the behaviour.

## Why this approach

It's the smallest change that satisfies all four acceptance criteria in #286 without touching any shared component or data flow. The styling tokens match the existing input (`theme === 'vault'` branch + stone palette), and reusing `clearSearch` avoids adding strings that would drift from `CollectionScreen`'s wording.

## Risks

Low (green-tier). Pure presentational additions to `HomeScreen.tsx`. No data, sync, AI, RLS, storage, or routing changes. AI fallback, public sample, and read-only states are untouched.

## How to verify

Vercel Preview: auto-deployed on this PR.

Steps:
1. Sign in (or load any state with ≥1 collection) and navigate to Home.
2. Type into the search input — observe the X button appear on the right edge of the input.
3. Click the X — the input empties and the full collection grid restores.
4. Type a query that matches nothing (e.g. `zzzzz`). Confirm the empty-results card shows a `Clear search` button below the body copy.
5. Click `Clear search` — input empties, grid restores.
6. Switch to ZH — both controls remain visible and use `清除搜索`.
7. Repeat across gallery / vault / atelier themes; the X hover state is theme-aware.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 702 passed, 2 skipped, 1 todo (49 files; 2 new tests in `tests/components/HomeScreen.test.tsx`)
- [x] `npm run build` — passed (vite 6.4.1, 1816 modules)
- [x] `npm run test:e2e` — 36 passed, 10 intentionally skipped

## Screenshot / GIF

Not captured (headless container, no display). New tests cover both affordances:
- `exposes an inline clear button on the search input only when it has a value`
- `offers a Clear search action in the empty-results card`

## Linear / Issues

Closes #286

## Rollback plan

Single-commit revert restores the prior input padding and empty-state copy:

```
git revert 5a89819
```

No schema, RLS, storage, env-var, or feature-flag changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AhjMX7zBrRgo1EZrv4e7dA)_