### PR TITLE
Fix item export card: reliable bottom sheet + working Save image

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -33,9 +33,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
   const [style, setStyle] = useState<TemplateStyle>('minimal');
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('3:4');
   const [imageFit, setImageFit] = useState<ImageFit>('cover');
-  // CUR-105: open the mobile bottom sheet expanded so Save / Share / Print are
-  // visible on first open. Users can drag the handle down to collapse and
-  // admire the card. Desktop is unaffected (sheet is forced full-height at md:).
+  // CUR-105: open the mobile bottom sheet so Save / Share / Print are visible on
+  // first open. The open height is a moderate fraction of the screen (see
+  // OPEN_SHEET_HEIGHT) so the card stays prominent above it; users can drag the
+  // handle / tap it to collapse to a peek and admire the card, then drag or tap
+  // again to re-open. Desktop is unaffected (sheet is forced full-height at md:).
   const [isExpanded, setIsExpanded] = useState(true);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isLoadingImage, setIsLoadingImage] = useState(true);
@@ -167,10 +169,23 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     const previewWidth = node.offsetWidth;
     const pixelRatio =
       previewWidth > 0 ? Math.max(2, EXPORT_TARGET_SHORT_EDGE_PX / previewWidth) : 2;
-    return toBlob(node, {
-      pixelRatio,
-      backgroundColor: '#ffffff',
-    });
+    try {
+      return await toBlob(node, {
+        pixelRatio,
+        backgroundColor: '#ffffff',
+      });
+    } catch (err) {
+      // html-to-image inlines the brand web fonts by fetching them. If that
+      // fetch fails (offline, CSP, flaky network) the whole export rejects.
+      // Retry without font embedding so the user still gets a card — it falls
+      // back to system serif/mono, which is far better than a hard failure.
+      console.warn('Card export failed with embedded fonts, retrying without them:', err);
+      return await toBlob(node, {
+        pixelRatio,
+        backgroundColor: '#ffffff',
+        skipFonts: true,
+      });
+    }
   }, []);
 
   const handleSaveImage = useCallback(async () => {
@@ -233,6 +248,13 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
   }, [exportAction, item.title, renderCardToBlob, t]);
 
   const PEEK_HEIGHT_PX = 56;
+  // Moderate open height: tall enough to reveal the action footer (Save / Share /
+  // Print) while leaving the card prominent above the sheet. Clamped so the
+  // footer still fits on short screens and the sheet never dominates tall ones.
+  const OPEN_SHEET_HEIGHT = 'clamp(20rem, 52dvh, 32rem)';
+  // Past this drag delta we commit to the new state; smaller drags snap back to
+  // the current state so a tap-sized wobble never flips the sheet.
+  const SNAP_DELTA_PX = 48;
 
   const handleSheetPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (window.matchMedia('(min-width: 768px)').matches) return;
@@ -272,8 +294,16 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
     }
     const finalHeight = dragHeight ?? drag.startHeight;
     if (drag.moved) {
-      const threshold = window.innerHeight * 0.35;
-      setIsExpanded(finalHeight > threshold);
+      // Snap by drag *direction* relative to where the drag started, not an
+      // absolute screen fraction. The old absolute threshold meant a short swipe
+      // up from the peek could never clear it, so a collapsed sheet got stuck.
+      const delta = finalHeight - drag.startHeight; // > 0 means dragged up (grew)
+      if (delta > SNAP_DELTA_PX) {
+        setIsExpanded(true);
+      } else if (delta < -SNAP_DELTA_PX) {
+        setIsExpanded(false);
+      }
+      // Otherwise keep the current state — the sheet snaps back to its prior snap.
     } else {
       setIsExpanded((prev) => !prev);
     }
@@ -422,7 +452,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, onClose, item,
   const mobileSheetHeight = isDragging
     ? `${dragHeight}px`
     : isExpanded
-      ? '85dvh'
+      ? OPEN_SHEET_HEIGHT
       : 'var(--peek-height)';
 
   return (

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -258,3 +258,39 @@ describe('ExportModal — CUR-99 fixed export resolution', () => {
     expect(options.pixelRatio).toBe(2);
   });
 });
+
+describe('ExportModal — export resilience when font embedding fails', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('retries the render with skipFonts when the first toBlob attempt rejects', async () => {
+    const mockedToBlob = toBlob as unknown as ReturnType<typeof vi.fn>;
+    mockedToBlob
+      .mockRejectedValueOnce(new Error('font fetch blocked by CSP'))
+      .mockResolvedValueOnce(new Blob(['fake'], { type: 'image/png' }));
+
+    const userEvent = (await import('@testing-library/user-event')).default;
+    const user = userEvent.setup();
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    await user.click(screen.getByRole('button', { name: /save image/i }));
+
+    await waitFor(() => {
+      expect(mockedToBlob).toHaveBeenCalledTimes(2);
+    });
+    // First attempt embeds fonts; the retry skips them so the user still gets an image.
+    expect(mockedToBlob.mock.calls[0][1]).not.toHaveProperty('skipFonts', true);
+    expect(mockedToBlob.mock.calls[1][1]).toHaveProperty('skipFonts', true);
+
+    // No error surfaced to the user because the retry succeeded.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/viteCsp.regression-1.test.ts
+++ b/tests/unit/viteCsp.regression-1.test.ts
@@ -15,4 +15,15 @@ describe('buildCspPolicy', () => {
       "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.curio.test",
     );
   });
+
+  it('allows Google Fonts origins in connect-src so html-to-image can inline fonts on export', () => {
+    // Regression: export card "Save image" failed because html-to-image fetches
+    // the Google Fonts stylesheet + font files and connect-src blocked them.
+    const policy = buildCspPolicy();
+    expect(policy).toContain('https://fonts.googleapis.com');
+    expect(policy).toContain('https://fonts.gstatic.com');
+    const connectDirective = policy.split('; ').find((d) => d.startsWith('connect-src '));
+    expect(connectDirective).toContain('https://fonts.googleapis.com');
+    expect(connectDirective).toContain('https://fonts.gstatic.com');
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,11 @@ export function buildCspPolicy({ apiBaseUrl = '' }: CspPolicyOptions = {}): stri
     'https://*.supabase.co',
     'wss://*.supabase.co',
     ...(apiBaseUrl ? [apiBaseUrl] : []),
+    // html-to-image fetches the Google Fonts stylesheet + font files to inline
+    // them into the exported card; without these origins the fetch is blocked by
+    // CSP and "Save image" / "Share" fail with a generic error.
+    'https://fonts.googleapis.com',
+    'https://fonts.gstatic.com',
   ].join(' ');
 
   const scriptSrc = ["'self'", 'https://va.vercel-scripts.com'].join(' ');


### PR DESCRIPTION
Fixes #292

## Problem

The item export/print card (`ExportModal`) was hard to use on mobile:

1. **Sheet dominated the screen** — the config bottom sheet opened fully expanded (`85dvh`), burying the card the user wanted to preview/export.
2. **Stuck after collapse** — swiping the sheet down to admire the card worked, but it couldn't be brought back. The snap-on-release logic compared the final height to an **absolute** `window.innerHeight * 0.35` threshold; from the ~56px peek, a short swipe up could never clear it, so it always snapped back to collapsed.
3. **"Save image" failed** — Save/Share showed "Could not save image." `html-to-image` inlines the brand web fonts by `fetch()`ing the Google Fonts stylesheet + font files, but the CSP `connect-src` blocked those origins, so `toBlob` rejected.

## Changes

| Area | Fix |
| --- | --- |
| `vite.config.ts` | Add `https://fonts.googleapis.com` + `https://fonts.gstatic.com` to CSP `connect-src` so `html-to-image` can inline fonts. |
| `ExportModal.tsx` | Retry `toBlob` with `skipFonts: true` if the first attempt fails (offline/blocked/flaky) — the user always gets a card (system-font fallback) instead of a hard error. |
| `ExportModal.tsx` | Open the sheet at a moderate `clamp(20rem, 52dvh, 32rem)` so the card stays prominent while Save/Share/Print stay visible. |
| `ExportModal.tsx` | Snap the sheet by drag **direction** (48px delta) instead of an absolute screen fraction, so a short swipe up from the peek re-opens it reliably. Tap-to-toggle unchanged. |

## Tests
- New CSP regression test asserting the Google Fonts origins are present in `connect-src`.
- New `ExportModal` test asserting the `skipFonts` retry path succeeds without surfacing an error.
- `npm run format:check`, `npm test` (704 passed), `npm run build`, and `npm run test:e2e` (36 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzQzfLKiRZ8gjULb7eRWJp)_