### PR TITLE
[CUR-112] Surface Terms / Privacy in the profile menu

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -196,6 +196,39 @@ export const Layout: React.FC<LayoutProps> = ({
         </div>
       </div>
 
+      <div
+        data-testid="profile-legal-links"
+        className={`px-4 pb-3 pt-1 flex items-center gap-3 text-[12px] ${
+          theme === 'vault' ? 'text-white/60' : 'text-stone-500'
+        }`}
+      >
+        <a
+          href="#/legal/terms"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={closeProfile}
+          className={`underline-offset-4 hover:underline transition-colors ${
+            theme === 'vault' ? 'hover:text-white' : 'hover:text-stone-900'
+          }`}
+        >
+          {t('termsOfService')}
+        </a>
+        <span aria-hidden="true" className="opacity-40">
+          ·
+        </span>
+        <a
+          href="#/legal/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={closeProfile}
+          className={`underline-offset-4 hover:underline transition-colors ${
+            theme === 'vault' ? 'hover:text-white' : 'hover:text-stone-900'
+          }`}
+        >
+          {t('privacyPolicy')}
+        </a>
+      </div>
+
       {isAuthenticated ? (
         <button
           onClick={() => {

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -688,6 +688,85 @@ describe('Layout Component', () => {
     });
   });
 
+  // CUR-112: Privacy / Terms have no in-app discovery path after signup.
+  // Profile menu (shared by header dropdown + mobile bottom sheet) now surfaces
+  // both legal docs in every auth state.
+  describe('CUR-112 Legal links in profile menu', () => {
+    const authenticatedUser = { id: 'user-1', email: 'test@example.com' };
+
+    it('surfaces Terms and Privacy links in the header dropdown when signed in', async () => {
+      renderWithProviders(<Layout {...defaultProps} user={authenticatedUser} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /account/i }));
+
+      await waitFor(() => {
+        const legal = within(screen.getByTestId('profile-dropdown')).getByTestId(
+          'profile-legal-links',
+        );
+        expect(within(legal).getByRole('link', { name: 'Terms of Service' })).toHaveAttribute(
+          'href',
+          '#/legal/terms',
+        );
+        expect(within(legal).getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
+          'href',
+          '#/legal/privacy',
+        );
+      });
+    });
+
+    it('surfaces the same Terms and Privacy links when signed out', async () => {
+      renderWithProviders(<Layout {...defaultProps} user={null} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /account/i }));
+
+      await waitFor(() => {
+        const legal = within(screen.getByTestId('profile-dropdown')).getByTestId(
+          'profile-legal-links',
+        );
+        expect(within(legal).getByRole('link', { name: 'Terms of Service' })).toBeInTheDocument();
+        expect(within(legal).getByRole('link', { name: 'Privacy Policy' })).toBeInTheDocument();
+      });
+    });
+
+    it('opens both legal links in a new tab with secure rel (mirrors signup pattern)', async () => {
+      renderWithProviders(<Layout {...defaultProps} user={authenticatedUser} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /account/i }));
+
+      await waitFor(() => {
+        const legal = within(screen.getByTestId('profile-dropdown')).getByTestId(
+          'profile-legal-links',
+        );
+        for (const name of ['Terms of Service', 'Privacy Policy']) {
+          const link = within(legal).getByRole('link', { name });
+          expect(link).toHaveAttribute('target', '_blank');
+          expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        }
+      });
+    });
+
+    it('surfaces both links from the mobile bottom sheet', async () => {
+      renderWithProviders(<Layout {...defaultProps} user={authenticatedUser} />);
+
+      const bottomNav = screen.getByRole('navigation', { name: /primary/i });
+      fireEvent.click(within(bottomNav).getByText('Profile').closest('button')!);
+
+      await waitFor(() => {
+        const legal = within(screen.getByTestId('profile-bottom-sheet')).getByTestId(
+          'profile-legal-links',
+        );
+        expect(within(legal).getByRole('link', { name: 'Terms of Service' })).toHaveAttribute(
+          'href',
+          '#/legal/terms',
+        );
+        expect(within(legal).getByRole('link', { name: 'Privacy Policy' })).toHaveAttribute(
+          'href',
+          '#/legal/privacy',
+        );
+      });
+    });
+  });
+
   describe('Accessibility', () => {
     it('has accessible account button with aria-label', () => {
       renderWithProviders(<Layout {...defaultProps} />);


### PR DESCRIPTION
## Problem

CUR-57 added `/legal/terms` and `/legal/privacy` pages, but the **only** in-app entry points are the consent links inside the signup form (`AuthModal`). The moment a user is signed in, both links are gone — there is no way to revisit what was agreed to from inside the app, and the route only works if a user remembers to type the hash URL manually.

That's a **trust + compliance** gap, not just polish — it's the "Trust before growth" principle in our product strategy, and it's table stakes for any privacy-policy review (GDPR / app stores). Anyone going through the existing profile menu surfaces (header dropdown, mobile bottom sheet, mobile bottom nav, header extras) finds nothing legal.

## Approach

Add a small Legal row to the **shared** `profileMenuBody` in `src/components/Layout.tsx` — the same JSX that renders into both the desktop dropdown and the mobile bottom sheet, so one edit covers every surface.

- Two text links, separated by a `·`, opening `#/legal/terms` and `#/legal/privacy` in a new tab.
- Reuses existing `t('termsOfService')` and `t('privacyPolicy')` keys — no new copy.
- Same `target="_blank" rel="noopener noreferrer"` pattern as the signup consent row in `AuthModal.tsx:664-693`.
- Theme-aware muted styling (`text-white/60` on Vault, `text-stone-500` elsewhere) with theme-aware hover (`hover:text-white` / `hover:text-stone-900`).
- Clicking a link also calls `closeProfile()` so the open menu / sheet closes behind the new tab.
- Tagged with `data-testid="profile-legal-links"` for stable targeting.

## Why this approach

`profileMenuBody` is the **only** shared surface that already renders in both the header dropdown and the mobile bottom sheet — adding the row there means one change covers desktop + mobile and ships with the existing show-on-open / Escape / backdrop / focus-restore behaviour. Re-using the existing translation keys and the AuthModal link pattern keeps the new row visually and behaviourally consistent with the only other legal-link entry point in the app.

Placement note: I put the row immediately under the Theme picker (per the issue's recommended location, between Theme picker and Sign Out / Sign In), so the auth action still anchors the bottom of the menu and Legal reads as a footnote.

## Risks

Low (green-tier, presentational + a small new aria-decoration row). Touches only `Layout.tsx` and its test file. Routes already exist; the LegalPage route in `App.tsx:2686` is unchanged. The signup legal consent footer (CUR-57) is untouched. No data flow, sync, AI, RLS, storage, routing, env-var, or feature-flag changes.

## How to verify

Vercel Preview: auto-deployed on this PR.

Steps:
1. Sign in (or stay signed out). Open the header account dropdown — the **Terms of Service · Privacy Policy** row is visible immediately under the Theme picker.
2. Click either link — it opens in a new tab and renders the legal page. The dropdown closes behind it.
3. On a mobile viewport (375px or 360px), tap **Profile** in the bottom nav. Both links are present inside the bottom sheet, and the sheet still scrolls under the new row.
4. Toggle between **Gallery / Vault / Atelier** themes — link muted colour and hover treatment adapt; nothing else changes.
5. Sign out — links are still reachable from the dropdown (and from the bottom sheet on mobile).
6. Switch language to ZH (`隐私政策 / 服务条款`) — same row, localized via existing keys.
7. Confirm the signup form's legal consent footer (open auth modal → Sign Up) is unchanged.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — 49 files, 714 passed, 2 skipped, 1 todo (4 new tests in `tests/components/Layout.test.tsx` for CUR-112)
- [x] `npm run build` — passed (vite 6.4.1, 1816 modules)
- [x] `npm run test:e2e` — 36 passed, 10 skipped

## Screenshot / GIF

Not captured (no display in this remote sandbox). New behaviour is locked in by four tests:
- `surfaces Terms and Privacy links in the header dropdown when signed in`
- `surfaces the same Terms and Privacy links when signed out`
- `opens both legal links in a new tab with secure rel (mirrors signup pattern)`
- `surfaces both links from the mobile bottom sheet`

## Linear

Closes CUR-112

## Rollback plan

Single-commit revert removes the legal row and its tests:

```
git revert c579efb
```

No schema, RLS, storage, env-var, or feature-flag changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQJiEQ7FLyCSxt8bx1UpuU)_