### PR TITLE
[CUR-115] Announce required + invalid state on Item Detail title

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2004,6 +2004,12 @@ export const AppContent: React.FC = () => {
                 <textarea
                   ref={titleTextareaRef}
                   rows={1}
+                  aria-label={t('title')}
+                  aria-required="true"
+                  aria-invalid={titleIsEmpty && !isReadOnly ? true : undefined}
+                  aria-describedby={
+                    titleIsEmpty && !isReadOnly ? 'item-detail-title-error' : undefined
+                  }
                   className={`${typographyClasses.titleDisplay} mb-2 sm:mb-3 w-full bg-transparent border-b-2 resize-none overflow-hidden break-words leading-tight ${
                     titleIsEmpty && !isReadOnly
                       ? 'border-red-400 focus:border-red-500'
@@ -2021,7 +2027,13 @@ export const AppContent: React.FC = () => {
                   disabled={isReadOnly}
                 />
                 {titleIsEmpty && !isReadOnly && (
-                  <p className="text-xs font-semibold text-red-500 mb-3">{t('titleRequired')}</p>
+                  <p
+                    id="item-detail-title-error"
+                    role="alert"
+                    className="text-xs font-semibold text-red-500 mb-3"
+                  >
+                    {t('titleRequired')}
+                  </p>
                 )}
                 <div className="flex flex-wrap items-center gap-2">
                   {[1, 2, 3, 4, 5].map((star) => (

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -544,6 +544,58 @@ describe('App Integration Tests', () => {
     }
   });
 
+  // CUR-115: Item Detail title textarea must announce its accessible name,
+  // required state, and validation error to assistive tech. The visual red
+  // border alone leaves SR users with no signal that the field is invalid.
+  it('exposes the Item Detail title textarea with aria-label and aria-required (CUR-115)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1/item/item1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const titleInput = await screen.findByRole('textbox', { name: 'Title' });
+    expect(titleInput).toBeInstanceOf(HTMLTextAreaElement);
+    expect(titleInput).toHaveAttribute('aria-required', 'true');
+    // A filled title is not invalid and must not be linked to an error.
+    expect(titleInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(titleInput).not.toHaveAttribute('aria-describedby');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('flags the Item Detail title as invalid and links the error when empty (CUR-115)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    const collectionWithUntitled = {
+      ...mockCollection,
+      items: [{ ...mockCollection.items[0], title: '' }],
+    };
+    vi.mocked(db.getLocalCollections).mockResolvedValue([collectionWithUntitled]);
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1/item/item1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const titleInput = await screen.findByRole('textbox', { name: 'Title' });
+    expect(titleInput).toHaveAttribute('aria-invalid', 'true');
+    expect(titleInput).toHaveAttribute('aria-describedby', 'item-detail-title-error');
+
+    const errorMessage = screen.getByRole('alert');
+    expect(errorMessage).toHaveAttribute('id', 'item-detail-title-error');
+    expect(errorMessage.textContent).toBe('Title is required');
+  });
+
   it('deep-links the access-gate "Explore sample" CTA into the sample collection (#287)', async () => {
     const { ThemeProvider } = await import('@/theme');
     // Signed-out visitor, Supabase configured, with a public sample loaded.


### PR DESCRIPTION
## Problem

The Item Detail title is the **required** field for an item, but its `<textarea>` (`src/App.tsx`) exposed nothing useful to assistive tech:

- No `aria-label` or `<label>` — only a placeholder, which is not an accessible name.
- No `aria-required` / `required` — screen readers couldn't tell the field was mandatory.
- The "Title is required" error sat as a sibling `<p>` with no `id`, no `role="alert"`, and no `aria-describedby` link from the textarea.

A blind user editing an item could leave it in an invalid state (the empty title renders as italic "Untitled" everywhere else) without ever hearing why. This is a small fix with disproportionate impact for assistive-tech users — and it protects **trust before growth**: controls should communicate their state, not hide it behind a visual-only red border.

## Approach

In `src/App.tsx` (the existing Item Detail title textarea):

- Added `aria-label={t('title')}` — reuses the existing `title` translation ("Title" / "标题"), no new copy.
- Added `aria-required="true"`.
- Added `aria-invalid={titleIsEmpty && !isReadOnly}` so the invalid signal toggles only when the field is actually editable and empty.
- Added `aria-describedby="item-detail-title-error"` (only when invalid) pointing at the error `<p>`.
- Gave the error `<p>` a stable `id="item-detail-title-error"` and `role="alert"` so the message announces when it appears.

Added two integration tests in `tests/integration/AppNavigation.test.tsx`:

- Filled title: textarea is queryable by `name: 'Title'`, has `aria-required="true"`, and has no `aria-invalid` / `aria-describedby` / alert.
- Empty title: same textarea now has `aria-invalid="true"`, `aria-describedby` linked to the error, and the error renders as `role="alert"` with the correct `id`.

## Why this approach

Smallest taste-aligned change: pure attribute additions on the existing element, reuses an existing translation, preserves the existing red-border visual treatment, and follows the same `role="alert"` pattern already used by `AuthModal`. No new dependencies, no design tokens touched, no data flow changes.

## Risks

Low — additive ARIA attributes on a single textarea + one error `<p>`. No behavior, layout, theme, sync, or auth paths change. The new tests would fail if any of the attributes regress.

## How to verify

Vercel Preview: _(populated by Vercel bot on push)_

Steps:
1. Open any item detail (e.g. on the public sample collection).
2. With DevTools accessibility panel (or VoiceOver/NVDA/TalkBack): the title textarea should announce as "Title, required".
3. Clear the title. The textarea should now announce as invalid and read out "Title is required" as an alert / error description.
4. Restore a title. The error should disappear and the textarea should no longer be marked invalid.
5. Open a public/read-only item. The textarea is `disabled` and remains non-invalid (no error path).

Checks:
- [x] `npm run format:check`
- [x] `npm test` — 729 passed / 2 skipped / 1 todo (50 files), including 2 new CUR-115 tests
- [x] `npm run build`
- [x] `npm run test:e2e` — 36 passed / 10 skipped (pre-existing skips)

## Screenshot / GIF

No visual change — the existing red-border treatment is preserved exactly. The diff is entirely in the accessibility tree.

## Linear

Closes CUR-115
https://linear.app/qiuyue/issue/CUR-115/ux-item-detail-title-textarea-doesnt-expose-required-invalid-state-to

## Rollback plan

Single-commit revert:

```
git revert 850f900
```

No data, schema, RLS, storage, or feature-flag changes — pure ARIA attributes in `src/App.tsx` + tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1KtxvBDZDJELtDuCc7crV)_