### PR TITLE
[CUR-54] Memoize LanguageProvider context value

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,12 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  ReactNode,
+} from 'react';
 
 export type Language = 'en' | 'zh';
 
@@ -1018,23 +1026,26 @@ export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }
     }
   }, [language]);
 
-  const t = (key: string, params?: Record<string, string | number>) => {
-    const dict = translations[language] as Record<string, string>;
-    const fallback = translations['en'] as Record<string, string>;
-    let text: string = dict[key] || fallback[key] || key;
-    if (params) {
-      Object.entries(params).forEach(([k, v]) => {
-        text = text.replace(`{${k}}`, String(v));
-      });
-    }
-    return text;
-  };
-
-  return React.createElement(
-    LanguageContext.Provider,
-    { value: { language, setLanguage, t } },
-    children,
+  const t = useCallback(
+    (key: string, params?: Record<string, string | number>) => {
+      const dict = translations[language] as Record<string, string>;
+      const fallback = translations['en'] as Record<string, string>;
+      let text: string = dict[key] || fallback[key] || key;
+      if (params) {
+        Object.entries(params).forEach(([k, v]) => {
+          text = text.replace(`{${k}}`, String(v));
+        });
+      }
+      return text;
+    },
+    [language],
   );
+
+  // Memoize the context value so consumers of `useTranslation()` only re-render
+  // when `language` actually changes, not on every render of LanguageProvider.
+  const value = useMemo(() => ({ language, setLanguage, t }), [language, t]);
+
+  return React.createElement(LanguageContext.Provider, { value }, children);
 };
 
 export const useTranslation = () => {

--- a/tests/unit/languageProvider.test.tsx
+++ b/tests/unit/languageProvider.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * CUR-54: LanguageProvider memoization regression test.
+ *
+ * LanguageProvider sits at the top of the tree, so every render of its parent
+ * (App / route changes / theme changes / unrelated state) used to recreate the
+ * context value object and the `t` function. That forced every consumer of
+ * `useTranslation()` to re-render, even when `language` hadn't changed. These
+ * tests pin that behavior in place:
+ *
+ * 1. A consumer of `useTranslation()` only re-renders when `language` actually
+ *    changes — not when the LanguageProvider's parent re-renders.
+ * 2. Toggling the language still propagates to consumers (no broken memo).
+ */
+
+import React, { useRef } from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { LanguageProvider, useTranslation } from '@/i18n';
+
+// React.memo'd so the consumer only re-renders when its context value
+// reference changes — exactly the behavior we want to gate on.
+const Consumer = React.memo(function Consumer() {
+  const { t } = useTranslation();
+  const renders = useRef(0);
+  renders.current += 1;
+  return (
+    <div>
+      <span data-testid="render-count">{renders.current}</span>
+      <span data-testid="translated">{t('artifacts')}</span>
+    </div>
+  );
+});
+
+function LanguageSwitcher() {
+  const { language, setLanguage } = useTranslation();
+  return <button onClick={() => setLanguage(language === 'en' ? 'zh' : 'en')}>switch</button>;
+}
+
+describe('LanguageProvider memoization (CUR-54)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('does not re-render translation consumers when the provider parent re-renders', () => {
+    let bumpParent: () => void = () => {};
+
+    function Parent() {
+      const [, setN] = React.useState(0);
+      bumpParent = () => setN((n) => n + 1);
+      return (
+        <LanguageProvider>
+          <Consumer />
+        </LanguageProvider>
+      );
+    }
+
+    render(<Parent />);
+    const initial = Number(screen.getByTestId('render-count').textContent);
+    expect(initial).toBeGreaterThan(0);
+
+    act(() => {
+      bumpParent();
+      bumpParent();
+      bumpParent();
+    });
+
+    // Without memoization the consumer would tick to `initial + 3` here.
+    expect(Number(screen.getByTestId('render-count').textContent)).toBe(initial);
+  });
+
+  it('still propagates language changes through to consumers', () => {
+    render(
+      <LanguageProvider>
+        <LanguageSwitcher />
+        <Consumer />
+      </LanguageProvider>,
+    );
+
+    expect(screen.getByTestId('translated').textContent).toBe('Artifacts');
+
+    fireEvent.click(screen.getByRole('button', { name: 'switch' }));
+
+    expect(screen.getByTestId('translated').textContent).toBe('珍品');
+  });
+});


### PR DESCRIPTION
## Problem

`LanguageProvider` sits near the top of the React tree, but it was creating a
brand-new context value object (and a brand-new inline `t` function) on every
render. Every consumer of `useTranslation()` — which is most of the component
tree — re-rendered any time `LanguageProvider` itself re-rendered, even when
`language` hadn't changed. This amplified prop/render churn across the whole
app and made "what triggered this render?" debugging noisier than it needed
to be. It also amplified the next bug of the same shape (this was split out
of the CUR-44 investigation for that reason).

This protects the **trust** principle indirectly: a stable, predictable
render graph makes it easier to keep sync/save UX feeling deterministic.

## Approach

- Wrap `t` in `useCallback([language])` so its identity is stable across
  unrelated re-renders.
- Wrap the context value in `useMemo([language, t])` so consumers see a
  stable reference whenever `language` is unchanged.
- Add a focused regression test that pins both halves of the contract:
  - A `React.memo`'d consumer does not re-render when the provider's parent
    re-renders for unrelated reasons.
  - Toggling `setLanguage` still propagates the new strings to consumers
    (i.e. the memo isn't accidentally too sticky).

## Why this approach

Smallest taste-aligned change: matches the existing React idioms already used
elsewhere in the codebase (no new abstractions, no library), and stays inside
`i18n.ts` so the diff is contained. Confirmed the test fails on the
unmemoized provider and passes after the fix, which is the only thing keeping
this from regressing silently.

## Risks

Low. Behavior is unchanged from the consumer's perspective — same context
shape, same `t(key, params)` signature. The only observable difference is
fewer re-renders. Verified by running the full unit suite and Playwright
E2E suite (both green) so no caller relies on the unstable reference.

## How to verify

Vercel Preview: (attached automatically by the integration)

Steps:
1. App loads in EN; UI strings render normally.
2. Toggle to ZH via the header language toggle — all visible strings flip.
3. Toggle back to EN — strings flip back.
4. (Optional) In React DevTools profiler, navigate between routes; consumers
   of `useTranslation()` no longer flash on every parent render.

Checks:
- [x] npm run format:check
- [x] npm test (731 passed)
- [x] npm run build
- [x] npm run test:e2e (36 passed, 10 skipped — same as main)

## Linear

Closes CUR-54


---
_Generated by [Claude Code](https://claude.ai/code/session_01JDxjjWWwUSNNLA3L7SbiAc)_