### PR TITLE
[CUR-116] Add inline X clear + aria-label to collection search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1375,14 +1375,29 @@ export const AppContent: React.FC = () => {
                   <option value="rating">{t('sortRating')}</option>
                 </select>
               </div>
-              <div className="relative flex gap-2 flex-1 min-w-[12rem]">
-                <input
-                  type="text"
-                  placeholder={t('collectionSearchPlaceholder')}
-                  value={filterInput}
-                  onChange={(e) => setFilterInput(e.target.value)}
-                  className={`pl-4 pr-4 py-2 rounded-xl border focus:ring-4 focus:ring-amber-500/5 outline-none text-sm w-full transition-all shadow-sm font-serif italic ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
-                />
+              <div className="flex gap-2 flex-1 min-w-[12rem]">
+                <div className="relative flex-1">
+                  <input
+                    type="text"
+                    placeholder={t('collectionSearchPlaceholder')}
+                    aria-label={t('collectionSearchPlaceholder')}
+                    value={filterInput}
+                    onChange={(e) => setFilterInput(e.target.value)}
+                    className={`pl-4 pr-11 py-2 rounded-xl border focus:ring-4 focus:ring-amber-500/5 outline-none text-sm w-full transition-all shadow-sm font-serif italic ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
+                  />
+                  {filterInput.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setFilterInput('')}
+                      aria-label={t('clearSearch')}
+                      title={t('clearSearch')}
+                      data-testid="collection-search-clear"
+                      className={`absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full flex items-center justify-center transition-colors ${theme === 'vault' ? 'text-stone-300 hover:bg-white/10' : 'text-stone-400 hover:bg-stone-100 hover:text-stone-600'}`}
+                    >
+                      <X size={16} />
+                    </button>
+                  )}
+                </div>
                 <Button
                   variant={activeFilterCount > 0 ? 'primary' : 'outline'}
                   className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1392,7 +1392,7 @@ export const AppContent: React.FC = () => {
                       aria-label={t('clearSearch')}
                       title={t('clearSearch')}
                       data-testid="collection-search-clear"
-                      className={`absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full flex items-center justify-center transition-colors ${theme === 'vault' ? 'text-stone-300 hover:bg-white/10' : 'text-stone-400 hover:bg-stone-100 hover:text-stone-600'}`}
+                      className={`absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 w-11 h-11 sm:w-9 sm:h-9 rounded-full flex items-center justify-center transition-colors ${theme === 'vault' ? 'text-stone-300 hover:bg-white/10' : 'text-stone-400 hover:bg-stone-100 hover:text-stone-600'}`}
                     >
                       <X size={16} />
                     </button>


### PR DESCRIPTION
## Summary

- Adds an inline X clear button to the `CollectionScreen` search input — same pattern Home picked up in #290.
- Adds `aria-label` on the input so screen readers don't have to rely on the placeholder.
- Filter (sliders) button placement is unchanged.

Closes [CUR-116](https://linear.app/qiuyue/issue/CUR-116/ux-collection-search-input-has-no-inline-x-clear-button-mirrors-home).

## Why

`HomeScreen` got the inline X clear in [`a66b634` / #290](https://github.com/Akkkkkkki/curio/commit/a66b634). One level deeper — inside any collection — the same field is missing the affordance, so users who learned the pattern on Home have no quick way to reset a long search term. The empty-results state offers a "Clear search" CTA but only after results drop to zero; while results still match partially, the only way back is to backspace the whole string.

## Change

`src/App.tsx` (around L1378 in the `CollectionScreen` toolbar): wrap the input in its own `relative flex-1` div so the X can be absolutely positioned inside the input bounds without overlapping the sliders button beside it. Reuse the same `clearSearch` strings and the same visual treatment Home uses.

```diff
- <div className="relative flex gap-2 flex-1 min-w-[12rem]">
-   <input ... pr-4 ... />
+ <div className="flex gap-2 flex-1 min-w-[12rem]">
+   <div className="relative flex-1">
+     <input ... aria-label={t('collectionSearchPlaceholder')} ... pr-11 ... />
+     {filterInput.length > 0 && (
+       <button onClick={() => setFilterInput('')} aria-label={t('clearSearch')} ...>
+         <X size={16} />
+       </button>
+     )}
+   </div>
    <Button ... filter button unchanged ... />
  </div>
```

## Test plan

- [x] `npm run format:check` ✅
- [x] `npm test` — 731 passed, 2 skipped ✅
- [x] `npm run build` ✅
- [x] `npm run test:e2e` — 36 passed, 10 skipped ✅
- [ ] Manual: open `/#/collection/<any>`, type into the search field, see X appear; tap X to clear; check 44px tap target on mobile.
- [ ] Manual: verify in Gallery, Vault, and Atelier themes.
- [ ] Manual: confirm screen reader announces the input as "Search this collection".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cCGmL4kvxThHBQuE49C5P

---
_Generated by [Claude Code](https://claude.ai/code/session_015cCGmL4kvxThHBQuE49C5P)_