### PR TITLE
[CUR-118] Hold deep-link routes during initial cloud fetch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1652,13 +1652,18 @@ export const AppContent: React.FC = () => {
       ta.style.height = `${ta.scrollHeight}px`;
     }, [item?.title]);
 
-    if (!collection) {
+    if (!collection || !item) {
       // CUR-118: deep-link reload of /collection/:id/item/:itemId must wait
       // for the cloud fetch instead of bouncing to Home / parent collection.
+      // The `!item` half matters too: `refreshCollections()` flips `isLoading`
+      // without clearing existing collection state, so a follow-up refresh
+      // can leave the parent collection cached while the item is still in
+      // the pending cloud response — without this guard, the shared link
+      // would lose the item to the parent route before the fetch resolves.
       if (isLoading) return <ItemDetailSkeleton label={t('restoringArchives')} />;
-      return <Navigate to="/" replace />;
+      if (!collection) return <Navigate to="/" replace />;
+      return <Navigate to={`/collection/${id}`} replace />;
     }
-    if (!item) return <Navigate to={`/collection/${id}`} replace />;
     const isReadOnly = Boolean(collection.isPublic) && !isAdmin;
 
     const snapshotItem = (target: CollectionItem) => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import {
 } from 'lucide-react';
 import { Button } from './components/ui/Button';
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
+import { CollectionScreenSkeleton, ItemDetailSkeleton } from './components/ui/Skeleton';
 import {
   fetchCloudCollections,
   getLocalCollections,
@@ -1239,7 +1240,13 @@ export const AppContent: React.FC = () => {
       }
     };
 
-    if (!collection) return <Navigate to="/" replace />;
+    if (!collection) {
+      // CUR-118: don't bounce a deep-link reload back to Home while the
+      // initial cloud fetch is still in flight. Only redirect once loading
+      // has settled and the id is genuinely absent.
+      if (isLoading) return <CollectionScreenSkeleton label={t('restoringArchives')} />;
+      return <Navigate to="/" replace />;
+    }
 
     return (
       <div className="space-y-10 animate-in slide-in-from-bottom-4 duration-500">
@@ -1645,7 +1652,13 @@ export const AppContent: React.FC = () => {
       ta.style.height = `${ta.scrollHeight}px`;
     }, [item?.title]);
 
-    if (!collection || !item) return <Navigate to={`/collection/${id}`} replace />;
+    if (!collection) {
+      // CUR-118: deep-link reload of /collection/:id/item/:itemId must wait
+      // for the cloud fetch instead of bouncing to Home / parent collection.
+      if (isLoading) return <ItemDetailSkeleton label={t('restoringArchives')} />;
+      return <Navigate to="/" replace />;
+    }
+    if (!item) return <Navigate to={`/collection/${id}`} replace />;
     const isReadOnly = Boolean(collection.isPublic) && !isAdmin;
 
     const snapshotItem = (target: CollectionItem) => ({

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Loader2 } from 'lucide-react';
 
 interface SkeletonProps {
   className?: string;
@@ -52,5 +53,38 @@ export const ItemCardSkeleton: React.FC = () => (
       <Skeleton variant="text" className="w-3/4 h-4" />
       <Skeleton variant="text" className="w-1/2 h-3" />
     </div>
+  </div>
+);
+
+// Deep-link routes (/collection/:id, /collection/:id/item/:itemId) reuse
+// HomeScreen's "Restoring the archives…" affordance while `isLoading` is
+// true, so a hard reload on a shared link no longer bounces back to Home
+// before the cloud fetch resolves (CUR-118). The label is passed in so the
+// component stays i18n-free.
+export const CollectionScreenSkeleton: React.FC<{ label: string }> = ({ label }) => (
+  <div
+    className="space-y-8 sm:space-y-10 animate-in fade-in duration-500"
+    data-testid="collection-screen-skeleton"
+  >
+    <div className="text-center pt-4">
+      <Loader2 className="text-stone-300 animate-spin mx-auto mb-4" size={24} />
+      <p className="text-stone-400 font-serif italic text-sm">{label}</p>
+    </div>
+    <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4 md:gap-5">
+      <ItemCardSkeleton />
+      <ItemCardSkeleton />
+      <ItemCardSkeleton />
+      <ItemCardSkeleton />
+    </div>
+  </div>
+);
+
+export const ItemDetailSkeleton: React.FC<{ label: string }> = ({ label }) => (
+  <div
+    className="flex flex-col items-center justify-center py-16 sm:py-24 animate-in fade-in duration-500"
+    data-testid="item-detail-skeleton"
+  >
+    <Loader2 className="text-stone-300 animate-spin mb-4" size={24} />
+    <p className="text-stone-400 font-serif italic text-sm">{label}</p>
   </div>
 );

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -666,4 +666,94 @@ describe('App Integration Tests', () => {
     expect(await screen.findByTestId('items-grid')).toBeInTheDocument();
     expect(screen.queryByTestId('collections-grid')).not.toBeInTheDocument();
   });
+
+  // CUR-118: a hard reload on a deep link must not bounce back to Home while
+  // the initial cloud fetch is still in flight. The route should hold its URL
+  // and render a loading affordance until data resolves, then render the
+  // target collection / item.
+  it('shows a loading skeleton on /collection/:id while cloud fetch is in flight (CUR-118)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    let resolveCloud: (value: (typeof mockCollection)[]) => void = () => {};
+    vi.mocked(db.getLocalCollections).mockResolvedValue([]);
+    vi.mocked(db.fetchCloudCollections).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCloud = resolve;
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    // While loading, the deep-link route renders its own skeleton — not
+    // HomeScreen's collections-grid. Bouncing back to Home would surface
+    // the grid (or the home loader) instead, so this asserts both halves.
+    expect(await screen.findByTestId('collection-screen-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('collections-grid')).not.toBeInTheDocument();
+
+    // Once the cloud fetch resolves, the actual collection takes over.
+    resolveCloud([mockCollection]);
+    await waitFor(() => {
+      expect(screen.getAllByText('Test Collection')[0]).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('collection-screen-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading skeleton on /collection/:id/item/:itemId while cloud fetch is in flight (CUR-118)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    let resolveCloud: (value: (typeof mockCollection)[]) => void = () => {};
+    vi.mocked(db.getLocalCollections).mockResolvedValue([]);
+    vi.mocked(db.fetchCloudCollections).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCloud = resolve;
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1/item/item1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('item-detail-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('collections-grid')).not.toBeInTheDocument();
+
+    resolveCloud([mockCollection]);
+    // Once data lands, the item detail textarea (Title) replaces the skeleton.
+    expect(await screen.findByRole('textbox', { name: 'Title' })).toBeInTheDocument();
+    expect(screen.queryByTestId('item-detail-skeleton')).not.toBeInTheDocument();
+  });
+
+  it('falls back to Home when /collection/:id is genuinely missing after load (CUR-118)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    vi.mocked(db.getLocalCollections).mockResolvedValue([mockCollection]);
+    vi.mocked(db.fetchCloudCollections).mockResolvedValue([mockCollection]);
+
+    render(
+      <MemoryRouter initialEntries={['/collection/does-not-exist']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    // Once loading completes and the id is still unknown, Navigate fires
+    // and HomeScreen's grid takes over — the loading skeleton disappears.
+    await waitFor(() => {
+      expect(screen.getByTestId('collections-grid')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('collection-screen-skeleton')).not.toBeInTheDocument();
+  });
 });

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -756,4 +756,43 @@ describe('App Integration Tests', () => {
     });
     expect(screen.queryByTestId('collection-screen-skeleton')).not.toBeInTheDocument();
   });
+
+  // CUR-118 follow-up (Codex review on #299): when the parent collection
+  // is already cached but the item is only in the pending cloud response,
+  // the missing-item branch must also wait for `isLoading` to settle —
+  // otherwise a refresh-mid-deep-link drops the user on the parent route.
+  it('holds /collection/:id/item/:itemId on the skeleton when the item is still pending while the collection is cached (CUR-118)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Local cache has the collection but no item; cloud will eventually
+    // deliver the same collection with the item attached.
+    const cachedCollectionWithoutItem = { ...mockCollection, items: [] };
+    let resolveCloud: (value: (typeof mockCollection)[]) => void = () => {};
+    vi.mocked(db.getLocalCollections).mockResolvedValue([cachedCollectionWithoutItem]);
+    vi.mocked(db.fetchCloudCollections).mockReturnValue(
+      new Promise((resolve) => {
+        resolveCloud = resolve;
+      }) as never,
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1/item/item1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    // While `isLoading` is true and only the cached collection (no item) is
+    // visible, the route must stay on the skeleton instead of redirecting
+    // to the parent collection.
+    expect(await screen.findByTestId('item-detail-skeleton')).toBeInTheDocument();
+    expect(screen.queryByTestId('items-grid')).not.toBeInTheDocument();
+
+    // Cloud lands with the item attached — detail renders.
+    resolveCloud([mockCollection]);
+    expect(await screen.findByRole('textbox', { name: 'Title' })).toBeInTheDocument();
+    expect(screen.queryByTestId('item-detail-skeleton')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Problem

Signed-in users hard-reloading a deep link to `/#/collection/:id` or `/#/collection/:id/item/:itemId` were bounced to Home before `refreshCollections()` had a chance to resolve. Both screens called `<Navigate>` the moment `collections.find(...)` returned undefined, regardless of whether the cloud fetch was still in flight (`src/App.tsx:1242`, `src/App.tsx:1648`).

The fail-closed redirect was invisible for signed-out users (the access gate masks the Routes) but real for everyone else — and it silently breaks shared item links, the atomic unit of distribution Phase 1 hangs on (`CUR-6`). Protects **Trust before growth**: users shouldn't lose their place on a refresh.

## Approach

- Gate the existing `Navigate` redirects on `isLoading`. While loading is in flight, render a route-shaped skeleton so the URL stays put.
- Add two minimal skeleton wrappers in `components/ui/Skeleton.tsx`:
  - `CollectionScreenSkeleton` — `Loader2` + "Restoring the archives…" + a 2×2 grid of `ItemCardSkeleton`s, sized to the actual item grid.
  - `ItemDetailSkeleton` — centered spinner + same i18n copy (the issue suggested either skeleton or a spinner is fine for the detail route).
- Both wrappers take their label as a prop, reusing `t('restoringArchives')` from HomeScreen instead of inventing new copy.
- Split `ItemDetailScreen`'s old combined `!collection || !item` guard so a missing collection routes to Home (not via a `/collection/:id` chain redirect that would just bounce again) while a missing item still falls back to the parent collection.

## Why this approach

This is the smallest change that satisfies the acceptance criteria: closure access to `isLoading` already exists in both screens, so no prop drilling, no new routing layer, no state-management churn. The skeleton reuses the existing HomeScreen affordance (typography, copy, spinner color) so the route transitions feel like part of the same loading experience instead of a new pattern.

## Risks

Low. The change is bounded to two early-return branches that only fired when `collections.find(...)` returned undefined. Behaviour after the load settles is unchanged: genuinely missing collections still redirect to Home, missing items still redirect to the parent collection. No data, sync, or auth code touched.

## How to verify

Vercel Preview: https://curio-git-claude-curio-118-deep-lin-6214b2-qs-projects-72b20d9d.vercel.app

Steps (signed in):
1. Open any item via `/#/collection/<id>/item/<itemId>`.
2. Hard-reload (Ctrl/Cmd+Shift+R) so the cloud fetch starts cold.
3. The URL stays put and an italic "Restoring the archives…" loader appears, then the item renders.
4. Repeat for `/#/collection/<id>` — same behaviour.
5. Visit `/#/collection/does-not-exist` while signed in: after load completes, you land on Home (not stuck on the loader).

Checks (this branch):
- [x] `npm run format:check`
- [x] `npm test` — 734 passed, 2 skipped, 1 todo (3 new tests for CUR-118)
- [x] `npm run build`
- [x] `npm run test:e2e` — 36 passed, 10 skipped

Note: no new Playwright test added. The deep-link bug only triggers for signed-in users (the access gate masks it for signed-out), and the existing `authenticated-user.spec.ts` skips without `E2E_EMAIL`/`E2E_PASSWORD`. The three new Vitest integration tests in `tests/integration/AppNavigation.test.tsx` cover the loading skeleton + post-load fallback at the AppContent level, which is where the bug lives.

## Linear

Closes CUR-118

## Rollback plan

`git revert 975e78d` cleanly restores the previous early-return redirects. No schema, RLS, env-var, or migration changes.