### PR TITLE
[CUR-117] Inherit current collection in bottom-nav Add

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2569,9 +2569,20 @@ export const AppContent: React.FC = () => {
       setIsCreateCollectionOpen(true);
       return;
     }
-    setAddModalDefaultCollectionId(undefined);
+    // When the bottom-nav Add is tapped from inside a collection (or one of
+    // its items), inherit that collection so the modal opens on the upload
+    // step instead of forcing a redundant picker pass — same behavior as the
+    // in-screen "Add Item" button. Read-only samples are filtered by
+    // editableCollections.some(...), so a visitor inside a public sample
+    // still gets the picker.
+    const collectionInPath = location.pathname.match(/^\/collection\/([^/]+)/)?.[1];
+    const presetCollectionId =
+      collectionInPath && editableCollections.some((c) => c.id === collectionInPath)
+        ? collectionInPath
+        : undefined;
+    setAddModalDefaultCollectionId(presetCollectionId);
     setIsAddModalOpen(true);
-  }, [editableCollections.length, isAuthenticated]);
+  }, [editableCollections, isAuthenticated, location.pathname]);
 
   const handleCreateCollectionAction = useCallback(() => {
     if (!isAuthenticated) {

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -795,4 +795,131 @@ describe('App Integration Tests', () => {
     expect(await screen.findByRole('textbox', { name: 'Title' })).toBeInTheDocument();
     expect(screen.queryByTestId('item-detail-skeleton')).not.toBeInTheDocument();
   });
+
+  // CUR-117: the bottom-nav Add is the most-touched primary action on mobile.
+  // When the user is already inside a collection (or one of its items), it
+  // must inherit that collection and open the modal on the upload step, the
+  // same as the in-screen "Add Item" button — otherwise the user is forced to
+  // re-pick a collection they just had open.
+  it('bottom-nav Add inherits the current collection from /collection/:id (CUR-117)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Two editable collections are required to prove the fix — with a single
+    // collection, the modal auto-picks it regardless, so the regression
+    // (forcing the picker) would only surface with multiple targets.
+    const secondCollection = {
+      ...mockCollection,
+      id: 'col2',
+      name: 'Second Collection',
+      items: [],
+    };
+    vi.mocked(db.getLocalCollections).mockResolvedValue([mockCollection, secondCollection]);
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Collection')).toBeInTheDocument();
+    });
+
+    const bottomNav = screen.getByRole('navigation', { name: 'Primary' });
+    fireEvent.click(within(bottomNav).getByTestId('bottom-nav-add-pill'));
+
+    // Upload step renders the "Take Photo" CTA; the collection picker would
+    // show the "New Archive" heading instead. Asserting the upload affordance
+    // proves the modal skipped the redundant pick step.
+    expect(await screen.findByRole('button', { name: /take photo/i })).toBeInTheDocument();
+    expect(screen.queryByText('New Archive')).not.toBeInTheDocument();
+  });
+
+  it('bottom-nav Add inherits the current collection from /collection/:id/item/:itemId (CUR-117)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Two editable collections so the modal would otherwise force a picker
+    // pass. The bottom-nav Add must still inherit col1 from the URL.
+    const secondCollection = {
+      ...mockCollection,
+      id: 'col2',
+      name: 'Second Collection',
+      items: [],
+    };
+    vi.mocked(db.getLocalCollections).mockResolvedValue([mockCollection, secondCollection]);
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1/item/item1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('textbox', { name: 'Title' })).toBeInTheDocument();
+
+    const bottomNav = screen.getByRole('navigation', { name: 'Primary' });
+    fireEvent.click(within(bottomNav).getByTestId('bottom-nav-add-pill'));
+
+    expect(await screen.findByRole('button', { name: /take photo/i })).toBeInTheDocument();
+    expect(screen.queryByText('New Archive')).not.toBeInTheDocument();
+  });
+
+  it('bottom-nav Add still shows the picker from inside a read-only sample collection (CUR-117)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Public sample (read-only for non-admin) plus two editable private
+    // collections. The user is browsing the sample, so the modal must NOT
+    // preset the sample (they can't save into it). With more than one
+    // editable target available, the picker must render so the user can
+    // route the new item to their own collection.
+    const publicSample = {
+      id: 'sample-vinyl',
+      name: 'The Vinyl Vault',
+      templateId: 'vinyl',
+      icon: '🎵',
+      customFields: [],
+      items: [],
+      isPublic: true,
+      updatedAt: new Date().toISOString(),
+    };
+    const secondCollection = {
+      ...mockCollection,
+      id: 'col2',
+      name: 'Second Collection',
+      items: [],
+    };
+    vi.mocked(db.getLocalCollections).mockResolvedValue([
+      publicSample,
+      mockCollection,
+      secondCollection,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={['/collection/sample-vinyl']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('The Vinyl Vault')).toBeInTheDocument();
+    });
+
+    const bottomNav = screen.getByRole('navigation', { name: 'Primary' });
+    fireEvent.click(within(bottomNav).getByTestId('bottom-nav-add-pill'));
+
+    // Picker step shows the "New Archive" heading and the user's own
+    // collection cards — proving the modal refused to default to the sample
+    // and instead let the user choose where the item belongs.
+    expect(await screen.findByText('New Archive')).toBeInTheDocument();
+    expect(screen.getByText('Test Collection')).toBeInTheDocument();
+    expect(screen.getByText('Second Collection')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Problem

The mobile bottom-nav **Add** is the most-touched primary write action, but it unconditionally cleared `addModalDefaultCollectionId`. A user already inside `/collection/:id` (or `/collection/:id/item/:itemId`) was forced to re-pick a collection they just had open. The in-screen "Add Item" button on the collection toolbar already presets the collection, so the two entrypoints were behaving inconsistently and breaking the "one clear primary path" first-run guidance for repeat additions on mobile. (Protects the *single-path*, *trust*, and *acceleration* principles from `docs/PRODUCT_STRATEGY.md`.)

## Approach

In `handleAddAction` (`src/App.tsx`), match the current pathname against `^/collection/([^/]+)` and preset the default collection id when it matches, but only when the id is present in `editableCollections`. Read-only public samples are excluded by that filter, so a visitor inside a sample still gets the picker. Home (`/`) and other routes are unchanged.

## Why this approach

This is the smallest possible fix — it lives entirely in the existing callback, reuses the `editableCollections` memo as the read-only safety gate, and matches the behavior of the in-screen Add Item button so there is one mental model. No new state, no new prop drilling, no UI changes.

## Risks

Low. The fix only affects which collection the modal opens with; existing modal logic (auto-skip when there's a single editable collection, picker when multiple, recovery from missing collection) is unchanged. The read-only sample case is covered by `editableCollections.some(...)`, mirroring the existing `recoverMissingCollection` guard inside `AddItemModal`.

## How to verify

Vercel Preview: _will be attached by the preview bot once available._

Steps:
1. Sign in with at least two editable collections.
2. Open `/collection/<A>`. Tap the bottom-nav **Add**. Modal opens on the **upload** step with Collection A preselected.
3. Open `/collection/<A>/item/<X>`. Tap the bottom-nav **Add**. Modal opens on the **upload** step with Collection A preselected.
4. Open `/collection/<sample-vinyl>` (signed-in non-admin). Tap the bottom-nav **Add**. Modal opens on the **picker** step, with the sample excluded from the choices.
5. From `/` (Home) the behavior is unchanged: modal opens on the picker when there are 2+ editable collections, on upload when there is exactly one.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (738 passed, 2 skipped, 1 todo)
- [x] `npm run build`
- [x] `npm run test:e2e` (36 passed, 10 skipped — same baseline as `main`)

## Screenshot / GIF

No visual change — this only redirects which step the modal opens on. Behavior is exercised by the three new Vitest integration tests in `tests/integration/AppNavigation.test.tsx`.

## Linear

Closes CUR-117

## Rollback plan

Green-tier, no migrations. Revert with:

```
git revert 8bd6f2d
```

or revert this PR via the GitHub UI.


---
_Generated by [Claude Code](https://claude.ai/code/session_019wQfUGy8pV8qXNhREsSy5t)_