### PR TITLE
[CUR-119] Make AddItemModal upload zone keyboard-accessible

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -903,21 +903,23 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     <div className="text-center space-y-6 sm:space-y-8 py-2 sm:py-4">
       <div className="flex justify-center">
         <div className="relative">
-          <div
-            className="w-32 h-32 sm:w-40 sm:h-40 rounded-full bg-stone-50 border-2 border-dashed border-stone-200 flex flex-col items-center justify-center text-stone-400 group hover:border-amber-400 hover:bg-amber-50 transition-all cursor-pointer overflow-hidden"
+          <button
+            type="button"
             onClick={pickFromGallery}
+            aria-label={imagePreview ? t('changePhoto') : undefined}
+            className="w-32 h-32 sm:w-40 sm:h-40 rounded-full bg-stone-50 border-2 border-dashed border-stone-200 flex flex-col items-center justify-center text-stone-400 group hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/40 focus-visible:ring-offset-2 transition-all cursor-pointer overflow-hidden"
           >
             {imagePreview ? (
-              <img src={imagePreview} className="w-full h-full object-cover" alt="Preview" />
+              <img src={imagePreview} className="w-full h-full object-cover" alt="" />
             ) : (
               <>
-                <Upload size={28} className="sm:w-8 sm:h-8 mb-2" />
+                <Upload size={28} className="sm:w-8 sm:h-8 mb-2" aria-hidden="true" />
                 <span className="text-[10px] sm:text-xs font-bold uppercase tracking-wider">
                   {t('uploadPhoto')}
                 </span>
               </>
             )}
-          </div>
+          </button>
         </div>
       </div>
       <div>

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@capacitor/camera', () => ({
 
 import { analyzeImage, refreshAiEnabled } from '@/services/geminiService';
 import { trackEvent } from '@/services/analytics';
-import { Camera } from '@capacitor/camera';
+import { Camera, CameraSource } from '@capacitor/camera';
 
 const mockAnalyzeImage = analyzeImage as ReturnType<typeof vi.fn>;
 const mockRefreshAiEnabled = refreshAiEnabled as ReturnType<typeof vi.fn>;
@@ -478,6 +478,42 @@ describe('AddItemModal', () => {
     );
   });
 
+  it('exposes the upload-step circle as a keyboard-activatable button (CUR-119)', async () => {
+    const user = userEvent.setup();
+    mockGetPhoto.mockResolvedValue({ dataUrl: undefined });
+
+    renderWithProviders(
+      <AddItemModal
+        isOpen
+        onClose={mockOnClose}
+        collections={[createMockCollection()]}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await screen.findByRole('heading', { name: 'Upload Photo' });
+
+    // The visual circle and the explicit CTA below both name themselves
+    // "Upload Photo". The circle is the first interactive control on the
+    // step and used to be a div with no role/tabindex/keyboard handler.
+    const uploadButtons = screen.getAllByRole('button', { name: 'Upload Photo' });
+    expect(uploadButtons.length).toBeGreaterThanOrEqual(2);
+
+    const circle = uploadButtons[0];
+    expect(circle.tagName).toBe('BUTTON');
+
+    circle.focus();
+    expect(circle).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(mockGetPhoto).toHaveBeenCalledWith(
+        expect.objectContaining({ source: CameraSource.Photos }),
+      );
+    });
+  });
+
   it('renders the analyzing step with theme-aware copy on Vault (#110)', async () => {
     const user = userEvent.setup();
     setMockTheme('vault');
@@ -710,7 +746,9 @@ describe('AddItemModal', () => {
       );
 
       // Single-image upload routes to the verify step (not batch-verify).
-      await user.click(screen.getByRole('button', { name: /upload photo/i }));
+      // Two controls expose "Upload Photo" — the visual circle (CUR-119) and
+      // the explicit CTA below it. Clicking either calls pickFromGallery.
+      await user.click(screen.getAllByRole('button', { name: /upload photo/i })[0]);
 
       // Wait for analysis to land on the verify step.
       expect(await screen.findByDisplayValue('Mock Artifact')).toBeInTheDocument();


### PR DESCRIPTION
## Problem

The large dashed-circle upload target on the first step of `AddItemModal` was rendered as a `<div>` with `cursor-pointer` and an `onClick` handler — no `role`, no `tabIndex`, no keyboard handler, no accessible name. Sighted mouse users saw a prominent primary CTA; keyboard and screen-reader users could not reach or describe it. Fails WCAG 2.1.1 (Keyboard) and 4.1.2 (Name, Role, Value), and undermines the "one clear primary path" first-run guidance because the visually-loudest control on the screen was inert for assistive tech.

Protects the **trust before growth** principle: every visible affordance should behave the way it looks.

## Approach

- Promote the wrapper `<div>` to a native `<button type="button">`. The existing visible "UPLOAD PHOTO" text serves as the accessible name when no preview is shown.
- When `imagePreview` is set the visible text is replaced by the user's photo, so the button switches to `aria-label={t('changePhoto')}` — matching the textual CTA below.
- Mark the inner `Upload` icon and `<img>` as decorative (`aria-hidden`, `alt=""`) since the wrapper button already names the control.
- Add `focus-visible:ring-amber-500/40 focus-visible:ring-offset-2` — amber works across all three themes (Gallery / Vault / Atelier) without further refactor; deeper theme alignment of the dashed circle's surface is CUR-92's scope.
- Add a focused Vitest regression: the upload circle is a button, receives focus, and triggers the gallery picker on Enter.
- Disambiguate the existing CUR-86 Escape test — there are now two buttons named "Upload Photo", so the test selects the first explicitly.

## Why this approach

Promoting to a real button is the smallest change that satisfies the keyboard + screen-reader acceptance criteria without touching the visual treatment or breaking the "single clear primary path" — the buttons stay where they are, the circle just becomes properly interactive. Theme-aware contrast across the wider modal stays parked in CUR-92.

## Risks

Low. No behavior change for mouse users; the `onClick` still calls `pickFromGallery`. The new tab stop is adjacent to an equivalent textual button — two affordances with the same accessible name doing the same thing, which is acceptable and consistent with how the textual `<Button>` below already names itself. Layout is preserved because all sizing classes carry over.

## How to verify

Vercel Preview: https://curio-git-claude-curio-119-additem-c472d8-qs-projects-72b20d9d.vercel.app

Steps:
1. Open Add Item from anywhere on the home screen.
2. Press Tab — focus should land on the upload circle and show an amber focus ring in all three themes.
3. Press Enter or Space — the file picker opens.
4. With VoiceOver / NVDA active, the circle is announced as "Upload Photo, button" (or "Change Photo, button" once a photo is selected).
5. Confirm the textual buttons below still work for mouse and keyboard users.

Checks:
- [x] npm run format:check
- [x] npm test (51 files / 739 tests / 2 skipped / 1 todo)
- [x] npm run build
- [x] npm run test:e2e (36 passed / 10 skipped)

## Linear

Closes CUR-119

## Rollback plan

Green-tier change; not required. Revert with `git revert 3047c82` if needed.
