### PR TITLE
[CUR-17] Preserve offline delete tombstones

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -840,12 +840,13 @@ const normalizePendingDeletes = (pending: unknown): PendingDelete[] => {
 };
 
 const readPendingDeleteJournal = (): PendingDelete[] | null => {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+  const localStorage = getLocalStorage();
+  if (!localStorage) {
     return null;
   }
 
   try {
-    const stored = window.localStorage.getItem(PENDING_DELETE_JOURNAL_KEY);
+    const stored = localStorage.getItem(PENDING_DELETE_JOURNAL_KEY);
     if (stored === null) return null;
     return normalizePendingDeletes(JSON.parse(stored));
   } catch {
@@ -854,14 +855,27 @@ const readPendingDeleteJournal = (): PendingDelete[] | null => {
 };
 
 const writePendingDeleteJournal = (pending: PendingDelete[]): void => {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+  const localStorage = getLocalStorage();
+  if (!localStorage) {
     return;
   }
 
   try {
-    window.localStorage.setItem(PENDING_DELETE_JOURNAL_KEY, JSON.stringify(pending));
+    localStorage.setItem(PENDING_DELETE_JOURNAL_KEY, JSON.stringify(pending));
   } catch {
     // IndexedDB remains the fallback when localStorage is unavailable.
+  }
+};
+
+const getLocalStorage = (): Storage | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
   }
 };
 

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -18,6 +18,7 @@ type ItemImageStatus = 'none' | 'processing' | 'ready' | 'failed';
 const PENDING_SYNC_KEY = 'pending_sync_ids';
 const PENDING_ASSET_UPLOADS_KEY = 'pending_asset_uploads';
 const PENDING_DELETE_KEY = 'pending_deletes';
+const PENDING_DELETE_JOURNAL_KEY = 'curio_pending_delete_journal';
 
 const SYNC_RETRY_BACKOFF_BASE_MS = 30_000;
 const SYNC_RETRY_BACKOFF_MAX_MS = 10 * 60_000;
@@ -255,17 +256,22 @@ export const mergeCollections = (
     .filter((cloudCol) => !pendingCollectionDeletes.has(cloudCol.id))
     .map((cloudCol) => {
       const localCol = localMap.get(cloudCol.id);
+      const collectionPendingDeletes = pendingDeletes.filter(
+        (d) => d.type === 'item' && d.collectionId === cloudCol.id,
+      );
       if (!localCol) {
-        return normalizeCollection(cloudCol);
+        return {
+          ...normalizeCollection(cloudCol),
+          items: mergeItems([], cloudCol.items, {
+            preserveLocalOnly: false,
+            pendingDeletes: collectionPendingDeletes,
+          }),
+        };
       }
       const localStamp = localCol.updatedAt;
       const cloudStamp = cloudCol.updatedAt;
       const useLocal = compareTimestamps(localStamp, cloudStamp) > 0;
       const base = useLocal ? localCol : cloudCol;
-      // Filter pending deletes to only those for this collection
-      const collectionPendingDeletes = pendingDeletes.filter(
-        (d) => d.type === 'item' && d.collectionId === cloudCol.id,
-      );
       const mergedItems = mergeItems(localCol.items, cloudCol.items, {
         preserveLocalOnly: includeLocalOnly(localCol),
         pendingDeletes: collectionPendingDeletes,
@@ -790,27 +796,106 @@ export const syncPendingAssetUploads = async (): Promise<number> => {
 // P0 Fix: Pending Delete Queue (prevents deleted items from resurrecting)
 // ============================================================================
 
-const normalizePendingDeletes = (pending: (PendingDelete | LegacyPendingDelete)[]) =>
-  pending.map((entry) => {
-    if ('type' in entry) {
-      return entry;
-    }
-    return {
-      type: 'item',
-      collectionId: entry.collectionId,
-      itemId: entry.itemId,
-      createdAt: entry.createdAt,
-    } as PendingDelete;
+const normalizePendingDeletes = (pending: unknown): PendingDelete[] => {
+  if (!Array.isArray(pending)) return [];
+
+  const seen = new Set<string>();
+  return pending
+    .map((candidate): PendingDelete | null => {
+      if (!candidate || typeof candidate !== 'object') return null;
+      const entry = candidate as Partial<PendingDelete & LegacyPendingDelete>;
+      if (typeof entry.collectionId !== 'string' || typeof entry.createdAt !== 'string') {
+        return null;
+      }
+
+      if (entry.type === 'collection') {
+        return {
+          type: 'collection',
+          collectionId: entry.collectionId,
+          createdAt: entry.createdAt,
+        };
+      }
+
+      if ((entry.type === 'item' || !('type' in entry)) && typeof entry.itemId === 'string') {
+        return {
+          type: 'item',
+          collectionId: entry.collectionId,
+          itemId: entry.itemId,
+          createdAt: entry.createdAt,
+        };
+      }
+
+      return null;
+    })
+    .filter((entry): entry is PendingDelete => {
+      if (!entry) return false;
+      const key =
+        entry.type === 'collection'
+          ? `collection:${entry.collectionId}`
+          : `item:${entry.collectionId}:${entry.itemId}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+};
+
+const readPendingDeleteJournal = (): PendingDelete[] | null => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return null;
+  }
+
+  try {
+    const stored = window.localStorage.getItem(PENDING_DELETE_JOURNAL_KEY);
+    if (stored === null) return null;
+    return normalizePendingDeletes(JSON.parse(stored));
+  } catch {
+    return null;
+  }
+};
+
+const writePendingDeleteJournal = (pending: PendingDelete[]): void => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(PENDING_DELETE_JOURNAL_KEY, JSON.stringify(pending));
+  } catch {
+    // IndexedDB remains the fallback when localStorage is unavailable.
+  }
+};
+
+const readPendingDeletesFromIndexedDb = async (db: IDBDatabase): Promise<PendingDelete[]> =>
+  new Promise((resolve) => {
+    const tx = db.transaction(SETTINGS_STORE, 'readonly');
+    const req = tx.objectStore(SETTINGS_STORE).get(PENDING_DELETE_KEY);
+    req.onsuccess = () => resolve(normalizePendingDeletes(req.result));
+    req.onerror = () => resolve([]);
+  });
+
+const writePendingDeletesToIndexedDb = async (
+  db: IDBDatabase,
+  pending: PendingDelete[],
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction(SETTINGS_STORE, 'readwrite');
+    tx.objectStore(SETTINGS_STORE).put(pending, PENDING_DELETE_KEY);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
   });
 
 export const getPendingDeletes = async (): Promise<PendingDelete[]> => {
   const db = await initDB();
-  return new Promise((resolve) => {
-    const tx = db.transaction(SETTINGS_STORE, 'readonly');
-    const req = tx.objectStore(SETTINGS_STORE).get(PENDING_DELETE_KEY);
-    req.onsuccess = () => resolve(normalizePendingDeletes((req.result as PendingDelete[]) || []));
-    req.onerror = () => resolve([]);
-  });
+  const journal = readPendingDeleteJournal();
+  if (journal !== null) {
+    await writePendingDeletesToIndexedDb(db, journal);
+    return journal;
+  }
+
+  const pending = await readPendingDeletesFromIndexedDb(db);
+  writePendingDeleteJournal(pending);
+  return pending;
 };
 
 export const addToPendingDeletes = async (entry: PendingDelete): Promise<void> => {
@@ -832,9 +917,12 @@ export const addToPendingDeletes = async (entry: PendingDelete): Promise<void> =
       return;
     }
   }
-  pending.push({ ...entry, createdAt: entry.createdAt ?? new Date().toISOString() });
-  const tx = db.transaction(SETTINGS_STORE, 'readwrite');
-  tx.objectStore(SETTINGS_STORE).put(pending, PENDING_DELETE_KEY);
+  const updated = [
+    ...pending,
+    { ...entry, createdAt: entry.createdAt ?? new Date().toISOString() },
+  ];
+  writePendingDeleteJournal(updated);
+  await writePendingDeletesToIndexedDb(db, updated);
 };
 
 export const removeFromPendingDeletes = async (
@@ -852,8 +940,8 @@ export const removeFromPendingDeletes = async (
     }
     return !(d.collectionId === collectionId && d.itemId === itemId);
   });
-  const tx = db.transaction(SETTINGS_STORE, 'readwrite');
-  tx.objectStore(SETTINGS_STORE).put(filtered, PENDING_DELETE_KEY);
+  await writePendingDeletesToIndexedDb(db, filtered);
+  writePendingDeleteJournal(filtered);
 };
 
 export const syncPendingDeletes = async (): Promise<number> => {

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -504,6 +504,42 @@ describe('deleteCollection', () => {
     expect(merged[0]?.items).toEqual([]);
   });
 
+  it('falls back to IndexedDB when browser storage access is blocked', async () => {
+    const { supabase } = createDeleteSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const blockedLocalStorage = vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+      throw new DOMException('Blocked', 'SecurityError');
+    });
+
+    try {
+      await dbMod.addToPendingDeletes({
+        type: 'item',
+        collectionId: 'col-blocked-storage',
+        itemId: 'item-blocked-storage',
+        createdAt: '2026-06-23T00:00:00.000Z',
+      });
+
+      await expect(dbMod.getPendingDeletes()).resolves.toEqual([
+        {
+          type: 'item',
+          collectionId: 'col-blocked-storage',
+          itemId: 'item-blocked-storage',
+          createdAt: '2026-06-23T00:00:00.000Z',
+        },
+      ]);
+
+      await dbMod.removeFromPendingDeletes('col-blocked-storage', 'item-blocked-storage');
+      await expect(dbMod.getPendingDeletes()).resolves.toEqual([]);
+    } finally {
+      blockedLocalStorage.mockRestore();
+    }
+  });
+
   it('keeps the durable delete journal until a retry confirms the cloud delete', async () => {
     const deleteResults = [{ error: new Error('offline') }, { error: null }];
     const deleteQuery: any = {};

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -22,6 +22,7 @@ let openDb: IDBDatabase | null = null;
  */
 const BASE_DB_NAME = 'CurioDatabase';
 const TEST_DB_NAME = `${BASE_DB_NAME}__vitest_${Math.random().toString(16).slice(2)}`;
+const PENDING_DELETE_JOURNAL_KEY = 'curio_pending_delete_journal';
 const originalOpen = indexedDB.open.bind(indexedDB);
 const originalDeleteDatabase = indexedDB.deleteDatabase.bind(indexedDB);
 
@@ -131,6 +132,7 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
       openDb.close();
       openDb = null;
     }
+    window.localStorage.removeItem(PENDING_DELETE_JOURNAL_KEY);
   });
 
   afterEach(() => {
@@ -138,6 +140,7 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
       openDb.close();
       openDb = null;
     }
+    window.localStorage.removeItem(PENDING_DELETE_JOURNAL_KEY);
     vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
@@ -388,6 +391,7 @@ describe('deleteCollection', () => {
       openDb.close();
       openDb = null;
     }
+    window.localStorage.removeItem(PENDING_DELETE_JOURNAL_KEY);
   });
 
   afterEach(() => {
@@ -395,6 +399,7 @@ describe('deleteCollection', () => {
       openDb.close();
       openDb = null;
     }
+    window.localStorage.removeItem(PENDING_DELETE_JOURNAL_KEY);
     vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
@@ -447,6 +452,95 @@ describe('deleteCollection', () => {
       eqMock,
     };
   }
+
+  it('pending item delete survives IndexedDB maintenance and still filters the cloud item', async () => {
+    const { supabase } = createDeleteSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    await dbMod.addToPendingDeletes({
+      type: 'item',
+      collectionId: 'col-offline',
+      itemId: 'item-offline',
+      createdAt: '2026-06-22T00:00:00.000Z',
+    });
+
+    await clearStores(db, ['settings']);
+
+    const pendingDeletes = await dbMod.getPendingDeletes();
+    expect(pendingDeletes).toEqual([
+      {
+        type: 'item',
+        collectionId: 'col-offline',
+        itemId: 'item-offline',
+        createdAt: '2026-06-22T00:00:00.000Z',
+      },
+    ]);
+
+    const cloudCollection: UserCollection = {
+      id: 'col-offline',
+      templateId: 'vinyl',
+      name: 'Cloud collection',
+      icon: '☁️',
+      customFields: [],
+      items: [
+        {
+          id: 'item-offline',
+          collectionId: 'col-offline',
+          photoUrl: 'cloud.jpg',
+          title: 'Deleted offline',
+          rating: 3,
+          data: {},
+          createdAt: '2026-06-21T00:00:00.000Z',
+          notes: '',
+        },
+      ],
+    };
+
+    const merged = dbMod.mergeCollections([], [cloudCollection], { pendingDeletes });
+    expect(merged[0]?.items).toEqual([]);
+  });
+
+  it('keeps the durable delete journal until a retry confirms the cloud delete', async () => {
+    const deleteResults = [{ error: new Error('offline') }, { error: null }];
+    const deleteQuery: any = {};
+    deleteQuery.eq = vi.fn().mockReturnValue(deleteQuery);
+    deleteQuery.then = (resolve: (value: { error: Error | null }) => unknown) =>
+      resolve(deleteResults.shift() ?? { error: null });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'test-user-id' } }, error: null }),
+      },
+      from: vi.fn(() => ({
+        delete: vi.fn(() => deleteQuery),
+      })),
+      storage: {
+        from: vi.fn(() => ({
+          upload: vi.fn().mockResolvedValue({ data: {}, error: null }),
+        })),
+      },
+    };
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    await dbMod.deleteCloudItem('col-retry', 'item-retry');
+
+    expect(await dbMod.getPendingDeletes()).toHaveLength(1);
+    expect(
+      JSON.parse(window.localStorage.getItem(PENDING_DELETE_JOURNAL_KEY) || '[]'),
+    ).toHaveLength(1);
+
+    await expect(dbMod.syncPendingDeletes()).resolves.toBe(1);
+    expect(await dbMod.getPendingDeletes()).toEqual([]);
+    expect(JSON.parse(window.localStorage.getItem(PENDING_DELETE_JOURNAL_KEY) || '[]')).toEqual([]);
+  });
 
   it('deleteCollection: removes collection from IndexedDB', async () => {
     const { supabase } = createDeleteSupabaseMock();


### PR DESCRIPTION
## Summary
- Add a durable localStorage-backed pending-delete journal mirrored into IndexedDB.
- Migrate and normalize legacy pending-delete entries while deduping invalid/stale records.
- Apply pending item tombstones even when IndexedDB recovery removes the whole local collection, so cloud refreshes cannot resurrect offline-deleted items.
- Add regressions for IndexedDB maintenance recovery and failed-then-successful cloud delete retry.

Fixes CUR-17.

## Verification
- `npm run format`
- `npm run format:check`
- `npx vitest run tests/services/db.operations.test.ts tests/services/db.merge.test.ts tests/services/db.loadCollections.test.ts tests/hooks/useCollections.test.ts tests/integration/AppNavigation.test.tsx` — 58 passed, 1 todo
- `npm run build` — passed
- `npm test` — 51 files passed; 733 passed, 2 skipped, 1 todo
- `npm run test:e2e` — 36 passed, 10 skipped

## Notes
- Initial sandboxed `npm test` and `npm run test:e2e` hit local socket binding restrictions (`listen EPERM`). Both were rerun elevated. Playwright Chromium was installed with `npx playwright install chromium` before the successful e2e run.