### PR TITLE
[CUR-109] Theme-aware stacked ThemePicker

### DIFF
--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Paintbrush, Check } from 'lucide-react';
 import { AppTheme } from '../types';
-import { useTheme } from '../theme';
+import { mutedTextClasses, useTheme } from '../theme';
 import { useTranslation, type TranslationKey } from '../i18n';
 
 const optionMeta: Record<AppTheme, { labelKey: TranslationKey; swatch: string[] }> = {
@@ -33,10 +33,16 @@ export const ThemePicker: React.FC<ThemePickerProps> = ({ layout = 'inline' }) =
     theme === 'vault'
       ? 'bg-white/10 text-white border border-white/20'
       : 'bg-white shadow-sm ring-1 ring-amber-200 text-stone-900';
-  const stackedSurface =
-    theme === 'vault'
-      ? 'border-white/10 bg-white/5 text-white'
-      : 'border-stone-200 bg-white text-stone-600';
+  const stackedSurfaceByTheme: Record<AppTheme, string> = {
+    gallery: 'border-stone-200 bg-white text-stone-600',
+    vault: 'border-white/10 bg-white/5 text-white',
+    atelier: 'border-[#D4C9B8] bg-[#F5EFE4] text-[#3D3530]',
+  };
+  const stackedActiveByTheme: Record<AppTheme, string> = {
+    gallery: 'border-amber-200 bg-amber-50 text-stone-900 shadow-sm',
+    vault: 'border-white/20 bg-white/10 text-white shadow-sm',
+    atelier: 'border-[#A86F3C]/40 bg-[#EDE4D3] text-[#3D3530] shadow-sm',
+  };
 
   if (isStacked) {
     return (
@@ -46,15 +52,13 @@ export const ThemePicker: React.FC<ThemePickerProps> = ({ layout = 'inline' }) =
             key={opt}
             onClick={() => setTheme(opt)}
             className={`flex items-center justify-between w-full px-3 py-2 rounded-lg border transition-all text-sm font-semibold ${
-              theme === opt
-                ? 'border-amber-200 bg-amber-50 text-stone-900 shadow-sm'
-                : stackedSurface
+              theme === opt ? stackedActiveByTheme[theme] : stackedSurfaceByTheme[theme]
             }`}
             aria-label={t(optionMeta[opt].labelKey)}
             title={t(optionMeta[opt].labelKey)}
           >
             <span className="flex items-center gap-2">
-              <Paintbrush size={14} className="text-stone-300" />
+              <Paintbrush size={14} className={mutedTextClasses[theme]} />
               <span>{t(optionMeta[opt].labelKey)}</span>
               {theme === opt && <Check size={14} />}
             </span>

--- a/tests/components/ThemePicker.test.tsx
+++ b/tests/components/ThemePicker.test.tsx
@@ -54,4 +54,38 @@ describe('ThemePicker', () => {
     const galleryButton = screen.getByRole('button', { name: /gallery/i });
     expect(galleryButton.querySelector('svg.lucide-check')).not.toBeInTheDocument();
   });
+
+  describe('stacked layout', () => {
+    // CUR-109: the stacked variant (used in the profile menu) must not
+    // hardcode Gallery's amber-50 active row on Vault/Atelier, and the
+    // paintbrush icon must stay legible on every theme.
+    it('uses Vault-toned active row when Vault is the current theme', () => {
+      setMockTheme('vault');
+      renderWithProviders(<ThemePicker layout="stacked" />);
+
+      const vaultButton = screen.getByRole('button', { name: /vault/i });
+      expect(vaultButton.className).toMatch(/bg-white\/10/);
+      expect(vaultButton.className).not.toMatch(/bg-amber-50/);
+    });
+
+    it('uses Atelier-toned active row when Atelier is the current theme', () => {
+      setMockTheme('atelier');
+      renderWithProviders(<ThemePicker layout="stacked" />);
+
+      const atelierButton = screen.getByRole('button', { name: /atelier/i });
+      expect(atelierButton.className).toContain('bg-[#EDE4D3]');
+      expect(atelierButton.className).not.toMatch(/bg-amber-50/);
+    });
+
+    it('keeps the paintbrush icon legible (no hardcoded text-stone-300 on light themes)', () => {
+      setMockTheme('gallery');
+      const { container } = renderWithProviders(<ThemePicker layout="stacked" />);
+
+      const icons = container.querySelectorAll('svg.lucide-paintbrush');
+      expect(icons.length).toBeGreaterThan(0);
+      icons.forEach((icon) => {
+        expect(icon.getAttribute('class') || '').not.toMatch(/text-stone-300/);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The stacked `ThemePicker` lives in the profile menu — it is the one control whose job is to demonstrate Curio's three themes. On Vault and Atelier it betrayed that promise:

- The active option was hardcoded to Gallery's amber-50 light tokens (`border-amber-200 bg-amber-50 text-stone-900 shadow-sm`). On Vault the selected row glowed as a bright light-amber chip against the dark sheet; on Atelier it clashed with the cream surface.
- The paintbrush icon was hardcoded to `text-stone-300`, which is essentially invisible on the white/amber-50 rows in Gallery and Atelier (well below 3:1 contrast).

This protects the "beauty before bureaucracy" product principle — the control demonstrating each theme should itself be theme-correct.

## Approach

In `src/components/ThemePicker.tsx`:

- Replaced the two-branch `stackedSurface` ternary and the inline hardcoded active state with per-theme `Record<AppTheme, string>` maps (`stackedSurfaceByTheme`, `stackedActiveByTheme`), matching the pattern already used by `cardSurfaceClasses`/`softSurfaceClasses` in `theme.tsx`.
  - Gallery active stays as-is.
  - Vault active uses `bg-white/10 border-white/20 text-white shadow-sm`, mirroring the inline variant's Vault active.
  - Atelier active uses warm tokens from `DESIGN.md` (`bg-[#EDE4D3]`, `border-[#A86F3C]/40`, `text-[#3D3530]`).
  - Atelier inactive gets a warm cream/sepia row to match its surface.
- Swapped the paintbrush's `text-stone-300` for `mutedTextClasses[theme]` so it inherits the theme-correct muted tone on every row.

In `tests/components/ThemePicker.test.tsx`:

- Added three regression tests under a `stacked layout` describe block locking in the Vault active tint, the Atelier active tint, and the absence of `text-stone-300` on the paintbrush.

## Why this approach

Smallest change that satisfies the acceptance criteria and matches the existing theme-map pattern from `theme.tsx`. No new shared helper because the two maps are only used in one component. The paintbrush continues to share a single class string across rows (kept the code simple) while leaning on the existing `mutedTextClasses` for legibility.

## Risks

Low. Visual-only change in one component, behind existing usage. Tests cover the per-theme active state and paintbrush color. No behavior, data, sync, or AI paths touched.

## How to verify

Vercel Preview: _attached by automation after this PR opens._

Steps:
1. Sign in (or use the access gate) and open the profile menu.
2. Switch between Gallery → Vault → Atelier via the stacked picker.
3. Confirm: each active row matches its theme palette (no amber-50 row on Vault/Atelier), and the small paintbrush icon next to each option label is visible on every row in every theme.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (778 passed)
- [x] `npm run build`
- [x] `npm run test:e2e` (36 passed, 10 pre-existing skips)

## Screenshot / GIF

Not attached — change is theme-token only and is covered by the new unit tests; the Vercel preview will reflect the live result. Happy to add screenshots if helpful.

## Linear

Closes CUR-109

## Rollback plan

Green-tier; revert this commit (`git revert 41370d7`) to restore the previous hardcoded active row and icon class.


---
_Generated by [Claude Code](https://claude.ai/code/session_013RNMwqwPUEmfPEkZySQJE1)_