### PR TITLE
[CUR-132] ExhibitionView dot pagination: add aria-label + aria-current

### DIFF
--- a/src/components/ExhibitionView.tsx
+++ b/src/components/ExhibitionView.tsx
@@ -174,6 +174,8 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
             <button
               key={i}
               onClick={() => setIndex(i)}
+              aria-label={t('exhibitionJumpTo', { n: i + 1 })}
+              aria-current={i === index ? 'true' : undefined}
               className={`h-1 rounded-full transition-all ${
                 i === index ? 'w-6 bg-amber-500' : 'w-1.5 bg-white/20 hover:bg-white/30'
               }`}
@@ -289,6 +291,8 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
               <button
                 key={i}
                 onClick={() => setIndex(i)}
+                aria-label={t('exhibitionJumpTo', { n: i + 1 })}
+                aria-current={i === index ? 'true' : undefined}
                 className={`h-1.5 rounded-full transition-all ${
                   i === index ? 'w-10 bg-amber-500' : 'w-3 bg-white/20 hover:bg-white/30'
                 }`}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -49,6 +49,7 @@ export const translations = {
     profile: 'Profile',
     add: 'Add',
     exhibitNo: 'Exhibit No. {n} of {total}',
+    exhibitionJumpTo: 'Jump to exhibit {n}',
     updatePhoto: 'Update photo',
     exportCard: 'Export Card',
     archiveNarrative: 'Story', // alias kept for one release; storyLabel is canonical
@@ -536,6 +537,7 @@ export const translations = {
     profile: '个人中心',
     add: '添加',
     exhibitNo: '展品 第 {n} 件 / 共 {total} 件',
+    exhibitionJumpTo: '跳转到第 {n} 件展品',
     updatePhoto: '更新照片',
     exportCard: '导出馆藏卡片',
     archiveNarrative: '故事', // alias kept for one release; story is canonical


### PR DESCRIPTION
Partial fix for CUR-132. Code-assisted UX review (Mode B — live host `curio.qiuyue.dev` returned HTTP 403 to WebFetch this run, so no browser session).

## Summary

The pagination dot buttons in `src/components/ExhibitionView.tsx` (both the mobile under-image pill row and the desktop footer) render as unlabeled `<button>` elements. A screen reader announces just "button" for each one, and the current-exhibit state lives only in colour and width.

This PR adds:

- `aria-label={t('exhibitionJumpTo', { n: i + 1 })}` to each dot.
- `aria-current={i === index ? 'true' : undefined}` to expose current-page state.
- New i18n key `exhibitionJumpTo` (EN: `"Jump to exhibit {n}"`, ZH: `"跳转到第 {n} 件展品"`).

The sliding-window fix for collections with >10 items (where the active dot silently disappears past index 9) is **not** in this PR — that's a behaviour change. It's left to the linked issue.

## Why this is a safe small PR

- Pure attribute additions on existing buttons. No behaviour change.
- No changes to navigation, styling, or click handlers.
- All existing unit (52 files, 778 passed) and E2E tests pass locally.

## Linked

- Linear: CUR-132 (under the CUR-121 UX review epic)

## Test plan

- [x] `npm run format:check` passes
- [x] `npm test` passes (778 passed / 2 skipped / 1 todo)
- [x] `npm run build` passes
- [x] `npm run test:e2e` passes
- [ ] **Browser confirmation appreciated**: open Enter Exhibition with VoiceOver/NVDA, focus a dot, confirm "Jump to exhibit N, current item" announces for the active dot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NXJCxnLYBHWAv5EZRRiyMc)_