### PR TITLE
[CUR-131] ExhibitionView dialog semantics + focus trap

### DIFF
--- a/src/components/ExhibitionView.tsx
+++ b/src/components/ExhibitionView.tsx
@@ -4,6 +4,7 @@ import { X, ChevronLeft, ChevronRight, Star } from 'lucide-react';
 import { UserCollection } from '../types';
 import { ItemImage } from './ItemImage';
 import { useTranslation, getFieldTranslation } from '../i18n';
+import { useModalA11y } from '../hooks/useModalA11y';
 
 interface ExhibitionViewProps {
   collection: UserCollection;
@@ -22,6 +23,7 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
   const [index, setIndex] = useState(initialIndex);
   const [showInfo, setShowInfo] = useState(true);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
   const getFieldLabel = (fieldId: string, fallback: string) =>
     getFieldTranslation(t, fieldId, fallback);
 
@@ -34,17 +36,18 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
     [collection.items.length],
   );
 
-  // Keyboard navigation
+  // Esc-to-close, focus trap and focus restore live in the shared modal a11y
+  // primitive; only arrow-key navigation is bespoke to the exhibition view.
+  useModalA11y(dialogRef, isOpen, onClose);
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowRight') next();
       else if (e.key === 'ArrowLeft') prev();
-      else if (e.key === 'Escape') onClose();
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [isOpen, next, prev, onClose]);
+  }, [isOpen, next, prev]);
 
   if (!isOpen || collection.items.length === 0) return null;
 
@@ -66,8 +69,14 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
     touchStartRef.current = null;
   };
 
+  const dialogLabel = `${collection.name} — ${t('exhibitNo', { n: index + 1, total: collection.items.length })}`;
+
   const content = (
     <div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={dialogLabel}
       className="fixed inset-0 z-[9999] bg-stone-950 text-white animate-in fade-in duration-500 flex flex-col pt-[env(safe-area-inset-top,0px)] pb-[env(safe-area-inset-bottom,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]"
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -43,17 +43,6 @@ export function useModalA11y(
   useEffect(() => {
     if (!isOpen) return;
 
-    const focusTarget = initialFocusRef?.current;
-    const dialog = dialogRef.current;
-    const frameId = requestAnimationFrame(() => {
-      if (focusTarget) {
-        focusTarget.focus();
-        return;
-      }
-      const firstFocusable = dialog?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-      firstFocusable?.focus();
-    });
-
     const getFocusable = () => {
       const el = dialogRef.current;
       if (!el) return [] as HTMLElement[];
@@ -61,6 +50,19 @@ export function useModalA11y(
         (n) => n.offsetParent !== null,
       );
     };
+
+    const focusTarget = initialFocusRef?.current;
+    const frameId = requestAnimationFrame(() => {
+      if (focusTarget) {
+        focusTarget.focus();
+        return;
+      }
+      // ExhibitionView renders mobile + desktop layouts side-by-side and hides
+      // one with `display: none`; the unfiltered DOM-first focusable can be in
+      // the hidden subtree, where `focus()` is a no-op. Pick from the same
+      // visible set the focus trap uses.
+      getFocusable()[0]?.focus();
+    });
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/tests/components/ExhibitionView.test.tsx
+++ b/tests/components/ExhibitionView.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders, setMockTheme } from '../utils/test-utils';
+import { ExhibitionView } from '@/components/ExhibitionView';
+import { UserCollection } from '@/types';
+
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+vi.mock('@/components/ItemImage', () => ({
+  ItemImage: ({ alt }: { alt: string }) => (
+    <div data-testid="mock-item-image" aria-label={alt}>
+      Mock Image
+    </div>
+  ),
+}));
+
+const collection: UserCollection = {
+  id: 'col-1',
+  templateId: 'vinyl',
+  name: 'Vinyl Vault',
+  customFields: [],
+  items: [
+    {
+      id: 'item-1',
+      collectionId: 'col-1',
+      photoUrl: 'asset',
+      title: 'Blue Train',
+      rating: 5,
+      data: {},
+      notes: '',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    },
+    {
+      id: 'item-2',
+      collectionId: 'col-1',
+      photoUrl: 'asset',
+      title: 'Kind of Blue',
+      rating: 4,
+      data: {},
+      notes: '',
+      createdAt: '2026-01-02T00:00:00.000Z',
+    },
+  ],
+};
+
+describe('ExhibitionView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockTheme('gallery');
+    document.body.innerHTML = '';
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(
+      <ExhibitionView collection={collection} isOpen={false} onClose={vi.fn()} />,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  describe('accessibility (CUR-131)', () => {
+    it('renders as a labelled modal dialog', () => {
+      renderWithProviders(
+        <ExhibitionView collection={collection} isOpen={true} onClose={vi.fn()} />,
+      );
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      // Accessible name should carry both the collection identity and the
+      // current exhibit position so screen readers announce useful context.
+      expect(dialog).toHaveAccessibleName(/Vinyl Vault/);
+      expect(dialog).toHaveAccessibleName(/1.*2/);
+    });
+
+    it('closes on Escape via the shared modal primitive', async () => {
+      const onClose = vi.fn();
+      renderWithProviders(
+        <ExhibitionView collection={collection} isOpen={true} onClose={onClose} />,
+      );
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('keeps ArrowRight / ArrowLeft navigation working alongside Esc', async () => {
+      const onClose = vi.fn();
+      renderWithProviders(
+        <ExhibitionView collection={collection} isOpen={true} onClose={onClose} />,
+      );
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAccessibleName(/1.*2/);
+
+      fireEvent.keyDown(window, { key: 'ArrowRight' });
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toHaveAccessibleName(/2.*2/);
+      });
+      // Navigation must not trigger the close handler.
+      expect(onClose).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(window, { key: 'ArrowLeft' });
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*2/);
+      });
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/hooks/useModalA11y.test.tsx
+++ b/tests/hooks/useModalA11y.test.tsx
@@ -66,6 +66,33 @@ describe('useModalA11y', () => {
     expect(document.activeElement).toBe(screen.getByTestId('first'));
   });
 
+  it('skips DOM-first focusables hidden by layout (e.g. ExhibitionView responsive layouts)', async () => {
+    // Regression for Codex P2 on PR #313: ExhibitionView renders mobile + desktop
+    // layouts in DOM order and toggles one with Tailwind's `sm:hidden`. In a real
+    // browser the hidden subtree's `offsetParent` is null and `focus()` is a no-op;
+    // initial focus must skip it and land on the visible layout's control instead.
+    function ResponsiveHarness() {
+      const dialogRef = useRef<HTMLDivElement>(null);
+      useModalA11y(dialogRef, true, () => {});
+      return (
+        <div ref={dialogRef} role="dialog" aria-modal="true">
+          <button data-testid="hidden">hidden close</button>
+          <button data-testid="visible">visible close</button>
+        </div>
+      );
+    }
+    const { unmount } = render(<ResponsiveHarness />);
+    // jsdom does not run layout, so simulate the browser's display:none result:
+    // hidden descendants report `offsetParent === null`.
+    const hidden = screen.getByTestId('hidden');
+    Object.defineProperty(hidden, 'offsetParent', { configurable: true, get: () => null });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(document.activeElement).toBe(screen.getByTestId('visible'));
+    unmount();
+  });
+
   it('focuses initialFocusRef when provided (safe action on confirm modals)', async () => {
     const onClose = vi.fn();
     render(<Harness isOpen={true} onClose={onClose} useInitialFocus />);


### PR DESCRIPTION
## Problem

`ExhibitionView` is the museum's flagship "exhibit it like a museum" surface, but it ships none of the modal accessibility primitives the rest of the app already standardised on. The outer overlay is a plain `<div>` with no `role`, no `aria-modal`, no accessible name, and no focus trap; pressing `Tab` from inside leaks focus into the underlying CollectionScreen, and closing the overlay drops focus at `document.body` instead of restoring it to the trigger.

This breaks the "trust before growth" and "beauty before bureaucracy" principles for keyboard and AT users — they hear no dialog announcement, can't tell where focus is, and have to Tab-traverse from scratch to recover context.

## Approach

- `ExhibitionView` outer container now declares `role="dialog"`, `aria-modal="true"`, and an `aria-label` composed of the collection name plus the current "Exhibit No. X of Y", so AT users land in a labelled dialog with useful position context.
- Esc-to-close, focus trap, and focus restore are delegated to the existing `useModalA11y(dialogRef, isOpen, onClose)` primitive (`src/hooks/useModalA11y.ts`). Arrow-key navigation stays bespoke (window-level `ArrowLeft`/`ArrowRight`) and the touch-swipe handler is unchanged.
- `useModalA11y` now picks its initial focus target via the same visibility-filtered `getFocusable()` set the focus trap uses, so the responsive mobile/desktop `display: none` siblings inside `ExhibitionView` can't claim focus into a hidden subtree. New Vitest regression covers this in `tests/hooks/useModalA11y.test.tsx`.

## Why this approach

Reusing the existing modal a11y primitive keeps every dialog feeling like one system rather than inventing a parallel inline implementation. The diff stays scoped to the dialog wiring on `ExhibitionView` plus the focused visibility fix on the shared hook, so regression risk is contained.

## Risks

Medium. The change is additive on the consuming side — Arrow keys, touch swipe, dot pagination, and Enter/Exit semantics are untouched. The `useModalA11y` hook attaches a `document`-level keydown listener while the exhibition is open; existing window-level handlers still fire because the hook only `preventDefault`s on `Escape` and `Tab` (`ArrowLeft`/`Right` are not intercepted). Focus restore now returns focus to whatever invoked the dialog — if any caller previously relied on focus landing on `document.body` after closing, that behavior changes. The shared `useModalA11y` change ships to every existing consumer (FilterModal, Delete*Modal, EnhanceImageModal, ConflictResolutionModal, ImageEditModal); behaviour for those modals is identical because their dialogs do not contain hidden DOM-first focusables — the new filter only changes behaviour for dialogs that do.

## How to verify

Vercel Preview: _attached automatically by the Vercel bot_

Steps:
1. Open any collection with ≥1 item and click **Enter Exhibition**.
2. With a screen reader (VoiceOver / NVDA) running, confirm the dialog announces "{Collection name} — Exhibit No. 1 of N, dialog".
3. Press `Tab` repeatedly: focus cycles only between the visible controls (close, prev, next, dot buttons, info toggle on mobile).
4. Press `Escape`: overlay closes and focus is restored to the **Enter Exhibition** trigger.
5. Press `ArrowLeft` / `ArrowRight`: navigation between exhibits still works.
6. On mobile viewport, swipe left/right: still navigates.

Checks (run on rebased branch against current `main`):
- [x] `npm run format:check` — passed
- [x] `npm test` — 54 files / **788 passed**, 2 skipped, 1 todo
- [x] `npm run build` — passed (vite 6.4.1, 1817 modules)
- [x] `npm run test:e2e` — 36 passed, 10 skipped

## Linear

Closes CUR-131

## Rollback plan

Revert the merge commit. `src/components/ExhibitionView.tsx` has a small set of edits (dialog props + a hook call); `src/hooks/useModalA11y.ts` gains a 1-line visibility filter on initial focus; `tests/components/ExhibitionView.test.tsx` is net-new and `tests/hooks/useModalA11y.test.tsx` gains one regression case. No data, schema, RLS, or storage changes — no SQL rollback required. Reverting cleanly restores the pre-PR behaviour.
