### PR TITLE
[CUR-120] Drop hardcoded vinyl fallback from ItemImage

### DIFF
--- a/src/components/ItemImage.tsx
+++ b/src/components/ItemImage.tsx
@@ -26,9 +26,7 @@ export const ItemImage: React.FC<ItemImageProps> = ({
   const [dbUrl, setDbUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
-  const [fallbackSrc, setFallbackSrc] = useState<string | null>(null);
   const currentUrlRef = useRef<string | null>(null);
-  const defaultFallback = `${import.meta.env.BASE_URL}assets/sample-vinyl.jpg`;
   const remoteAssetPath = useMemo(() => {
     if (!photoUrl) return null;
     if (photoUrl === 'asset') return null;
@@ -70,8 +68,6 @@ export const ItemImage: React.FC<ItemImageProps> = ({
     resolvedPhotoUrl && resolvedPhotoUrl !== 'asset' && resolvedPhotoUrl !== '';
 
   useEffect(() => {
-    // Reset fallback/error when the source changes
-    setFallbackSrc(null);
     setError(false);
   }, [photoUrl]);
 
@@ -157,7 +153,7 @@ export const ItemImage: React.FC<ItemImageProps> = ({
     };
   }, []);
 
-  const finalSrc = fallbackSrc || (isDirectSource ? resolvedPhotoUrl : dbUrl);
+  const finalSrc = isDirectSource ? resolvedPhotoUrl : dbUrl;
 
   if (loading && !finalSrc) {
     return (
@@ -208,15 +204,7 @@ export const ItemImage: React.FC<ItemImageProps> = ({
       alt={alt}
       className={`object-cover ${className}`}
       loading="lazy"
-      onError={() => {
-        // Handle native browser load errors (e.g., 404 for relative paths)
-        if (!fallbackSrc && isDirectSource) {
-          setFallbackSrc(defaultFallback);
-          setError(false);
-          return;
-        }
-        setError(true);
-      }}
+      onError={() => setError(true)}
     />
   );
 };

--- a/tests/components/ItemImage.test.tsx
+++ b/tests/components/ItemImage.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, fireEvent } from '../utils/test-utils';
+import { ItemImage } from '@/components/ItemImage';
+
+vi.mock('@/services/db', () => ({
+  extractCurioAssetPath: vi.fn(() => null),
+  getAsset: vi.fn(async () => null),
+  getEnhancedAsset: vi.fn(async () => null),
+}));
+
+describe('ItemImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Direct-source fallback (CUR-120)', () => {
+    it('renders the Image Error tile when a direct-URL photo fails to load', () => {
+      renderWithProviders(
+        <ItemImage itemId="truffle-1" photoUrl="https://example.com/missing.jpg" alt="A truffle" />,
+      );
+
+      const img = screen.getByAltText('A truffle') as HTMLImageElement;
+      expect(img.src).toBe('https://example.com/missing.jpg');
+
+      fireEvent.error(img);
+
+      expect(screen.getByText('Image Error')).toBeInTheDocument();
+      expect(screen.queryByAltText('A truffle')).not.toBeInTheDocument();
+      expect(
+        screen
+          .queryAllByRole('img')
+          .some((node) => (node as HTMLImageElement).src.includes('sample-vinyl.jpg')),
+      ).toBe(false);
+    });
+
+    it('keeps a successful direct-URL render intact', () => {
+      renderWithProviders(
+        <ItemImage itemId="truffle-2" photoUrl="https://example.com/photo.jpg" alt="A photo" />,
+      );
+
+      const img = screen.getByAltText('A photo') as HTMLImageElement;
+      expect(img.src).toBe('https://example.com/photo.jpg');
+    });
+  });
+});

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -161,16 +161,19 @@ test.describe('Accessibility', () => {
     test('should have alt text for images', async ({ page }) => {
       await page.goto('/');
 
-      const images = page.locator('img');
-      const count = await images.count();
+      // Snapshot the current DOM rather than auto-waiting per <img>; image elements
+      // can be replaced by a placeholder tile if their source fails to load.
+      const altTexts = await page.locator('img').evaluateAll((nodes) =>
+        nodes.slice(0, 5).map((img) => ({
+          visible: (img as HTMLElement).offsetParent !== null,
+          alt: img.getAttribute('alt'),
+        })),
+      );
 
-      for (let i = 0; i < Math.min(count, 5); i++) {
-        const img = images.nth(i);
-        if (await img.isVisible()) {
-          const alt = await img.getAttribute('alt');
-          // Images should have alt attribute (can be empty for decorative)
-          expect(alt !== null).toBeTruthy();
-        }
+      for (const { visible, alt } of altTexts) {
+        if (!visible) continue;
+        // Images should have alt attribute (can be empty for decorative)
+        expect(alt !== null).toBeTruthy();
       }
     });
   });


### PR DESCRIPTION
## Problem

`ItemImage` reacted to a broken direct-URL photo by silently swapping in `assets/sample-vinyl.jpg`. With only the Vinyl Vault sample shipping today the swap looks innocuous, but the moment any non-vinyl direct-source item lands (chocolate, sneakers, spirits — all of which exist as templates), a 404 would surface a vinyl LP instead of a missing-photo placeholder. It also created a latent infinite-retry shape if the fallback path itself 404'd. The behaviour breaks the "trust before growth" principle: users would read it as a UI bug ("why is my truffle showing a record?").

Closes CUR-120.

## Approach

* Delete the `defaultFallback` constant and the `fallbackSrc` state it fed; route direct-source `<img>` load failures through the existing `setError(true)` path so the placeholder is template-agnostic — the same `imageError` tile already used for missing IndexedDB assets.
* Add a focused Vitest covering the regression: a broken direct URL renders the `Image Error` tile, no vinyl `<img>` is reintroduced, and a successful direct URL still renders the original `<img>`.
* The accessibility e2e (`should have alt text for images`) auto-waited per `<img>` element, which times out now that ItemImage correctly unmounts a failed image instead of leaving a broken `<img>` in the DOM. Snapshot the visible imgs at one moment via `evaluateAll` so the assertion no longer depends on the broken-fallback behaviour.

## Why this approach

Mirrors the issue's recommended one-line fix, deletes the dead `fallbackSrc` state that becomes unreachable, and reuses the consistent error tile across both IndexedDB and direct-URL failure paths. A future template-aware fallback (template emoji/icon) would belong on top of this clean baseline rather than alongside a hardcoded vinyl JPG.

## Risks

Low. Successful direct-URL loads and IndexedDB asset reads are unchanged. The only behaviour change is what users see when a direct-URL image fails: `Image Error` tile instead of a vinyl LP. The new Vitest pins that path; e2e still passes locally (36 passed, 10 skipped, 0 failed).

## How to verify

Vercel Preview: https://curio-git-claude-curio-120-itemimag-498d11-qs-projects-72b20d9d.vercel.app

Steps:
1. Add (or simulate) a non-vinyl direct-URL item whose photo 404s.
2. Confirm the placeholder is the standard `Image Error` tile (`AlertCircle` + uppercase label), not `sample-vinyl.jpg`.
3. Open a successful direct-URL item: photo renders as before.
4. Open a private collection whose items use IndexedDB-backed photos: same `Image Error` tile on missing assets (unchanged).

Checks:
- [x] `npm run format:check`
- [x] `npm test` — 780 passed
- [x] `npm run build`
- [x] `npm run test:e2e` — 36 passed, 10 skipped

## Linear

Closes CUR-120

## Rollback plan

`git revert <merge-sha>` cleanly restores the previous behaviour. No data, schema, RLS, or storage changes.
