### PR TITLE
[CUR-137] Show "No photo" placeholder when export card image fails to load

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -53,6 +53,12 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   const [isExpanded, setIsExpanded] = useState(true);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isLoadingImage, setIsLoadingImage] = useState(true);
+  // CUR-137: distinguish "no photo on this item" from "photo failed to load".
+  // The card preview used to render whatever the browser put in the broken
+  // `<img>` slot (a default broken-image glyph), which then also poisoned
+  // html-to-image's canvas. Surface the same `noPhoto` placeholder either way
+  // so the exported PNG is intentional, not an accident.
+  const [imageLoadError, setImageLoadError] = useState(false);
   const [exportAction, setExportAction] = useState<null | 'save' | 'share'>(null);
   const [exportError, setExportError] = useState<string | null>(null);
   const [dragHeight, setDragHeight] = useState<number | null>(null);
@@ -105,8 +111,10 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   useEffect(() => {
     if (!isOpen) {
       setImageUrl(null);
+      setImageLoadError(false);
       return;
     }
+    setImageLoadError(false);
     if (directPhotoUrl) {
       setImageUrl(directPhotoUrl);
       setIsLoadingImage(false);
@@ -140,9 +148,12 @@ export const ExportModal: React.FC<ExportModalProps> = ({
         if (blob && blob.size > 0) {
           objectUrl = URL.createObjectURL(blob);
           setImageUrl(objectUrl);
+        } else {
+          setImageLoadError(true);
         }
       } catch (e) {
         console.error(e);
+        setImageLoadError(true);
       } finally {
         setIsLoadingImage(false);
       }
@@ -346,6 +357,13 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     return val !== undefined && val !== null ? val.toString() : null;
   };
 
+  // CUR-137: only set crossOrigin for HTTP(S) sources. Setting it on `blob:` /
+  // `data:` URLs is a no-op in spec terms but some browsers cache differently;
+  // for same-origin assets (relative paths) the attribute is unnecessary.
+  const imgCrossOrigin = imageUrl && /^https?:\/\//i.test(imageUrl) ? 'anonymous' : undefined;
+  const handleImageError = () => setImageLoadError(true);
+  const hasPhoto = Boolean(imageUrl) && !imageLoadError;
+
   const renderCardPreview = () => {
     const containerStyles = {
       minimal:
@@ -387,9 +405,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({
                   <div className="absolute inset-0 flex items-center justify-center">
                     <Loader2 className="animate-spin text-stone-200" />
                   </div>
-                ) : imageUrl ? (
+                ) : hasPhoto ? (
                   <img
-                    src={imageUrl}
+                    src={imageUrl!}
+                    crossOrigin={imgCrossOrigin}
+                    onError={handleImageError}
                     className={`w-full h-full ${imageFit === 'contain' ? 'object-contain' : 'object-cover'}`}
                     alt={item.title || t('photoPreview')}
                   />
@@ -424,10 +444,12 @@ export const ExportModal: React.FC<ExportModalProps> = ({
           )}
           {style === 'full' && (
             <>
-              {imageUrl && (
+              {hasPhoto && (
                 <div className="absolute inset-0">
                   <img
-                    src={imageUrl}
+                    src={imageUrl!}
+                    crossOrigin={imgCrossOrigin}
+                    onError={handleImageError}
                     className={`w-full h-full ${imageFit === 'contain' ? 'object-contain' : 'object-cover'} opacity-80`}
                     alt=""
                   />
@@ -451,9 +473,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({
           {style === 'retro' && (
             <>
               <div className="w-full flex-1 border-2 border-stone-800 mb-4 bg-stone-200 grayscale contrast-125 overflow-hidden relative min-h-0">
-                {imageUrl && (
+                {hasPhoto && (
                   <img
-                    src={imageUrl}
+                    src={imageUrl!}
+                    crossOrigin={imgCrossOrigin}
+                    onError={handleImageError}
                     className={`w-full h-full mix-blend-multiply ${imageFit === 'contain' ? 'object-contain' : 'object-cover'}`}
                     alt=""
                   />

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../utils/test-utils';
 import { ExportModal } from '@/components/ExportModal';
 import type { CollectionItem, FieldDefinition } from '@/types';
@@ -461,6 +461,68 @@ describe('ExportModal — CUR-106 export feedback tone', () => {
     expect(alert.textContent).toMatch(/could not save image/i);
     // Failure must not also masquerade as a positive trust signal.
     expect(onStatus).not.toHaveBeenCalledWith(expect.anything(), 'success');
+  });
+});
+
+describe('ExportModal — CUR-137 broken-photo fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('falls back to the "No photo" placeholder when the card image fails to load instead of showing a broken-image glyph', async () => {
+    renderWithProviders(
+      <ExportModal
+        isOpen
+        onClose={vi.fn()}
+        fields={[]}
+        item={makeItem({
+          photoUrl: 'https://example.invalid/missing.jpg',
+          title: 'Broken photo case',
+        })}
+      />,
+    );
+
+    // The minimal template is default and is the path the user hits from the
+    // mobile Save Image / Share flow. The card preview should render the photo
+    // slot until the load actually fails.
+    const card = document.getElementById('card-preview');
+    expect(card).not.toBeNull();
+    const img = card!.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('crossorigin')).toBe('anonymous');
+
+    // Simulate the network / 404 / CORS failure that produced the broken-image
+    // glyph in the bug report.
+    await act(async () => {
+      fireEvent.error(img!);
+    });
+
+    // The image is replaced by the explicit "No photo" placeholder. This is the
+    // user-visible contract: no broken-image glyph ever survives to the card.
+    expect(card!.querySelector('img')).toBeNull();
+    expect(screen.getByText(/no photo/i)).toBeInTheDocument();
+  });
+
+  it('marks the photo slot empty when the IndexedDB asset waterfall returns nothing, so the card never relies on a broken <img>', async () => {
+    // Default mocks already return null for both getEnhancedAsset and getAsset,
+    // simulating an item whose photo blob is missing from local + cloud.
+    renderWithProviders(
+      <ExportModal
+        isOpen
+        onClose={vi.fn()}
+        fields={[]}
+        item={makeItem({ photoUrl: 'asset', title: 'Asset-keyword case' })}
+      />,
+    );
+
+    // Wait for the loading spinner to clear (waterfall resolves).
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save image/i })).not.toBeDisabled();
+    });
+
+    const card = document.getElementById('card-preview')!;
+    expect(card.querySelector('img')).toBeNull();
+    expect(screen.getByText(/no photo/i)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Problem

The export card preview rendered the browser's default broken-image glyph whenever the photo URL was set but the image couldn't actually be fetched. That glyph then got rasterised into html-to-image's canvas, so "Save Image" / "Share" produced a card with a visible broken-image marker — or failed outright with `saveImageFailed` when the canvas was tainted by a cross-origin image.

Reported in CUR-137 for the "Kind of Blue" sample on mobile, but the same path triggers for any item whose blob waterfall (`getEnhancedAsset` → `getAsset('original')` → `getAsset('display')`) returns null, and for any cross-origin Supabase Storage URL.

Protects **"trust before growth"** (sharing surface should never silently look broken) and **"sharing before social complexity"** (Save / Share is the export contract — a broken-image PNG isn't a shareable artefact).

## Approach

- Track an explicit `imageLoadError` state in `ExportModal`. The IndexedDB/Supabase blob waterfall flips it when nothing comes back; the `<img>` `onError` handler flips it on browser load failure (including CORS taint, 404, and network errors).
- Route both failure paths through the existing `noPhoto` placeholder (already in use for items with no photo at all). The card preview never renders an `<img>` that the browser couldn't load, so the html-to-image canvas stays clean and the exported PNG is intentional.
- Add `crossOrigin="anonymous"` to HTTP(S) sources so Supabase Storage's CORS headers keep the canvas un-tainted on rasterise. Skipped for `data:` / `blob:` / same-origin sources where it's unnecessary.
- Applied across all three card templates (`minimal`, `full`, `retro`) so the contract is uniform.

## Why this approach

It's the smallest change that closes the user-visible gap: the bug is "broken image glyph reaches the exported card", and the fix is "never render a broken `<img>` in the first place." No new dependencies, no new product surface, no behaviour change for the happy path (item with a working photo) — only the failure path is now intentional rather than accidental.

Storage CORS configuration (item #2 in the issue's fix direction) is infrastructure, not code, so it's out of scope for this PR; Supabase's public bucket already returns `Access-Control-Allow-Origin: *`, so `crossOrigin="anonymous"` should work end-to-end in production.

## Risks

Low. The change is additive on the consuming side — the happy path (valid image loads) renders the same `<img>` it always did, just with `crossOrigin="anonymous"` for HTTP(S) sources and an `onError` handler that only fires on actual load failures. Fail-open behaviour: if `imageLoadError` was already true on first paint we'd flicker through the placeholder, but the state defaults to `false` and only flips on a real load failure, so no flicker on the happy path.

One edge case worth watching: if a Supabase Storage URL is somehow served without CORS headers in a production environment, `crossOrigin="anonymous"` would block it where the old (silent-taint) behaviour would have shown the image at least visually. That's the right trade — the export was already broken in that case, but now the user sees the explicit placeholder instead of guessing why "Save Image" fails.

## How to verify

Vercel Preview: https://curio-git-claude-curio-137-export-i-75816e-qs-projects-72b20d9d.vercel.app

Steps:
1. Open any sample item ("Kind of Blue" in the Vinyl Vault).
2. Tap the export icon on item detail → confirm the card preview shows the photo (happy path).
3. In DevTools, block the image request via Network → Block Request URL on `sample-vinyl.jpg` (or simulate a cross-origin 404).
4. Re-open the export modal → card now shows the "No photo" placeholder cleanly, no broken-image glyph.
5. Click Save Image → the downloaded PNG renders the placeholder, not a broken glyph; no error toast.
6. Repeat the verification on the `full` and `retro` templates.

Checks:
- [x] `npm run format:check`
- [x] `npm test` — 783 passed (incl. 2 new CUR-137 cases)
- [x] `npm run build`
- [x] `npm run test:e2e` — 36 passed / 10 skipped (pre-existing skips, unchanged from main)

## Linear

Closes CUR-137

## Rollback plan

Revert this commit. The change is contained to `src/components/ExportModal.tsx` and its Vitest. No data, schema, RLS, storage, or env-var changes — reverting cleanly restores the prior render path.