### PR TITLE
[CUR-22] Theme-aware tone tokens for AddItem / CreateCollection / DeleteCollection modals

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -180,6 +180,39 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     vault: 'border-white/15 text-stone-300 hover:border-amber-400/40 hover:bg-white/5',
     atelier: 'border-[#D4C9B8] text-[#8C7B6B] hover:border-[#A86F3C]/40 hover:bg-[#EDE4D3]',
   }[theme];
+  // CUR-22: theme-aware tone tokens for the upload empty state, collection
+  // picker tiles, and subtle "skip / hide" links so Vault stops rendering a
+  // bright cream pill / heading inside an otherwise dark modal.
+  const uploadEmptyTileClass = {
+    gallery: 'bg-stone-50 border-stone-200 text-stone-400 hover:border-amber-400 hover:bg-amber-50',
+    vault: 'bg-white/5 border-white/15 text-stone-300 hover:border-amber-400/60 hover:bg-white/10',
+    atelier:
+      'bg-[#EDE4D3] border-[#D4C9B8] text-[#8C7B6B] hover:border-[#A86F3C]/60 hover:bg-[#E6D9C2]',
+  }[theme];
+  const uploadHeadingClass = {
+    gallery: 'text-stone-900',
+    vault: 'text-white',
+    atelier: 'text-[#3D3530]',
+  }[theme];
+  const selectTileClass = {
+    gallery: 'border border-stone-100 bg-stone-50/50 hover:border-amber-400 hover:bg-amber-50',
+    vault: 'border border-white/10 bg-white/5 hover:border-amber-400/60 hover:bg-white/10',
+    atelier: 'border border-[#D4C9B8] bg-[#EDE4D3]/60 hover:border-[#A86F3C]/60 hover:bg-[#EDE4D3]',
+  }[theme];
+  const selectTileTitleClass = {
+    gallery: 'text-stone-800',
+    vault: 'text-white',
+    atelier: 'text-[#3D3530]',
+  }[theme];
+  // Subtle "skip / dismiss" link hover tone. The original
+  // "hover:text-stone-600 / hover:text-stone-700" disappears against Vault's
+  // stone-900 surface — pin a theme-specific destination so the hover affordance
+  // stays legible across all three themes.
+  const subtleLinkHoverClass = {
+    gallery: 'hover:text-stone-700',
+    vault: 'hover:text-white',
+    atelier: 'hover:text-[#3D3530]',
+  }[theme];
   // Matches the dialog surface so the bottom fade blends into the panel bg.
   const scrollFadeFrom =
     theme === 'vault' ? 'from-stone-900' : theme === 'atelier' ? 'from-[#F5EFE4]' : 'from-white';
@@ -936,15 +969,18 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
               setSelectedCollectionId(c.id);
               setStep('upload');
             }}
-            className="p-4 sm:p-6 rounded-xl sm:rounded-2xl border border-stone-100 bg-stone-50/50 hover:border-amber-400 hover:bg-amber-50 transition-all text-left group shadow-sm hover:shadow-md"
+            data-testid="add-item-collection-tile"
+            className={`p-4 sm:p-6 rounded-xl sm:rounded-2xl ${selectTileClass} transition-all text-left group shadow-sm hover:shadow-md`}
           >
             <span className="block text-2xl sm:text-3xl mb-2 sm:mb-3 group-hover:scale-110 transition-transform origin-left">
               {c.icon || '📦'}
             </span>
-            <span className="font-bold text-stone-800 block text-base sm:text-lg truncate">
+            <span
+              className={`font-bold ${selectTileTitleClass} block text-base sm:text-lg truncate`}
+            >
               {c.name}
             </span>
-            <span className="text-[10px] text-stone-400 font-medium uppercase tracking-wider">
+            <span className={`text-[10px] font-medium uppercase tracking-wider ${mutedText}`}>
               {t('artifacts')}: {c.items.length}
             </span>
           </button>
@@ -961,7 +997,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
             type="button"
             onClick={pickFromGallery}
             aria-label={imagePreview ? t('changePhoto') : undefined}
-            className="w-32 h-32 sm:w-40 sm:h-40 rounded-full bg-stone-50 border-2 border-dashed border-stone-200 flex flex-col items-center justify-center text-stone-400 group hover:border-amber-400 hover:bg-amber-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/40 focus-visible:ring-offset-2 transition-all cursor-pointer overflow-hidden"
+            data-testid="add-item-upload-empty"
+            className={`w-32 h-32 sm:w-40 sm:h-40 rounded-full border-2 border-dashed flex flex-col items-center justify-center group focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/40 focus-visible:ring-offset-2 transition-all cursor-pointer overflow-hidden ${uploadEmptyTileClass}`}
           >
             {imagePreview ? (
               <img src={imagePreview} className="w-full h-full object-cover" alt="" />
@@ -977,7 +1014,9 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
         </div>
       </div>
       <div>
-        <h3 className="text-xl sm:text-2xl font-serif font-bold text-stone-900 mb-1 sm:mb-2">
+        <h3
+          className={`text-xl sm:text-2xl font-serif font-bold mb-1 sm:mb-2 ${uploadHeadingClass}`}
+        >
           {t('uploadPhoto')}
         </h3>
         <p className={`text-sm sm:text-base ${mutedText} max-w-xs mx-auto`}>
@@ -1010,7 +1049,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
         </Button>
         <button
           onClick={switchToManual}
-          className="text-xs sm:text-sm font-medium text-stone-400 hover:text-stone-600"
+          data-testid="add-item-skip-manual"
+          className={`text-xs sm:text-sm font-medium transition-colors ${mutedText} ${subtleLinkHoverClass}`}
         >
           {t('skipManual')}
         </button>
@@ -1339,7 +1379,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
                 <button
                   type="button"
                   onClick={() => setPromptsOpen(false)}
-                  className={`text-[11px] ${mutedText} hover:text-stone-700`}
+                  data-testid="add-item-story-prompt-hide"
+                  className={`text-[11px] transition-colors ${mutedText} ${subtleLinkHoverClass}`}
                 >
                   {t('storyPromptHide')}
                 </button>

--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -109,6 +109,20 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       ? 'bg-white/5 border border-white/10 text-white placeholder:text-stone-400'
       : 'bg-stone-50 border border-stone-200 text-stone-800';
 
+  // CUR-22: theme-aware tone tokens for the status banner and loading spinner
+  // backdrop. Mirrors the AddItemModal warnBannerClass (CUR-92) so amber
+  // pastels stop punching through Vault's stone-950 surface.
+  const statusBannerClass = {
+    gallery: 'bg-amber-50 text-amber-700 border-amber-100',
+    vault: 'bg-amber-500/10 text-amber-200 border-amber-400/20',
+    atelier: 'bg-amber-100/70 text-amber-900 border-amber-300/60',
+  }[theme];
+  const loadingSpinnerClass = {
+    gallery: 'bg-amber-50 text-amber-500',
+    vault: 'bg-amber-500/15 text-amber-300',
+    atelier: 'bg-amber-100/70 text-[#A86F3C]',
+  }[theme];
+
   const resetState = () => {
     suggestRunRef.current += 1;
     setStep('entry');
@@ -523,7 +537,10 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   const renderLoading = () => (
     <div className="text-center py-12 sm:py-16 space-y-4">
       <div className="flex justify-center">
-        <div className="w-14 h-14 rounded-full flex items-center justify-center bg-amber-50 text-amber-500">
+        <div
+          data-testid="collection-loading-spinner"
+          className={`w-14 h-14 rounded-full flex items-center justify-center ${loadingSpinnerClass}`}
+        >
           <Loader2 size={24} className="animate-spin" />
         </div>
       </div>
@@ -565,7 +582,10 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
         </div>
 
         {statusMessage && (
-          <div className="p-3 rounded-xl border text-xs font-medium bg-amber-50 text-amber-700 border-amber-100">
+          <div
+            data-testid="collection-status-message"
+            className={`p-3 rounded-xl border text-xs font-medium ${statusBannerClass}`}
+          >
             {statusMessage}
           </div>
         )}

--- a/src/components/DeleteCollectionModal.tsx
+++ b/src/components/DeleteCollectionModal.tsx
@@ -45,7 +45,16 @@ export const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
         <div className="sm:hidden h-3" />
         <div className={`flex items-center justify-between px-6 py-5 border-b ${borderClass}`}>
           <div className="flex items-center gap-2">
-            <div className="p-1.5 rounded-lg bg-red-100 text-red-600">
+            <div
+              data-testid="delete-collection-warning-icon"
+              className={`p-1.5 rounded-lg ${
+                theme === 'vault'
+                  ? 'bg-red-500/15 text-red-300'
+                  : theme === 'atelier'
+                    ? 'bg-red-100/70 text-red-700'
+                    : 'bg-red-100 text-red-600'
+              }`}
+            >
               <AlertTriangle size={18} />
             </div>
             <h2

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -778,4 +778,93 @@ describe('AddItemModal', () => {
       expect(mockOnClose).not.toHaveBeenCalled();
     });
   });
+
+  describe('Vault theme contrast (CUR-22)', () => {
+    it('renders collection picker tiles with theme-aware surface tokens on Vault', () => {
+      setMockTheme('vault');
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[
+            createMockCollection({ id: 'a', name: 'Vinyl' }),
+            createMockCollection({ id: 'b', name: 'Chocolate' }),
+          ]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      const tiles = screen.getAllByTestId('add-item-collection-tile');
+      expect(tiles).toHaveLength(2);
+      tiles.forEach((tile) => {
+        // Light Gallery tokens (bg-stone-50/50, text-stone-800) must NOT leak
+        // into the dark surface — they collapse against the dark modal body.
+        expect(tile).not.toHaveClass('bg-stone-50/50');
+        expect(tile).toHaveClass('bg-white/5');
+        expect(tile).toHaveClass('border-white/10');
+      });
+
+      const titles = tiles.map((tile) => tile.querySelector('span.font-bold'));
+      titles.forEach((title) => {
+        expect(title).not.toBeNull();
+        expect(title!.className).toMatch(/text-white/);
+        expect(title!.className).not.toMatch(/text-stone-800/);
+      });
+    });
+
+    it('renders the upload empty-state circle with a Vault-tinted surface, not a cream pill', () => {
+      setMockTheme('vault');
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection({ customFields: [] })]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      const uploadEmpty = screen.getByTestId('add-item-upload-empty');
+      expect(uploadEmpty).toHaveClass('bg-white/5');
+      expect(uploadEmpty).toHaveClass('border-white/15');
+      // The empty cream pill must not survive on Vault.
+      expect(uploadEmpty).not.toHaveClass('bg-stone-50');
+      expect(uploadEmpty).not.toHaveClass('hover:bg-amber-50');
+    });
+
+    it('keeps the "Skip Manual" link hover visible against the dark surface', () => {
+      setMockTheme('vault');
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection({ customFields: [] })]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      const skipLink = screen.getByTestId('add-item-skip-manual');
+      // hover:text-stone-600 was invisible on stone-900 — pin to white.
+      expect(skipLink).toHaveClass('hover:text-white');
+      expect(skipLink.className).not.toMatch(/hover:text-stone-(500|600|700)/);
+    });
+
+    it('preserves Gallery tokens for the collection picker on the default theme', () => {
+      setMockTheme('gallery');
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[
+            createMockCollection({ id: 'a', name: 'Vinyl' }),
+            createMockCollection({ id: 'b', name: 'Chocolate' }),
+          ]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      const tile = screen.getAllByTestId('add-item-collection-tile')[0];
+      expect(tile).toHaveClass('bg-stone-50/50');
+      expect(tile).toHaveClass('border-stone-100');
+    });
+  });
 });

--- a/tests/components/DeleteCollectionModal.test.tsx
+++ b/tests/components/DeleteCollectionModal.test.tsx
@@ -91,4 +91,25 @@ describe('DeleteCollectionModal', () => {
       });
     });
   });
+
+  describe('Vault theme contrast (CUR-22)', () => {
+    it('renders the warning icon with a Vault-tinted tile, not a pastel pill', () => {
+      setMockTheme('vault');
+      renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+      const icon = screen.getByTestId('delete-collection-warning-icon');
+      expect(icon).toHaveClass('bg-red-500/15');
+      expect(icon).toHaveClass('text-red-300');
+      // Cream pastel must NOT leak through onto the dark surface.
+      expect(icon).not.toHaveClass('bg-red-100');
+      expect(icon).not.toHaveClass('text-red-600');
+    });
+
+    it('keeps the Gallery icon tile unchanged on the default theme', () => {
+      setMockTheme('gallery');
+      renderWithProviders(<DeleteCollectionModal {...defaultProps} />);
+      const icon = screen.getByTestId('delete-collection-warning-icon');
+      expect(icon).toHaveClass('bg-red-100');
+      expect(icon).toHaveClass('text-red-600');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Three modal surfaces hardcoded Gallery (light) Tailwind tokens, so on Vault they punched through the dark dialog body and broke both the *beauty* and the *trust* contract of the modal:

- **`AddItemModal`** — the collection-picker tiles rendered as `bg-stone-50/50 border-stone-100 text-stone-800` (cream pills with near-invisible titles on `bg-stone-900`); the upload empty-state circle was a literal `bg-stone-50 border-stone-200` cream pill in the middle of the dark modal; the "Upload Photo" heading was `text-stone-900` (invisible on Vault); and both the "Skip Manual" link and the story-prompt "hide" link used `hover:text-stone-600 / hover:text-stone-700`, which collapse against stone-900 — the hover affordance silently disappeared.
- **`CreateCollectionModal`** — the validation status banner and the loading spinner backdrop hardcoded `bg-amber-50 text-amber-700 border-amber-100`, leaving a glaring cream wash on dark.
- **`DeleteCollectionModal`** — the warning-icon tile hardcoded `bg-red-100 text-red-600`, a pastel pink chip on `bg-stone-900`.

Protects the **beauty before bureaucracy** and **trust before growth** product principles. CUR-22 calls out WCAG AA contrast specifically — `text-stone-900` on `bg-stone-950` is 1.2:1, far below the 4.5:1 normal-text floor; the cream-pill surfaces aren't a contrast failure on their own but they collapse the dark modal's visual coherence.

## Approach

Add per-theme `Record<AppTheme, string>` lookup tables near the existing CUR-92 / CUR-108 records:

- `AddItemModal`: `uploadEmptyTileClass`, `uploadHeadingClass`, `selectTileClass`, `selectTileTitleClass`, `subtleLinkHoverClass` (hover-only — resting stays `mutedText` so existing AA-passing tones aren't downgraded).
- `CreateCollectionModal`: `statusBannerClass`, `loadingSpinnerClass` (mirrors the AddItemModal `warnBannerClass` palette).
- `DeleteCollectionModal`: inline 3-theme switch for the warning-icon tile (the file has only one affected surface — a full record would be over-engineering).

Each gains a `data-testid` so the per-theme variants can be pinned without scraping classnames out of intermediate flex containers.

## Why this approach

Mirrors the established CUR-81 / CUR-88 / CUR-92 / CUR-108 pattern, so reviewers see a familiar shape and the trust surfaces feel like one system. Pure presentational diff — no auth, sync, RLS, storage, AI, or product-behavior change. The amber + red treatments reuse the exact tone tokens already in use across StatusBanner / StatusToast / AddItemModal's analyzing banner, so the modals stay visually coherent across the app.

`ExportModal` is intentionally **out of scope**: every `<Button>` inside it hardcodes `theme="gallery"`, and the printed-card preview is paper-toned by design. A Vault-coherent export chrome warrants a separate, larger PR — calling it out so the issue isn't half-closed.

## Risks

Low (Green tier). Pure CSS class substitution in three components plus six new tests. No API surface changes, no state changes, no behavior changes. Gallery resting tones are byte-identical or strictly improved (the "Skip Manual" link's resting `text-stone-400` → `mutedText` = `text-stone-500` on Gallery — an AA-passing improvement, not a downgrade). The new `data-testid` props are passive — no consumer relies on their absence.

## How to verify

Vercel Preview: _attached automatically by the Vercel bot_

Steps (mobile viewport recommended):

1. Open the preview and switch theme to **Vault**.
2. Tap **+** in the bottom nav to open Add Item. With ≥2 collections, confirm:
   - Collection picker tiles use a `bg-white/5 border-white/10` surface and white titles — not cream pills with stone-800 text.
3. Pick a collection (or have only one — flow goes straight to upload). Confirm:
   - The upload empty-state circle is a subtle `bg-white/5 border-white/15` ring, not a bright cream pill.
   - The "Upload Photo" heading reads as `text-white`, not invisible stone-900.
   - The "Skip Manual" link's hover is visible (transitions to white), not invisible stone-600.
4. From a `customFields` collection, upload → analyze → land on verify. Tap **Story Prompts**, then **Hide** — hover state transitions to white, not invisible stone-700.
5. Open **New Archive** (CreateCollectionModal). Type a description and click Continue. While loading, the spinner backdrop is a brass-tinted `bg-amber-500/15`, not a cream pastel.
6. Trigger a validation banner (e.g. proceed without picking enough fields). The amber banner adopts the Vault `bg-amber-500/10 text-amber-200` treatment, not the cream `bg-amber-50 text-amber-700`.
7. Open a private collection → kebab → **Delete Collection**. The warning-icon tile reads as `bg-red-500/15 text-red-300`, not a pastel pink chip.
8. Switch to **Atelier** (cream theme) — every surface adopts warm parchment tones with leather-brown text/icons.
9. Switch back to **Gallery** — every surface is visually identical to `main`.

Checks:
- [x] `npm run format:check` — passed
- [x] `npm test` — **789 passed**, 2 skipped, 1 todo (53 files; includes 4 new AddItemModal CUR-22 tests + 2 new DeleteCollectionModal CUR-22 tests)
- [x] `npm run build` — passed (vite 6.4.1, 1817 modules)
- [x] `npm run test:e2e` — **36 passed**, 10 skipped (no e2e regressions; the new theme-accessibility e2e under `tests/e2e/accessibility.spec.ts` still passes)

## Screenshot / GIF

Visual changes are theme-conditional and easiest to verify on the Vercel preview by switching themes. The 6 new Vitest cases pin the Vault treatment for each fixed surface plus regression guards proving the Gallery tokens still apply on the default theme.

## Linear

Closes CUR-22

## Rollback plan

Revert this single commit (`git revert 7d2cfb4`). No data, schema, RLS, storage, env-var, or feature-flag changes — pure CSS-class substitution plus theme lookup records. The new `data-testid` props are passive and safe to leave in place if a partial revert is needed.

## Follow-up note

`ExportModal`'s modal chrome (close button, option pills, sheet background) is locked to Gallery tokens by design. A Vault-coherent export modal is a separate scope — happy to file a follow-up issue if it should be tracked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H98ooYDtTzkgZ1JEmAhaRe)_