### PR TITLE
[CUR-93] Theme-aware active filter chips + Clear all link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,6 +146,36 @@ import { HomeScreen } from './components/HomeScreen';
 import { useDebouncedValue } from './hooks/useDebouncedValue';
 import { useAndroidBackButton } from './hooks/useAndroidBackButton';
 
+// CUR-93: Active filter chips and the "Clear all" link used to hardcode
+// Gallery (light) tokens, so on Vault the amber-50 pills punched through
+// the dark page and the stone-500 link collapsed against the page muted
+// text. The palette here mirrors the warning tone in StatusBanner (CUR-81)
+// and the muted link tones already used elsewhere in the file, so the
+// chips read as one system across themes.
+const filterChipClasses: Record<AppTheme, string> = {
+  gallery: 'bg-amber-50 text-amber-800 border-amber-100',
+  vault: 'bg-amber-500/10 text-amber-200 border-amber-400/20',
+  atelier: 'bg-amber-100/70 text-amber-900 border-amber-300/60',
+};
+
+const filterChipSeparatorClasses: Record<AppTheme, string> = {
+  gallery: 'text-amber-700/80',
+  vault: 'text-amber-200/70',
+  atelier: 'text-amber-800/70',
+};
+
+const filterChipIconClasses: Record<AppTheme, string> = {
+  gallery: 'text-amber-600',
+  vault: 'text-amber-200',
+  atelier: 'text-amber-800',
+};
+
+const clearFiltersLinkClasses: Record<AppTheme, string> = {
+  gallery: 'text-stone-500 hover:text-stone-800 decoration-stone-300',
+  vault: 'text-stone-300 hover:text-white decoration-white/30',
+  atelier: 'text-[#8C7B6B] hover:text-[#3D3530] decoration-[#D4C9B8]',
+};
+
 export const AppContent: React.FC = () => {
   const { t, language } = useTranslation();
   const { theme, setTheme } = useTheme();
@@ -1429,19 +1459,21 @@ export const AppContent: React.FC = () => {
             {activeFilterEntries.map(([key, value]) => (
               <button
                 key={key}
-                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm bg-amber-50 text-amber-800 border border-amber-100 motion-chip"
+                data-testid="active-filter-chip"
+                className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm border motion-chip ${filterChipClasses[theme]}`}
                 onClick={() => handleRemoveFilter(key)}
                 title={t('clearFilter')}
               >
                 <span className="font-semibold">{getFieldLabel(key)}</span>
-                <span className="text-amber-700/80">·</span>
+                <span className={filterChipSeparatorClasses[theme]}>·</span>
                 <span className="font-medium">{value}</span>
-                <X size={14} className="text-amber-600" />
+                <X size={14} className={filterChipIconClasses[theme]} />
               </button>
             ))}
             <button
+              data-testid="active-filter-clear-all"
               onClick={handleClearFilters}
-              className="text-sm font-semibold text-stone-500 hover:text-stone-800 underline decoration-stone-300"
+              className={`text-sm font-semibold underline ${clearFiltersLinkClasses[theme]}`}
             >
               {t('clearAll')}
             </button>

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -922,4 +922,105 @@ describe('App Integration Tests', () => {
     expect(screen.getByText('Test Collection')).toBeInTheDocument();
     expect(screen.getByText('Second Collection')).toBeInTheDocument();
   });
+
+  // CUR-93: Active filter chips and the "Clear all" link hardcoded amber-50
+  // and stone-500 tokens. On Vault the chips punched through the dark page as
+  // pale yellow blocks and the muted link collapsed against the surface. The
+  // fix mirrors the warning tone in StatusBanner (CUR-81) so the chips read
+  // as one system across all three themes.
+  const applyRatingFilter = async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Filter Collection' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Filter Collection' });
+    const ratingSelect = within(dialog).getByRole('combobox');
+    fireEvent.change(ratingSelect, { target: { value: '5' } });
+    fireEvent.click(within(dialog).getByRole('button', { name: /apply/i }));
+  };
+
+  it('renders active filter chips with theme-aware tokens on Vault (CUR-93)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1']}>
+        {/* @ts-ignore - mocked ThemeProvider accepts initialTheme */}
+        <ThemeProvider initialTheme="vault">
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Collection')).toBeInTheDocument();
+    });
+
+    await applyRatingFilter();
+
+    const chip = await screen.findByTestId('active-filter-chip');
+    // Vault uses amber-tinted dark tokens instead of the pale amber-50 pill.
+    expect(chip.classList).toContain('bg-amber-500/10');
+    expect(chip.classList).toContain('text-amber-200');
+    expect(chip.classList).toContain('border-amber-400/20');
+    expect(chip.classList).not.toContain('bg-amber-50');
+
+    const clearAll = screen.getByTestId('active-filter-clear-all');
+    expect(clearAll.classList).toContain('text-stone-300');
+    expect(clearAll.classList).not.toContain('text-stone-500');
+  });
+
+  it('preserves Gallery tokens for active filter chips on the default theme (CUR-93)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Collection')).toBeInTheDocument();
+    });
+
+    await applyRatingFilter();
+
+    const chip = await screen.findByTestId('active-filter-chip');
+    expect(chip.classList).toContain('bg-amber-50');
+    expect(chip.classList).toContain('text-amber-800');
+    expect(chip.classList).toContain('border-amber-100');
+
+    const clearAll = screen.getByTestId('active-filter-clear-all');
+    expect(clearAll.classList).toContain('text-stone-500');
+  });
+
+  it('uses Atelier warm-brown tokens for active filter chips (CUR-93)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1']}>
+        {/* @ts-ignore - mocked ThemeProvider accepts initialTheme */}
+        <ThemeProvider initialTheme="atelier">
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Collection')).toBeInTheDocument();
+    });
+
+    await applyRatingFilter();
+
+    const chip = await screen.findByTestId('active-filter-chip');
+    expect(chip.classList).toContain('bg-amber-100/70');
+    expect(chip.classList).toContain('text-amber-900');
+
+    const clearAll = screen.getByTestId('active-filter-clear-all');
+    expect(clearAll.classList).toContain('text-[#8C7B6B]');
+  });
 });


### PR DESCRIPTION
## Problem

When a user applies filters on a CollectionScreen, an "Active filters" row of chips renders under the toolbar. Each chip and the "Clear all" link were hardcoded to Gallery (light) tokens:

- `bg-amber-50 text-amber-800 border-amber-100` on every chip
- `text-amber-700/80` separator dot and `text-amber-600` X icon
- `text-stone-500 hover:text-stone-800 decoration-stone-300` on Clear all

None of these read `theme`, so on **Vault** the chips punched through the dark page as pale yellow blocks and the muted link collapsed against the surface; on **Atelier** the cream-tinted amber-50 clashed with the warm parchment theme.

Protects the **beauty before bureaucracy** product principle — the active-filter row is the main "what's currently filtered" affordance on the most-visited route. It should read as one system across all three themes, the same way StatusBanner (CUR-81), StatusToast (CUR-88), and the bottom-nav Add pill (CUR-71) already do.

## Approach

Add four module-level `Record<AppTheme, string>` lookups in `src/App.tsx`, just before the `AppContent` declaration:

- `filterChipClasses` — chip surface + text + border (warning palette mirroring StatusBanner)
- `filterChipSeparatorClasses` — the `·` between label and value
- `filterChipIconClasses` — the X close icon
- `clearFiltersLinkClasses` — the Clear all link with theme-aware hover + decoration

Wire each into the existing render and add `data-testid="active-filter-chip"` + `data-testid="active-filter-clear-all"` so the per-theme treatments can be pinned without scraping classes off intermediate flex containers.

## Why this approach

Mirrors the established CUR-71 / CUR-81 / CUR-88 / CUR-85 pattern, so reviewers see a familiar shape and the trust surfaces feel like one system. Pure presentational diff — no auth, sync, RLS, storage, AI, or product-behavior change. The amber palette reuses the exact tone tokens already in use across StatusBanner / StatusToast, so chips, banners, and toasts stay visually coherent.

The four records live next to `AppContent` rather than in `src/theme.tsx` because they only apply to one localized region (matches StatusBanner's tone records living inside StatusBanner.tsx). If a second chip-like pattern appears later, the records can be hoisted then.

## Risks

Low (Green tier). Pure CSS class substitution at one location in `src/App.tsx` plus three integration tests. No API surface changes, no state changes, no behavior changes. Gallery resting tones are byte-identical (`bg-amber-50 text-amber-800 border-amber-100`). The new `data-testid` props are passive — no consumer relies on their absence.

## How to verify

Vercel Preview: _attached automatically by the Vercel bot_

Steps (mobile viewport recommended):

1. Open any private collection with custom fields.
2. Tap the filter icon, set a rating (e.g. 5 only) and optionally one custom-field filter, tap **Apply**.
3. Switch theme to **Vault**:
   - Active filter chips read as `bg-amber-500/10 border-amber-400/20` with `text-amber-200` labels — not pale yellow pills.
   - The X icon is `text-amber-200`, the separator dot is `text-amber-200/70`.
   - The **Clear all** link is `text-stone-300 hover:text-white` — legible against the dark surface, not the old invisible stone-500.
4. Switch to **Atelier** (cream theme):
   - Chips adopt `bg-amber-100/70 text-amber-900` warm-parchment tones; the link uses the sepia `text-[#8C7B6B]`.
5. Switch back to **Gallery**:
   - Chips and link are visually identical to `main`.
6. In each theme, click a chip — the filter is removed; click **Clear all** — all filters drop.

Checks:

- [x] `npm run format:check` — passed
- [x] `npm test` — **786 passed**, 2 skipped, 1 todo (53 files; includes 3 new CUR-93 integration tests for Gallery / Vault / Atelier)
- [x] `npm run build` — passed (vite 6.4.1, 1817 modules)
- [x] `npm run test:e2e` — **36 passed**, 10 skipped (no e2e regressions)

## Screenshot / GIF

Visual changes are theme-conditional and easiest to verify on the Vercel preview by switching themes. The three new integration tests drive a real rating filter through the FilterModal in CollectionScreen and pin the per-theme treatment, so the regression would surface in CI without needing screenshots.

## Linear

Closes CUR-93

## Rollback plan

Revert this single commit (`git revert 948cd36`). No data, schema, RLS, storage, env-var, or feature-flag changes — pure CSS-class substitution plus four theme lookup records. The new `data-testid` props are passive and safe to leave in place if a partial revert is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq7TV7zE82wcNUWvFeGMim)_