### PR TITLE
[CUR-103] Scope print CSS to Export modal

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -153,6 +153,10 @@ body {
 }
 
 /* Print styles */
+/* CUR-103: scope the card-only print rules to when the Export modal is open.
+   `#card-preview` only exists while `<ExportModal data-export-modal>` is
+   mounted; without the scope, Ctrl/Cmd+P on any other screen hides everything
+   and prints a blank sheet. */
 @media print {
   * {
     -webkit-print-color-adjust: exact !important;
@@ -164,18 +168,18 @@ body {
     padding: 0 !important;
     background: white !important;
   }
-  body * {
+  body:has([data-export-modal]) * {
     visibility: hidden !important;
   }
-  body *:not(#card-preview):not(#card-preview *) {
+  body:has([data-export-modal]) *:not(#card-preview):not(#card-preview *) {
     background: transparent !important;
     backdrop-filter: none !important;
   }
-  #card-preview,
-  #card-preview * {
+  body:has([data-export-modal]) #card-preview,
+  body:has([data-export-modal]) #card-preview * {
     visibility: visible !important;
   }
-  #card-preview {
+  body:has([data-export-modal]) #card-preview {
     position: fixed !important;
     left: 50% !important;
     top: 10mm !important;

--- a/tests/unit/printCssScope.regression.test.ts
+++ b/tests/unit/printCssScope.regression.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Regression: CUR-103 — global `@media print` rules unconditionally hid every
+// element outside `#card-preview`, which only exists while the Export modal is
+// open. Ctrl/Cmd+P anywhere else printed a blank sheet. The rules must be
+// scoped to `body:has([data-export-modal])` so normal pages fall back to the
+// browser default print rendering.
+
+const REPO_ROOT = resolve(__dirname, '../..');
+const SCOPE = 'body:has([data-export-modal])';
+
+const readSource = (relativePath: string) => readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+
+/** Collapse whitespace so the assertion tolerates Prettier reflow. */
+const normalise = (text: string) => text.replace(/\s+/g, ' ');
+
+describe('print stylesheet scope (CUR-103)', () => {
+  const css = normalise(readSource('src/index.css'));
+
+  it('scopes the visibility-hidden rule to the Export modal so other screens print normally', () => {
+    expect(css).toContain(`${SCOPE} * { visibility: hidden !important; }`);
+  });
+
+  it('scopes the #card-preview visibility + layout overrides to the Export modal', () => {
+    // Both "make the card visible" and "pin the card at the print origin" must
+    // live behind the same scope; otherwise the card selector matches nothing
+    // and the scope has no anchor.
+    expect(css).toContain(`${SCOPE} #card-preview, ${SCOPE} #card-preview *`);
+    expect(css).toMatch(
+      new RegExp(
+        `${SCOPE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} #card-preview \\{[^}]*position: fixed`,
+      ),
+    );
+  });
+
+  it('keeps `data-export-modal` on the ExportModal root as the scope anchor', () => {
+    // The CSS scope resolves via this attribute; renaming it silently breaks
+    // print from the modal, which is why the guard lives beside the CSS check.
+    const source = readSource('src/components/ExportModal.tsx');
+    expect(source).toMatch(/data-export-modal(\s|>|=)/);
+  });
+});


### PR DESCRIPTION
## Problem

The global `@media print` block in `src/index.css` hides every element outside `#card-preview`, but `#card-preview` only exists while the Export modal is mounted. So `Ctrl/Cmd+P` (or the browser print menu) on Home, a collection page, or an item detail prints a **blank sheet** with no in-app cue that print is only supported through the export card. This reads as the app being broken — a **trust** regression against Curio's "explicit outcomes" principle.

## Approach

Wrap the card-only print rules in `body:has([data-export-modal])` so they only apply while the Export modal is mounted. The modal root already carries `data-export-modal` (`src/components/ExportModal.tsx:519`), so the scope needs no new plumbing.

Also add `tests/unit/printCssScope.regression.test.ts` — a small unit-level guard that reads `src/index.css` + `ExportModal.tsx` to catch two silent-drift modes: someone removing the scope selector, or renaming the `data-export-modal` anchor and leaving the CSS aimed at nothing.

## Why this approach

Smallest possible fix. `:has()` is supported in every evergreen browser (Curio already ships as a modern-only PWA), so no JS toggle or body-class dance is needed. The CSS-file regression test is the tightest guard you can write without a real browser + `emulateMedia('print')` harness — it survives Prettier reflow via a normalised whitespace check.

## Risks

Low (Green tier, CSS-only). Two paths to think about:

- **Print from the Export modal** — selector list is unchanged, still `body:has(...)`, but the modal is always mounted when the user presses Print in the export sheet, so the scope resolves and the rules apply exactly as before. Verified via the compiled bundle (`grep body:has\(\[data-export-modal\]\) dist/assets/*.css` → 5 hits).
- **Print anywhere else** — no card-only overrides applied, browser default rendering wins. Only the harmless `-webkit-print-color-adjust` and `html, body { margin: 0 }` reset stays unscoped, which matches the intent.

## How to verify

Vercel Preview: _auto-deployed on this PR_

Steps:
1. Open the Vercel preview on the sample gallery. Press `Ctrl/Cmd+P` on the Home screen. The print preview should show the actual page (was blank before this change).
2. Repeat on a collection page and on an item detail page — same result.
3. Open the item detail Export modal (printer icon), press **Print**. The print preview should show only the card at 80mm width, exactly as before.
4. Close the modal, press `Ctrl/Cmd+P` again — normal page renders.

Checks:
- [x] `npm run format:check`
- [x] `npm test` — 55 files, 806 passed, 2 skipped, 1 todo (incl. 3 new for CUR-103)
- [x] `npm run build` — passed (5 scoped selectors present in dist CSS)
- [x] `npm run test:e2e` — 40 passed, 6 skipped (chromium + mobile-chrome)

## Screenshot / GIF

CSS-only fix; behaviour is visible only in the print dialog, which the preview URL exercises via the verification steps above.

## Linear

Closes CUR-103

## Rollback plan

Single-commit revert restores the unscoped print block exactly as it was:

```
git revert 79c54cc
```

No schema, storage, RLS, env-var, feature-flag, or dependency changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEUE3VnBfHjBpTbzvgEwRY)_