### PR TITLE
[CUR-139] Show Last updated date on Privacy / Terms pages

### DIFF
--- a/src/components/LegalPage.tsx
+++ b/src/components/LegalPage.tsx
@@ -24,12 +24,19 @@ const TERMS_SECTIONS: Section[] = [
   { titleKey: 'legalTermsAvailabilityTitle', bodyKey: 'legalTermsAvailabilityBody' },
 ];
 
+// Bump these whenever the corresponding copy above/below is materially changed
+// so returning users can see the policy is a different revision.
+const LEGAL_LAST_UPDATED: Record<LegalDoc, string> = {
+  privacy: '2026-07-03',
+  terms: '2026-07-03',
+};
+
 const isLegalDoc = (value: string | undefined): value is LegalDoc =>
   value === 'privacy' || value === 'terms';
 
 export const LegalPage: React.FC = () => {
   const { doc } = useParams<{ doc: string }>();
-  const { t } = useTranslation();
+  const { t, language } = useTranslation();
   const { theme } = useTheme();
 
   const resolvedDoc: LegalDoc = isLegalDoc(doc) ? doc : 'privacy';
@@ -83,6 +90,25 @@ export const LegalPage: React.FC = () => {
             </span>
           </div>
           <h1 className={typographyClasses.titleLarge}>{t(titleKey)}</h1>
+          {(() => {
+            const iso = LEGAL_LAST_UPDATED[resolvedDoc];
+            const parsed = new Date(`${iso}T00:00:00Z`);
+            const locale = language === 'zh' ? 'zh-CN' : 'en-US';
+            const formatted = Number.isNaN(parsed.getTime())
+              ? iso
+              : new Intl.DateTimeFormat(locale, {
+                  dateStyle: 'long',
+                  timeZone: 'UTC',
+                }).format(parsed);
+            return (
+              <p className={`${typographyClasses.labelMuted} ${mutedClass}`}>
+                {t('legalLastUpdatedLabel')}{' '}
+                <time dateTime={iso} data-testid="legal-last-updated">
+                  {formatted}
+                </time>
+              </p>
+            );
+          })()}
           <p className={`${typographyClasses.body} ${mutedClass}`}>{t(introKey)}</p>
         </div>
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -480,6 +480,7 @@ export const translations = {
     signupLegalConsentTail: '.',
     legalBackToCurio: 'Back to Curio',
     legalDraftBadge: 'Beta — plain-language summary',
+    legalLastUpdatedLabel: 'Last updated',
     legalPrivacyIntro:
       'Curio is in early development. A formal policy will arrive before general availability. In the meantime, here is what we actually do with your data today.',
     legalPrivacyDataTitle: 'What we store',
@@ -969,6 +970,7 @@ export const translations = {
     signupLegalConsentTail: '。',
     legalBackToCurio: '返回 Curio',
     legalDraftBadge: '测试版 · 简明说明',
+    legalLastUpdatedLabel: '最近更新',
     legalPrivacyIntro:
       'Curio 仍在早期开发阶段，正式政策将在公开发布前推出。这里先说明我们目前如何处理您的数据。',
     legalPrivacyDataTitle: '我们保存什么',

--- a/tests/components/LegalPage.test.tsx
+++ b/tests/components/LegalPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { LanguageProvider } from '@/i18n';
@@ -18,6 +18,10 @@ function renderAtPath(path: string) {
     </MemoryRouter>,
   );
 }
+
+afterEach(() => {
+  window.localStorage.clear();
+});
 
 describe('LegalPage (CUR-57)', () => {
   it('renders the Privacy Policy at /legal/privacy with all summary sections', () => {
@@ -57,5 +61,39 @@ describe('LegalPage (CUR-57)', () => {
   it('falls back to the Privacy doc when the param is unknown', () => {
     renderAtPath('/legal/something-else');
     expect(screen.getByTestId('legal-page-privacy')).toBeInTheDocument();
+  });
+});
+
+describe('LegalPage last-updated date (CUR-139)', () => {
+  it('renders a machine-readable Last updated time on the Privacy page in EN', () => {
+    renderAtPath('/legal/privacy');
+    const timeEl = screen.getByTestId('legal-last-updated');
+    expect(timeEl.tagName).toBe('TIME');
+    expect(timeEl).toHaveAttribute('datetime');
+    expect(timeEl.getAttribute('datetime')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    // Label appears alongside the time so users know what the date means.
+    expect(screen.getByText(/last updated/i)).toBeInTheDocument();
+  });
+
+  it('renders a machine-readable Last updated time on the Terms page in EN', () => {
+    renderAtPath('/legal/terms');
+    const timeEl = screen.getByTestId('legal-last-updated');
+    expect(timeEl.tagName).toBe('TIME');
+    expect(timeEl).toHaveAttribute('datetime');
+    expect(timeEl.getAttribute('datetime')).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('localises the Last updated label to Chinese when the ZH locale is active', () => {
+    window.localStorage.setItem('curio_language', 'zh');
+    renderAtPath('/legal/privacy');
+    const timeEl = screen.getByTestId('legal-last-updated');
+    expect(timeEl).toHaveAttribute('datetime');
+    expect(screen.getByText(/最近更新/)).toBeInTheDocument();
+  });
+
+  it('keeps the Beta / plain-language summary badge alongside the date', () => {
+    renderAtPath('/legal/privacy');
+    expect(screen.getByText(/beta — plain-language summary/i)).toBeInTheDocument();
+    expect(screen.getByTestId('legal-last-updated')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem

The Legal pages at `/legal/privacy` and `/legal/terms` (linked inline from the AuthModal sign-up consent line and from the profile menu) rendered a "Beta — plain-language summary" badge and an intro that promises a formal policy later, but no visible revision date. Users clicking through to accept those policies during sign-up had no way to tell which draft they were agreeing to, and returning users had no way to notice when the copy changed. This weakens the "Trust before growth" product principle and puts us out of step with the standard "Last updated" cue expected by privacy-conscious users.

## Approach

- Add a single translation key `legalLastUpdatedLabel` in EN (`Last updated`) and ZH (`最近更新`).
- In `src/components/LegalPage.tsx`, source the effective date from a single `Record<LegalDoc, string>` (`LEGAL_LAST_UPDATED`) so the two pages cannot drift, and render a machine-readable `<time datetime="YYYY-MM-DD">` right under the page title.
- Format the visible date with `Intl.DateTimeFormat` in the current locale (mirroring the existing "added on" pattern in Item Detail) and force UTC to keep the label stable across viewer timezones.
- Style it with the existing `typographyClasses.labelMuted` + `mutedTextClasses[theme]` so the date supplements — not competes with — the section titles across all three themes.
- Extend `tests/components/LegalPage.test.tsx` with a `CUR-139` group asserting the `time` element and its `datetime` attribute exist for both docs, and that the label localises to ZH.

## Why this approach

Adding a maintainable per-doc date and a translated label is the minimum change that satisfies "users can tell which version they agreed to" without leaking a whole date-versioning system into the codebase. Keeping the Beta badge alongside the date preserves the honest "this is still a draft" framing while adding a version cue AT users and returning users can actually see. The `Intl.DateTimeFormat` reuse and existing typography tokens keep the addition invisible to Curio's tone.

## Risks

Low. The change is content-only, touches one component and one translations file, and is covered by tests. Risk is a stale date if the maintainer changes policy copy without bumping the constant — mitigated with a code comment right above `LEGAL_LAST_UPDATED`.

## How to verify

Vercel Preview: https://curio-git-claude-curio-139-legal-la-45d3ae-qs-projects-72b20d9d.vercel.app

Steps:
1. Open `#/legal/privacy` in each theme (gallery / vault / atelier). A muted, uppercase "Last updated <long-date>" line appears under the page title, with a `<time datetime="2026-07-03">` element in the DOM.
2. Repeat for `#/legal/terms` — same treatment, same date source.
3. Switch language to 中文 in the header. The label reads "最近更新" and the date reformats to Chinese long form.
4. Confirm the Beta / plain-language summary badge remains in place.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (55 files, 821 passed)
- [x] `npm run build`
- [x] `npm run test:e2e` (40 passed)

## Screenshot / GIF

_Static content addition; screenshot capture blocked in this headless environment. Verify visually on the Vercel Preview above._

## Linear

Closes CUR-139

## Rollback plan

Green tier — no rollback plan required. Revert the single commit if the date treatment needs redesign: `git revert 8d2a828`.
