### PR TITLE
[CUR-138] Expose bottom-nav active tab to screen readers

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -460,6 +460,7 @@ export const Layout: React.FC<LayoutProps> = ({
           <div className={`grid ${exploreTo ? 'grid-cols-4' : 'grid-cols-3'} items-center w-full`}>
             <Link
               to="/"
+              aria-current={location.pathname === '/' ? 'page' : undefined}
               className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${location.pathname === '/' ? 'text-amber-500' : bottomNavMuted}`}
             >
               <Home size={22} />
@@ -470,6 +471,7 @@ export const Layout: React.FC<LayoutProps> = ({
               <Link
                 to={exploreTo}
                 onClick={onExploreSamples}
+                aria-current={isExploreActive ? 'page' : undefined}
                 className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
               >
                 <Compass size={22} />

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -936,6 +936,68 @@ describe('Layout Component', () => {
     });
   });
 
+  // CUR-138: Bottom-nav Home / Explore links were flagged as active only via
+  // color (text-amber-500) with no programmatic signal, so screen readers
+  // could not tell which tab was the current page. Pin aria-current="page"
+  // on the active tab and its absence on inactive tabs and non-page buttons.
+  describe('CUR-138 Bottom-nav aria-current', () => {
+    const findBottomNav = () => screen.getByRole('navigation', { name: /primary/i });
+
+    beforeEach(() => {
+      window.location.hash = '#/';
+    });
+
+    it('marks the Home link as the current page on Home', () => {
+      renderWithProviders(<Layout {...defaultProps} sampleCollectionId="sample-vinyl-1" />);
+
+      const nav = findBottomNav();
+      const homeLink = within(nav).getByRole('link', { name: /home/i });
+      expect(homeLink).toHaveAttribute('aria-current', 'page');
+
+      const exploreLink = within(nav).getByRole('link', { name: /explore/i });
+      expect(exploreLink).not.toHaveAttribute('aria-current');
+    });
+
+    it('marks the Explore link as the current page while browsing the sample collection', () => {
+      window.location.hash = '#/collection/sample-vinyl-1';
+      renderWithProviders(<Layout {...defaultProps} sampleCollectionId="sample-vinyl-1" />);
+
+      const nav = findBottomNav();
+      const exploreLink = within(nav).getByRole('link', { name: /explore/i });
+      expect(exploreLink).toHaveAttribute('aria-current', 'page');
+
+      const homeLink = within(nav).getByRole('link', { name: /home/i });
+      expect(homeLink).not.toHaveAttribute('aria-current');
+    });
+
+    it('leaves both tabs uncurrent when the route is neither Home nor the sample collection', () => {
+      window.location.hash = '#/collection/other-user-collection';
+      renderWithProviders(<Layout {...defaultProps} sampleCollectionId="sample-vinyl-1" />);
+
+      const nav = findBottomNav();
+      expect(within(nav).getByRole('link', { name: /home/i })).not.toHaveAttribute('aria-current');
+      expect(within(nav).getByRole('link', { name: /explore/i })).not.toHaveAttribute(
+        'aria-current',
+      );
+    });
+
+    it('does not set aria-current on the Add or Profile trigger buttons', () => {
+      renderWithProviders(
+        <Layout
+          {...defaultProps}
+          user={{ id: 'user-1', email: 'test@example.com' }}
+          sampleCollectionId="sample-vinyl-1"
+        />,
+      );
+
+      const nav = findBottomNav();
+      const addButton = within(nav).getByText('Add').closest('button');
+      const profileButton = within(nav).getByText('Profile').closest('button');
+      expect(addButton).not.toHaveAttribute('aria-current');
+      expect(profileButton).not.toHaveAttribute('aria-current');
+    });
+  });
+
   describe('Accessibility', () => {
     it('has accessible account button with aria-label', () => {
       renderWithProviders(<Layout {...defaultProps} />);


### PR DESCRIPTION
## Problem

The mobile bottom nav in `src/components/Layout.tsx` (rendered on every mobile screen) signalled the active tab **visually only** — the current item flipped to `text-amber-500` while inactive items used `bottomNavMuted`. Neither the Home nor Explore `<Link>` set `aria-current`, so screen readers (VoiceOver, TalkBack, NVDA) had no programmatic signal for which tab is the current page and users had to guess or open each tab to reorient. Fails WCAG 2.1 SC 1.3.1 and mirrors the CUR-132 gap already fixed on ExhibitionView pagination.

Protects **trust before growth** — assistive-tech users deserve the same "you are here" clarity sighted users get from the amber tint.

## Approach

- Set `aria-current="page"` on the bottom-nav Home link when `location.pathname === '/'`.
- Set `aria-current="page"` on the bottom-nav Explore link when `isExploreActive` is true (`/explore` or the sample-collection root).
- Leave the Add and Profile trigger buttons untouched — they open sheets, not pages, and keep their existing `aria-haspopup` / `aria-expanded` semantics.

## Why this approach

This is the minimal fix the acceptance criteria asked for and matches the CUR-132 precedent already accepted in this codebase. `aria-current="page"` is the standard hook screen readers announce as "current page"; no new components, tokens, or state are needed. Add/Profile intentionally stay off `aria-current` because they aren't pages.

## Risks

Low. Pure attribute addition on two `<Link>` elements — no visual, layout, or behavior change for sighted users. No dependency, style, or state changes. Screen-reader manual confirmation is the one thing this environment can't run.

## How to verify

Vercel Preview: https://curio-git-claude-happy-planck-utes72-qs-projects-72b20d9d.vercel.app

Steps:
1. On a mobile-width viewport, load Home and inspect the bottom nav's Home link — it should have `aria-current="page"`.
2. Tap Explore; on the sample collection, the Explore link should have `aria-current="page"` and Home should not.
3. With VoiceOver (iOS Safari) or TalkBack (Chrome Android), swipe through the bottom-nav landmark — the active tab should announce "current page".
4. Add and Profile buttons should never carry `aria-current`.

Checks:
- [x] `npm run format:check`
- [x] `npm test` (825 passed, 2 skipped, 1 todo)
- [x] `npm run build`
- [x] `npm run test:e2e` (40 passed, 6 intentional skips)

## Screenshot / GIF

No visual change — this is a pure ARIA attribute audit. Sighted state remains the existing amber-tinted text.

## Linear

Closes CUR-138

## Rollback plan

Green tier, but if needed: `git revert 08e4644` on `main`. The change is two attribute additions plus one Vitest describe block; no data, no schema, no config.
