### PR TITLE
[CUR-42] Bring ExportModal up to the shared modal accessibility standard

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -4,6 +4,7 @@ import { toBlob } from 'html-to-image';
 import { CollectionItem, FieldDefinition } from '../types';
 import { Button } from './ui/Button';
 import { extractCurioAssetPath, getAsset, getEnhancedAsset } from '../services/db';
+import { useModalA11y } from '../hooks/useModalA11y';
 import { useTranslation } from '../i18n';
 import { trackEvent } from '../services/analytics';
 import type { StatusTone } from './StatusToast';
@@ -63,6 +64,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   const [exportError, setExportError] = useState<string | null>(null);
   const [dragHeight, setDragHeight] = useState<number | null>(null);
   const cardRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const dragStateRef = useRef<{
     startY: number;
@@ -70,6 +72,9 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     pointerId: number;
     moved: boolean;
   } | null>(null);
+  // CUR-42: same dialog primitive as every other modal — Escape-to-close,
+  // focus trap, initial focus, and focus restore back to the export trigger.
+  useModalA11y(dialogRef, isOpen, onClose);
   const remoteAssetPath = useMemo(() => {
     if (!item.photoUrl || item.photoUrl === 'asset') return null;
     const extracted = extractCurioAssetPath(item.photoUrl);
@@ -522,6 +527,10 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   return (
     <div
       data-export-modal
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="export-modal-title"
       className={`fixed inset-0 z-50 bg-stone-950/90 backdrop-blur-md animate-in fade-in duration-200 print:bg-white print:static print:block print:inset-auto print:h-auto print:overflow-visible overflow-hidden pt-[env(safe-area-inset-top,0px)] pl-[env(safe-area-inset-left,0px)] pr-[env(safe-area-inset-right,0px)]`}
       style={
         {
@@ -574,7 +583,9 @@ export const ExportModal: React.FC<ExportModalProps> = ({
         </div>
         <div className="px-6 pb-4 md:pt-6 border-b border-stone-100 flex justify-between items-center shrink-0">
           <div>
-            <h2 className="font-serif font-bold text-xl text-stone-900">{t('exportCard')}</h2>
+            <h2 id="export-modal-title" className="font-serif font-bold text-xl text-stone-900">
+              {t('exportCard')}
+            </h2>
           </div>
           <button
             onClick={onClose}

--- a/src/hooks/useModalA11y.ts
+++ b/src/hooks/useModalA11y.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from 'react';
 
+// `tabindex="-1"` elements are skipped by native Tab order, so they must not
+// become trap boundaries or receive initial focus either — e.g. ExportModal's
+// aria-hidden tap-to-collapse overlay is a <button tabindex="-1">.
 const FOCUSABLE_SELECTOR =
-  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  'button:not([disabled]):not([tabindex="-1"]), [href]:not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), select:not([disabled]):not([tabindex="-1"]), textarea:not([disabled]):not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
 
 interface UseModalA11yOptions {
   /**

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -172,6 +172,50 @@ describe('ExportModal — CUR-100 Print disabled while photo loading', () => {
   });
 });
 
+describe('ExportModal — CUR-42 dialog semantics', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when closed', () => {
+    renderWithProviders(<ExportModal {...baseProps} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders as a labelled dialog', () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'export-modal-title');
+    expect(document.getElementById('export-modal-title')).toHaveTextContent(/export card/i);
+  });
+
+  it('closes on Escape', async () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('gives initial focus to the Close button, not the aria-hidden tap-to-collapse overlay', async () => {
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /close/i }));
+  });
+});
+
 describe('ExportModal — CUR-105 mobile sheet opens expanded', () => {
   const baseProps = {
     isOpen: true,

--- a/tests/hooks/useModalA11y.test.tsx
+++ b/tests/hooks/useModalA11y.test.tsx
@@ -93,6 +93,33 @@ describe('useModalA11y', () => {
     unmount();
   });
 
+  it('skips tabindex="-1" elements for initial focus and trap boundaries (e.g. ExportModal tap-to-collapse overlay)', async () => {
+    // Native Tab order never visits tabindex="-1" elements, so the trap must
+    // not use them as boundaries either — otherwise Shift+Tab from the real
+    // first control escapes the dialog instead of wrapping.
+    function OverlayHarness() {
+      const dialogRef = useRef<HTMLDivElement>(null);
+      useModalA11y(dialogRef, true, () => {});
+      return (
+        <div ref={dialogRef} role="dialog" aria-modal="true">
+          <button data-testid="overlay" aria-hidden="true" tabIndex={-1}>
+            collapse
+          </button>
+          <button data-testid="close">close</button>
+          <button data-testid="action">action</button>
+        </div>
+      );
+    }
+    const { unmount } = render(<OverlayHarness />);
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(document.activeElement).toBe(screen.getByTestId('close'));
+
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByTestId('action'));
+    unmount();
+  });
+
   it('focuses initialFocusRef when provided (safe action on confirm modals)', async () => {
     const onClose = vi.fn();
     render(<Harness isOpen={true} onClose={onClose} useInitialFocus />);


### PR DESCRIPTION
## Problem

CUR-42 asks for consistent modal accessibility (Escape, focus trap, dialog semantics) across the audit list. Everything on that list is already covered except **ExportModal** — the one modal with no `role="dialog"`, no `aria-modal`, no `aria-labelledby`, no Escape-to-close, no focus trap, and no focus restore. A keyboard or screen-reader user who opens the export card from Item Detail lands in an unlabelled region they can Tab straight out of and can only leave by finding the X button.

Protects **trust before growth** and **sharing before social complexity**: exporting a card is the core sharing gesture, and it should work for everyone.

## Approach

- Wire `ExportModal` into the existing `useModalA11y` hook (Escape-to-close, focus trap, initial focus, focus restore) and add `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing at the Export Card title — the exact pattern every other modal uses.
- Fix a latent gap this exposed in the shared hook: its focusable selector counted `tabindex="-1"` buttons, but native Tab order skips those. ExportModal's aria-hidden tap-to-collapse overlay (CUR-105) is exactly such a button — without the fix it would have received initial focus and broken the Shift+Tab wrap boundary on mobile. The selector now excludes `tabindex="-1"` elements everywhere, matching real tab order.
- Tests: 4 new ExportModal tests (closed = no dialog, labelled dialog, Escape closes, initial focus lands on Close rather than the aria-hidden overlay) and 1 new `useModalA11y` test pinning the tabindex="-1" exclusion.

## Why this approach

The shared hook already exists and is adopted by all seven other hook-based modals, so ExportModal joining it is the smallest change that closes the audit list. Fixing the selector in the hook rather than special-casing ExportModal makes the trap correct for any future modal with a decorative focus-excluded control. No visual change of any kind.

## Risks

Low. The selector change only removes `tabindex="-1"` elements from trap boundaries / initial focus — elements native Tab already skips — and the full unit + e2e suites pass. Escape-to-close is new behavior for ExportModal, consistent with every other modal.

## How to verify

Vercel Preview: https://curio-git-claude-eloquent-meitner-aauoxj-qs-projects-72b20d9d.vercel.app

Steps:

1. Open any item in the Vinyl Vault sample → tap the export icon.
2. Press **Escape** — the modal closes and focus returns to the export trigger.
3. Reopen it; initial focus is on the **Close** button, and Tab / Shift+Tab cycle stays inside the modal (previously it walked into the page behind the overlay).
4. With VoiceOver/NVDA, the surface announces as an "Export Card" dialog.

Checks:

- [x] `npm run format:check`
- [x] `npm test` (869 passed, 2 skipped, 1 todo)
- [x] `npm run build`
- [x] `npm run test:e2e` (42 passed, 6 intentional skips)

## Screenshot / GIF

No visual change — markup semantics and keyboard behavior only.

## Linear

Closes CUR-42

## Rollback plan

`git revert a01753f` on `main`. One component, one hook, two test files — no schema, storage, config, or sync surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTFvxvsFpKeV41FP5VrFUf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTFvxvsFpKeV41FP5VrFUf)_