### PR TITLE
Fix save-item-with-photo: decode data URLs without fetch (CSP blocks connect-src data:)

### DIFF
--- a/src/services/imageProcessor.ts
+++ b/src/services/imageProcessor.ts
@@ -13,9 +13,26 @@ export class ImageProcessingError extends Error {
   }
 }
 
-const dataUrlToBlob = async (dataUrl: string): Promise<Blob> => {
-  const res = await fetch(dataUrl);
-  return await res.blob();
+// Decoded manually because fetch(data:) counts against CSP connect-src, which
+// deliberately does not allow data: — a fetch here fails on production and
+// takes the whole "save item with photo" path down with it.
+export const dataUrlToBlob = async (dataUrl: string): Promise<Blob> => {
+  const comma = dataUrl.indexOf(',');
+  if (!dataUrl.startsWith('data:') || comma === -1) {
+    throw new ImageProcessingError('Invalid data URL');
+  }
+  const meta = dataUrl.slice(5, comma);
+  const payload = dataUrl.slice(comma + 1);
+  const mime = meta.split(';')[0] || 'application/octet-stream';
+  if (/(^|;)base64$/i.test(meta)) {
+    const binary = atob(payload);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new Blob([bytes], { type: mime });
+  }
+  return new Blob([decodeURIComponent(payload)], { type: mime });
 };
 
 const loadImageFromBlob = async (blob: Blob): Promise<HTMLImageElement> => {

--- a/tests/unit/services/dataUrlToBlob.regression.test.ts
+++ b/tests/unit/services/dataUrlToBlob.regression.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { dataUrlToBlob, ImageProcessingError } from '@/services/imageProcessor';
+
+// Regression test for the production CSP outage: connect-src does not allow
+// data:, so any fetch(dataUrl) is blocked by the browser and "save item with
+// photo" fails with "Could not save image". dataUrlToBlob must therefore
+// decode data URLs without ever touching fetch.
+describe('dataUrlToBlob (CSP regression)', () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(() => {
+      throw new TypeError('Failed to fetch (blocked by connect-src CSP)');
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('decodes a base64 data URL without calling fetch', async () => {
+    // 1x1 transparent PNG
+    const base64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+    const blob = await dataUrlToBlob(`data:image/png;base64,${base64}`);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(blob.type).toBe('image/png');
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    // PNG signature: 89 50 4E 47
+    expect([...bytes.slice(0, 4)]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it('decodes a URL-encoded (non-base64) data URL', async () => {
+    const blob = await dataUrlToBlob('data:text/plain,hello%20world');
+    expect(blob.type).toBe('text/plain');
+    expect(await blob.text()).toBe('hello world');
+  });
+
+  it('rejects non-data URLs instead of falling back to fetch', async () => {
+    await expect(dataUrlToBlob('https://example.com/a.jpg')).rejects.toBeInstanceOf(
+      ImageProcessingError,
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Adding an item **with a photo is currently broken on production** (https://curio.qiuyue.dev). The save fails with *"Could not save image. Please try again."* and retrying never helps.

Root cause: the CSP introduced in fb38557 sets `connect-src 'self' https://*.supabase.co …` **without `data:`**, while `imageProcessor.ts` converts the captured photo via `fetch(dataUrl)`. The browser blocks that fetch (`Refused to connect to 'data:image/jpeg;base64,…' because it violates … connect-src`), `processImage` throws, and `handleSave` aborts the whole item save. The same block makes `compressImageForAi` fall back to raw base64 with console errors on every AI analysis.

Reproduced today in a real Chromium session against production: Add Item → upload photo → AI verify → Save → amber "Could not save image" banner, item never created.

## Fix

Decode the data URL manually in `dataUrlToBlob` (`atob` for base64 payloads, `decodeURIComponent` otherwise) instead of round-tripping through `fetch`. No CSP loosening needed; non-`data:` inputs (https/blob object URLs fetched elsewhere) are untouched.

## Tests

- New regression test `tests/unit/services/dataUrlToBlob.regression.test.ts`: stubs `global.fetch` to throw exactly like the CSP block and asserts base64 + URL-encoded data URLs still decode, and that non-data URLs reject instead of silently falling back to fetch.
- `npm run format:check` ✓, `npm test` (867 passed) ✓, `npm run build` ✓, `npm run test:e2e` (42 passed) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgytTyGtcV43ADzLFvMug8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgytTyGtcV43ADzLFvMug8)_