### PR TITLE
Show localized fallback message instead of raw AI error status

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -612,7 +612,10 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
           locale: language,
         });
         if (result.status !== 'success') {
-          setError(result.status === 'error' ? result.message : t('analysisFallback'));
+          if (result.status === 'error') {
+            console.warn('AI analysis failed:', result.message);
+          }
+          setError(t('analysisFallback'));
           hadError = true;
           analyzed.push(createBatchItem(image, existingIds[idx] ? { id: existingIds[idx] } : {}));
           continue;
@@ -775,7 +778,10 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
         locale: language,
       });
       if (result.status !== 'success') {
-        setError(result.status === 'error' ? result.message : t('analysisFallback'));
+        if (result.status === 'error') {
+          console.warn('AI analysis failed:', result.message);
+        }
+        setError(t('analysisFallback'));
         setAnalysisError(true);
         setStep('verify');
         return;


### PR DESCRIPTION
## Summary
- A user reported seeing a raw `AI request failed (413)` error in the batch "Add items" flow (photo too large for the AI analyze endpoint).
- Root cause: `AddItemModal.tsx` showed the raw technical `Error` message from `analyzeImage()` directly in the UI whenever the AI call failed with a network/HTTP error, bypassing the existing localized fallback copy (`analysisFallback`) used everywhere else in the same component.
- Fix: log the raw error to console for debugging, and always show the translated `analysisFallback` message to the user in both the single-item and batch analysis flows. The item itself was already preserved for manual entry in this case (per the "Recoverable AI" product constraint) — this only fixes the confusing error text.

## Test plan
- [x] `npm run format:write` / `npm run format:check`
- [x] `npm test` (864 passed)
- [x] `npm run build`
- [x] `npm run test:e2e` (42 passed, 6 skipped)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BBgXPFZdmqTiwoGgzgeC14)_