### PR TITLE
[CUR-142] Keep Add Item Save clickable on desktop — flex-size the verify panel

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1495,12 +1495,16 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
             </button>
           </div>
 
-          <div className="relative flex-1 min-h-0">
+          {/* The desktop dialog is sm:h-auto (indefinite height), so percentage
+              heights inside this panel never resolve — h-full falls back to
+              content height and paints over the footer, making Save
+              unclickable (CUR-142). Size children with flex instead. */}
+          <div className="relative flex-1 min-h-0 flex flex-col">
             {confirmingDiscard ? (
               <div
                 ref={confirmRef}
                 data-testid="add-item-discard-confirm"
-                className="h-full flex flex-col items-center justify-center text-center p-6 sm:p-8"
+                className="flex-1 flex flex-col items-center justify-center text-center p-6 sm:p-8"
               >
                 <div
                   className={`p-2.5 rounded-full mb-4 ${
@@ -1551,7 +1555,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
                   ref={scrollRef}
                   data-testid="add-item-scroll"
                   onScroll={updateScrollAffordance}
-                  className="h-full overflow-y-auto p-5 pb-6 sm:p-8 overscroll-contain"
+                  className="flex-1 min-h-0 overflow-y-auto p-5 pb-6 sm:p-8 overscroll-contain"
                 >
                   <div ref={scrollContentRef} className="space-y-6">
                     {step === 'select-type' && renderCollectionSelect()}

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -581,6 +581,42 @@ describe('AddItemModal', () => {
     expect(fade.className).toContain('opacity-0');
   });
 
+  it('sizes the verify-step scroll panel with flex, never percentage heights (CUR-142)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AddItemModal
+        isOpen
+        onClose={mockOnClose}
+        collections={[createMockCollection()]}
+        onSave={mockOnSave}
+      />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: 'Skip and add manually' }));
+
+    const scroller = screen.getByTestId('add-item-scroll');
+    const panel = scroller.parentElement!;
+
+    // The desktop dialog is sm:h-auto, so its height is indefinite and h-full
+    // on the scroller resolves to content height — the panel then paints over
+    // the Save footer and clicks land on the rating stars. Both levels must
+    // size via flex so the footer always stays below the scroll area.
+    expect(panel.className).toContain('flex-col');
+    expect(panel.className).toContain('min-h-0');
+    expect(scroller.className).not.toContain('h-full');
+    expect(scroller.className).toContain('flex-1');
+    expect(scroller.className).toContain('min-h-0');
+
+    // The Save footer is a sibling below the scroll panel, not content inside
+    // it — the structural guarantee that it cannot be covered by overflow.
+    const saveButton = screen.getByRole('button', { name: /save without story/i });
+    expect(scroller.contains(saveButton)).toBe(false);
+    expect(panel.contains(saveButton)).toBe(false);
+    expect(
+      panel.compareDocumentPosition(saveButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   describe('discard confirmation (CUR-80)', () => {
     it('closes immediately when the user has no work in progress on the verify step', async () => {
       const user = userEvent.setup();

--- a/tests/e2e/authenticated-user.spec.ts
+++ b/tests/e2e/authenticated-user.spec.ts
@@ -66,4 +66,48 @@ test.describe('Authenticated User Experience', () => {
     await expect(page.getByTestId('status-toast')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('status-toast-message')).toContainText(/saved/i);
   });
+
+  test('keeps Save clickable on desktop when the verify fields overflow (CUR-142)', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, 'Desktop-only regression — the mobile dialog has a definite height');
+
+    // Short desktop viewport so the verify fields panel is guaranteed to
+    // overflow the dialog (the CUR-142 geometry: panel taller than its
+    // parent, previously painting over the Save footer).
+    await page.setViewportSize({ width: 1280, height: 600 });
+
+    await expect(page.getByTestId('collections-grid')).toBeVisible({ timeout: 15000 });
+    await page.getByText(/start a collection/i).click();
+    await expect(page.getByTestId('create-collection-modal')).toBeVisible();
+    const name = `CUR-142 ${Date.now()}`;
+    await page.getByTestId('create-collection-name').fill(name);
+    await page.getByRole('button', { name: /create/i }).click();
+
+    await expect(page.getByText(name).first()).toBeVisible({ timeout: 15000 });
+    await page.getByText(name).first().click();
+
+    await page.getByRole('button', { name: /add item/i }).click();
+    await page.getByText(/skip and add manually/i).click();
+
+    await page.getByRole('textbox').first().fill('CUR-142 Item');
+    await page.getByRole('textbox').nth(1).fill('A story long enough to keep.');
+
+    // The regression only manifests when the scroll panel actually overflows.
+    const scroller = page.getByTestId('add-item-scroll');
+    await expect
+      .poll(() => scroller.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .toBeGreaterThan(0);
+
+    // Before the fix the panel covered the footer: this trial click failed
+    // with "subtree intercepts pointer events" and real clicks changed the
+    // item's rating instead of saving.
+    const save = page.getByRole('button', { name: /add to collection/i });
+    await save.click({ trial: true });
+    await save.click();
+
+    await expect(page.getByTestId('status-toast')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('status-toast-message')).toContainText(/saved/i);
+  });
 });


### PR DESCRIPTION
## Problem
On desktop (confirmed at 1280×800 and 1440×1000), the Add Item verify/batch-verify step's scrollable fields panel painted over the footer action bar: Save was 0% hit-testable and clicks aimed at it landed on the rating stars — silently changing the rating instead of saving. Desktop users could not complete the core "add your first item" flow. Protects **Trust before growth** and the 5-minute value promise.

Root cause: the desktop dialog is `sm:h-auto` (indefinite height), so the scroll container's `h-full` couldn't resolve as a percentage and fell back to content height (measured 788px inside a 538px parent), overflowing the unclipped `relative flex-1 min-h-0` wrapper and covering the footer sibling. Mobile was unaffected because its dialog height is definite (`h-[100dvh]`).

## Approach
- `src/components/AddItemModal.tsx`: size both levels with flex instead of percentage heights — the wrapper becomes a flex column (`relative flex-1 min-h-0 flex flex-col`) and the scroll container becomes `flex-1 min-h-0 overflow-y-auto` (the discard-confirm branch's `h-full` becomes `flex-1` for the same reason). Flex layout computes the used height directly, so it works whether the dialog height is definite (mobile) or indefinite (desktop). A short comment records the constraint.
- `tests/components/AddItemModal.test.tsx`: regression test locking the flex sizing (no `h-full` on the scroller, flex-col parent) and the structural guarantee that the Save footer is a sibling *below* the scroll panel. Verified it fails against the pre-fix source.
- `tests/e2e/authenticated-user.spec.ts`: desktop e2e that forces the fields panel to overflow (1280×600), asserts real overflow, then trial-clicks and clicks Save — before the fix this click failed with "subtree intercepts pointer events". Auth-gated like the rest of that spec (runs when `E2E_EMAIL`/`E2E_PASSWORD` are set; skipped in CI, which has no credentials).

## Why this approach
It's the smallest structural fix that removes the whole class of bug (percentage heights against an indefinite parent) rather than patching symptoms with `overflow-hidden`, which would have clipped fields unreachably instead. It matches the issue's recommended direction and changes three class strings, nothing else. Mobile renders the identical box it did before.

## Risks
Low-medium (touches AddItemModal layout). The flex chain is exercised on every step of the modal (select-type, upload, analyzing, verify, batch-verify, discard-confirm), so a sizing regression would be visible immediately; all 873 unit/component tests and the full local e2e suite pass. No data flow, sync, AI, or routing changes.

## How to verify
Vercel Preview: https://curio-git-claude-curio-142-add-item-dd147b-qs-projects-72b20d9d.vercel.app
Steps:
1. On a desktop viewport (1280×800), sign in → open a collection → Add Item.
2. Upload a photo (or "Skip and add manually"), reach the verify step.
3. The fields panel scrolls within its own area; the Save footer stays visible below it.
4. Click "Add to Collection" / "Save without story" — the item saves; the rating no longer changes from clicks aimed at Save.
5. On mobile (390×844), confirm the flow is unchanged.

Real-browser proof (this sandbox, Chromium against the compiled stylesheet, exact modal DOM at 1280×800):
- Before: scroller 656px inside a 554px panel, not scrollable, all 4 hit-test points over Save land on the overflowing content.
- After: scroller 554px, scrollable, Save fully hit-testable at all 4 points.

Checks:
- [x] npm run format:check
- [x] npm test (873 passed)
- [x] npm run build
- [x] npm run test:e2e (42 passed, 8 skipped — the 2 new skips are the cred-gated CUR-142 e2e on both projects)

## Screenshot / GIF
Before/after renders attached on the Linear issue (CUR-142) — this environment can't upload images to GitHub directly. Before shows the rating stars painting over the Save button; after shows the clean footer.

## Linear
Closes CUR-142

## Rollback plan
Single-commit revert: `git revert 2db89a4`. No schema, RLS, storage, env-var, or feature-flag changes.