### PR TITLE
[CUR-144] Let anonymous collection deep links through the access gate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1412,6 +1412,58 @@ export const AppContent: React.FC = () => {
       // initial cloud fetch is still in flight. Only redirect once loading
       // has settled and the id is genuinely absent.
       if (isLoading) return <CollectionScreenSkeleton label={t('restoringArchives')} />;
+      // CUR-144: a signed-out visitor following a dead or private link gets
+      // an explanation and a path onward (sign in / explore the sample)
+      // instead of silently landing back on the welcome card.
+      if (!user && isSupabaseReady) {
+        return (
+          <div
+            className="flex flex-col items-center justify-center px-4 py-16 sm:py-24"
+            data-testid="collection-unavailable"
+          >
+            <div
+              className={`max-w-md w-full text-center border rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl ${theme === 'vault' ? 'bg-white/5 border-white/10' : theme === 'atelier' ? 'bg-[#EDE4D3]/70 border-[#D4C9B8]' : 'bg-white/70 border-stone-200'}`}
+            >
+              <div
+                className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-white/10 text-stone-400' : theme === 'atelier' ? 'bg-[#D4C9B8]/50 text-[#8C7B6B]' : 'bg-stone-100 text-stone-500'}`}
+              >
+                <Landmark size={24} />
+              </div>
+              <h1
+                className={`font-serif text-2xl font-bold mb-2 ${theme === 'vault' ? 'text-white' : theme === 'atelier' ? 'text-[#3D3530]' : 'text-stone-900'}`}
+              >
+                {t('collectionUnavailableTitle')}
+              </h1>
+              <p
+                className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+              >
+                {t('collectionUnavailableDesc')}
+              </p>
+              <div className="space-y-2">
+                <Button
+                  onClick={() => setIsAuthModalOpen(true)}
+                  size="lg"
+                  className="w-full"
+                  data-testid="collection-unavailable-sign-in"
+                >
+                  {t('login')}
+                </Button>
+                {sampleCollectionId && (
+                  <Button
+                    onClick={() => navigate(`/collection/${sampleCollectionId}`)}
+                    size="lg"
+                    variant="secondary"
+                    className="w-full"
+                    data-testid="collection-unavailable-explore"
+                  >
+                    {t('exploreSample')}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      }
       return <Navigate to="/" replace />;
     }
 
@@ -2745,7 +2797,22 @@ export const AppContent: React.FC = () => {
   const showAccessGate = isSupabaseReady && !isAuthenticated && !allowPublicBrowse;
   const isExploreRoute = location.pathname === '/explore';
   const isLegalRoute = location.pathname.startsWith('/legal/');
-  const shouldShowAccessGate = showAccessGate && !isExploreRoute && !isLegalRoute;
+  // CUR-144: shared collection links are the product's sharing pillar — a
+  // signed-out visitor opening /collection/:id must reach the content (or
+  // CollectionScreen's not-available state), never the generic welcome gate
+  // rendered under the collection URL.
+  const isCollectionRoute = location.pathname.startsWith('/collection/');
+  const shouldShowAccessGate =
+    showAccessGate && !isExploreRoute && !isLegalRoute && !isCollectionRoute;
+  // A signed-out visitor who arrives on a collection deep link is already
+  // exploring, so latch public browsing — the same contract as the Explore
+  // CTAs (handleExploreSamples / handleExploreFromNav). Navigating Home from
+  // the shared collection then lands on the sample-aware Home, not the gate.
+  useEffect(() => {
+    if (isCollectionRoute && !allowPublicBrowse) {
+      setAllowPublicBrowse(true);
+    }
+  }, [isCollectionRoute, allowPublicBrowse]);
   const fallbackSampleCollectionId = fallbackSampleCollections[0]?.id ?? null;
   // Only expose a sample collection id that is actually present in `collections`.
   // The fallback sample is not part of merged cloud state for an authenticated

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1935,7 +1935,10 @@ export const AppContent: React.FC = () => {
       // the pending cloud response — without this guard, the shared link
       // would lose the item to the parent route before the fetch resolves.
       if (isLoading) return <ItemDetailSkeleton label={t('restoringArchives')} />;
-      if (!collection) return <Navigate to="/" replace />;
+      // CUR-144: when the whole collection is unknown, fall through to the
+      // collection route instead of straight to Home — for a signed-out
+      // visitor CollectionScreen renders the "isn't on view" explanation
+      // there (authed users continue to Home via its existing redirect).
       return <Navigate to={`/collection/${id}`} replace />;
     }
     const isReadOnly = Boolean(collection.isPublic) && !isAdmin;
@@ -2808,11 +2811,14 @@ export const AppContent: React.FC = () => {
   // exploring, so latch public browsing — the same contract as the Explore
   // CTAs (handleExploreSamples / handleExploreFromNav). Navigating Home from
   // the shared collection then lands on the sample-aware Home, not the gate.
+  // Latch only once auth has settled signed-out: a signed-in visit must not
+  // set the flag, or the welcome gate would stay suppressed after a later
+  // sign-out (Codex review on #340).
   useEffect(() => {
-    if (isCollectionRoute && !allowPublicBrowse) {
+    if (isCollectionRoute && authReady && !isAuthenticated && !allowPublicBrowse) {
       setAllowPublicBrowse(true);
     }
-  }, [isCollectionRoute, allowPublicBrowse]);
+  }, [isCollectionRoute, authReady, isAuthenticated, allowPublicBrowse]);
   const fallbackSampleCollectionId = fallbackSampleCollections[0]?.id ?? null;
   // Only expose a sample collection id that is actually present in `collections`.
   // The fallback sample is not part of merged cloud state for an authenticated

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -294,6 +294,9 @@ export const translations = {
     authRequiredDesc:
       'Capture, remember, and share the objects that define your taste. Add your first item to begin, or explore a sample first.',
     authRequiredAction: 'Sign In',
+    collectionUnavailableTitle: "This collection isn't on view",
+    collectionUnavailableDesc:
+      'It may be private, or its link may have changed. Sign in to see your own museum, or wander the sample gallery.',
     authLoading: 'Checking session...',
     authLoadingDesc: 'Verifying your account status.',
     cloudRequiredTitle: 'Cloud setup required',
@@ -799,6 +802,9 @@ export const translations = {
     accessGateTagline: '为你珍视之物打造的私人博物馆。',
     authRequiredDesc: '记录、珍藏并分享定义你品味的物件。添加第一件藏品即可开始，或先浏览示例。',
     authRequiredAction: '登录',
+    collectionUnavailableTitle: '此收藏暂未展出',
+    collectionUnavailableDesc:
+      '它可能是私密收藏，或链接已更改。登录查看你自己的博物馆，或先逛逛示例展馆。',
     authLoading: '正在检查登录状态...',
     authLoadingDesc: '正在确认您的账号状态。',
     cloudRequiredTitle: '需要云端配置',

--- a/tests/e2e/first-time-user.spec.ts
+++ b/tests/e2e/first-time-user.spec.ts
@@ -153,4 +153,19 @@ test.describe('Navigation and Routing', () => {
     }
     await expect(page).toHaveURL(/\/#\/?$/);
   });
+
+  // CUR-144: a shared collection link opened signed-out must render the
+  // collection under its own URL — never the welcome gate.
+  test('should render the sample collection from an anonymous deep link (CUR-144)', async ({
+    page,
+  }) => {
+    await page.goto('/#/collection/sample-vinyl');
+    await waitForAppReady(page);
+
+    await expect(page.getByRole('heading', { name: 'The Vinyl Vault' })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page).toHaveURL(/#\/collection\/sample-vinyl/);
+    await expect(page.getByTestId('access-gate')).toHaveCount(0);
+  });
 });

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -1040,6 +1040,120 @@ describe('App Integration Tests', () => {
     expect(screen.queryByTestId('collection-screen-skeleton')).not.toBeInTheDocument();
   });
 
+  // CUR-144: shared collection links are the sharing pillar. A signed-out
+  // visitor opening /collection/:id must reach the content — not the generic
+  // welcome gate rendered forever under the collection URL.
+  describe('anonymous collection deep links (CUR-144)', () => {
+    const publicSample = {
+      id: 'sample-vinyl',
+      name: 'The Vinyl Vault',
+      templateId: 'vinyl',
+      icon: '🎵',
+      customFields: [],
+      items: [
+        {
+          id: 'sample-item-1',
+          collectionId: 'sample-vinyl',
+          title: 'Kind of Blue',
+          rating: 5,
+          data: {},
+          photoUrl: '',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          notes: '',
+        },
+      ],
+      isPublic: true,
+      updatedAt: new Date().toISOString(),
+    };
+
+    beforeEach(() => {
+      vi.mocked(supabaseService.isSupabaseConfigured).mockReturnValue(true);
+      vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+        data: { session: null },
+      } as never);
+      vi.mocked(db.getLocalCollections).mockResolvedValue([]);
+      vi.mocked(db.fetchCloudCollections).mockResolvedValue([publicSample]);
+    });
+
+    it('renders the public sample collection instead of the access gate', async () => {
+      const { ThemeProvider } = await import('@/theme');
+
+      render(
+        <MemoryRouter initialEntries={['/collection/sample-vinyl']}>
+          <ThemeProvider>
+            <LanguageProvider>
+              <AppContent />
+            </LanguageProvider>
+          </ThemeProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'The Vinyl Vault' })).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('items-grid')).toBeInTheDocument();
+      expect(screen.queryByTestId('access-gate')).not.toBeInTheDocument();
+    });
+
+    it('shows an explanatory not-available state (not the welcome card) for a private or unknown id', async () => {
+      const { ThemeProvider } = await import('@/theme');
+
+      render(
+        <MemoryRouter initialEntries={['/collection/someone-elses-archive']}>
+          <ThemeProvider>
+            <LanguageProvider>
+              <AppContent />
+            </LanguageProvider>
+          </ThemeProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('collection-unavailable')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('access-gate')).not.toBeInTheDocument();
+      expect(screen.getByTestId('collection-unavailable-sign-in')).toBeInTheDocument();
+
+      // The Explore path routes onward to the resolvable public sample.
+      fireEvent.click(screen.getByTestId('collection-unavailable-explore'));
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'The Vinyl Vault' })).toBeInTheDocument();
+      });
+    });
+
+    it('latches public browsing so navigating Home afterwards is not re-gated', async () => {
+      const { ThemeProvider } = await import('@/theme');
+
+      render(
+        <MemoryRouter initialEntries={['/collection/sample-vinyl']}>
+          <ThemeProvider>
+            <LanguageProvider>
+              <AppContent />
+            </LanguageProvider>
+          </ThemeProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'The Vinyl Vault' })).toBeInTheDocument();
+      });
+
+      // Same contract as the Explore CTAs: once the visitor is browsing
+      // shared content, Home shows the sample-aware first-run Home, not the
+      // access gate again.
+      const bottomNav = screen.getByRole('navigation', { name: 'Primary' });
+      fireEvent.click(within(bottomNav).getByRole('link', { name: /home/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: /start your museum with one thing you love/i }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('access-gate')).not.toBeInTheDocument();
+    });
+  });
+
   // CUR-118 follow-up (Codex review on #299): when the parent collection
   // is already cached but the item is only in the pending cloud response,
   // the missing-item branch must also wait for `isLoading` to settle —

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -1122,6 +1122,78 @@ describe('App Integration Tests', () => {
       });
     });
 
+    it('routes an anonymous item link with an unknown collection to the not-available state', async () => {
+      const { ThemeProvider } = await import('@/theme');
+
+      render(
+        <MemoryRouter initialEntries={['/collection/someone-elses-archive/item/some-item']}>
+          <ThemeProvider>
+            <LanguageProvider>
+              <AppContent />
+            </LanguageProvider>
+          </ThemeProvider>
+        </MemoryRouter>,
+      );
+
+      // The item route falls through to /collection/:id, where the anon
+      // not-available explanation renders — the visitor never silently loses
+      // the link to a bare Home (Codex review on #340).
+      await waitFor(() => {
+        expect(screen.getByTestId('collection-unavailable')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('access-gate')).not.toBeInTheDocument();
+    });
+
+    it('does not latch public browsing for a signed-in collection visit (gate survives sign-out)', async () => {
+      const { ThemeProvider } = await import('@/theme');
+      // Signed-in session viewing a private collection; capture the auth
+      // listener so the test can emit SIGNED_OUT later.
+      vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+        data: { session: { user: { id: 'user1' } } },
+      } as never);
+      vi.mocked(db.getLocalCollections).mockResolvedValue([mockCollection]);
+      vi.mocked(db.fetchCloudCollections).mockResolvedValue([mockCollection]);
+      let authCallback: ((event: string, session: unknown) => void) | null = null;
+      vi.mocked(supabaseService.supabase!.auth.onAuthStateChange).mockImplementation(((
+        cb: (event: string, session: unknown) => void,
+      ) => {
+        authCallback = cb;
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      }) as never);
+
+      render(
+        <MemoryRouter initialEntries={['/collection/col1']}>
+          <ThemeProvider>
+            <LanguageProvider>
+              <AppContent />
+            </LanguageProvider>
+          </ThemeProvider>
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Test Collection')[0]).toBeInTheDocument();
+      });
+
+      // Leave the collection while still signed in, then sign out from Home.
+      const bottomNav = screen.getByRole('navigation', { name: 'Primary' });
+      fireEvent.click(within(bottomNav).getByRole('link', { name: /home/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('collections-grid')).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        authCallback?.('SIGNED_OUT', null);
+      });
+
+      // The authed collection visit must not have latched public browsing —
+      // a signed-out Home still greets with the welcome gate (Codex review
+      // on #340).
+      await waitFor(() => {
+        expect(screen.getByTestId('access-gate')).toBeInTheDocument();
+      });
+    });
+
     it('latches public browsing so navigating Home afterwards is not re-gated', async () => {
       const { ThemeProvider } = await import('@/theme');
 


### PR DESCRIPTION
## Problem
A signed-out visitor opening a shared collection link — e.g. `#/collection/sample-vinyl` — got the generic "Welcome to Curio" access gate rendered forever under the collection URL. The gate bypass list only covered `/explore` and `/legal/*`, so every anonymous deep link to the product's sharing pillar dead-ended on a welcome card with no hint that a specific collection was requested. Protects **Sharing before social complexity** and **Delight before auth**: a link someone receives must show them the museum, not a login-wall lookalike.

## Approach
- `src/App.tsx`: collection routes (`/collection/…`, which also covers item deep links) now bypass the access gate the same way `/explore` does, so the route renders — skeleton while loading, then the collection. Landing on a collection route while genuinely signed out (`authReady && !isAuthenticated`) also latches `allowPublicBrowse` (the same contract as both Explore CTAs), so navigating Home afterwards shows the sample-aware first-run Home instead of re-gating mid-browse; signed-in visits never set the flag, so the gate still greets a later sign-out (Codex review).
- `src/App.tsx` (CollectionScreen): when loading has settled and the id is genuinely absent, a signed-out visitor now gets a purposeful "This collection isn't on view" card (private / changed link explanation) with **Sign In** and **Explore** paths, styled after the access-gate card. Authed users keep the existing CUR-118 redirect-to-Home behavior.
- `src/App.tsx` (ItemDetailScreen): an unknown collection on an item link falls through to `/collection/:id` so signed-out visitors reach the same explanation instead of silently losing the URL to Home (Codex review); authed users end up on Home exactly as before.
- `src/i18n.ts`: two new keys (`collectionUnavailableTitle` / `collectionUnavailableDesc`) in EN + ZH, phrased in museum language ("isn't on view") and compliant with the CUR-122 warm-vocabulary guard.
- `tests/integration/AppNavigation.test.tsx`: five new tests — anon deep link renders the public sample (not the gate); private/unknown id shows the not-available state whose Explore CTA routes onward to the sample; anon item link with unknown collection reaches the not-available state; Home after an anon deep link is not re-gated; an authed collection visit does not latch, so the gate survives sign-out. **All fail against pre-fix source** (verified via stash).
- `tests/e2e/first-time-user.spec.ts`: anon deep-link e2e (`goto #/collection/sample-vinyl` → Vinyl Vault heading, URL kept, no access gate), per the issue's third acceptance criterion.

## Why this approach
It is the smallest change that makes shared links land on content: one derived boolean in the existing gate condition, one guarded latch effect mirroring the Explore handlers, and one explanatory state reusing the gate's own card styling and existing i18n keys (`login`, `exploreSample`). No routing, sync, auth-flow, or RLS changes — the gate still guards Home for cold visitors, and read-only labeling on the sample is untouched.

## Risks
Medium-low (Yellow: route-behavior change). The gate no longer intercepts collection URLs for signed-out visitors — that is the intended behavior change, and RLS still decides what data an anon client can actually read, so nothing private becomes visible. The latch means a deep-linked anon visitor sees the first-run Home (with sample + CTAs) instead of the gate when they tap Home; this matches the post-Explore experience that already exists. Authed flows are untouched (`showAccessGate` was already false for them, and the latch ignores signed-in visits).

## How to verify
Vercel Preview: https://curio-git-claude-curio-144-anon-col-948d78-qs-projects-72b20d9d.vercel.app
Steps:
1. In a fresh signed-out browser, open `<preview>/#/collection/sample-vinyl` directly.
2. The Vinyl Vault renders (read-only banner, items) under the same URL — no "Welcome to Curio" card.
3. Open `<preview>/#/collection/some-unknown-id` — a "This collection isn't on view" card appears with Sign In and Explore; Explore lands on the sample. An item link under an unknown collection (`…/#/collection/some-unknown-id/item/x`) lands on the same card.
4. Tap the bottom-nav Home — the sample-aware first-run Home renders, not the gate.
5. Sign in and confirm your own collections + deep links behave exactly as before; sign out from Home and confirm the welcome gate still appears.

Note on the live preview: until CUR-143 (drifted cloud sample: `is_public=false`, 1 of 5 items) is repaired, an anon visitor's cloud fetch returns no public collections, so the app serves the client-side fallback sample — the deep link renders it either way. The read-only sample images show the known CUR-141 placeholder until #338 merges.

Checks:
- [x] npm run format:check
- [x] npm test (877 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 6 skipped — includes the new CUR-144 spec on both projects)

## Screenshot / GIF
Before/after mobile screenshots attached on the Linear issue (CUR-144): before shows the welcome gate under `#/collection/sample-vinyl`; after shows the rendered sample collection and the new "isn't on view" state. (This environment can't upload images to GitHub directly.)

## Linear
Closes CUR-144

## Rollback plan
Revert both commits: `git revert 612d824 c1d5669`. No schema, RLS, storage, env-var, or feature-flag changes.