### PR TITLE
[CUR-143] Repair drifted cloud sample seed on admin load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -632,11 +632,17 @@ export const AppContent: React.FC = () => {
       // seed on every admin load, not just when the cloud is empty — a drifted
       // copy (toggled private, missing items) could otherwise never self-heal
       // (CUR-143). A healthy cloud copy makes this a no-op.
+      // A fresh or cleared device reports seed version 0, which says nothing
+      // about the cloud — only a device that recorded an older version forces
+      // a content re-push; otherwise structural drift alone decides.
       const localSeedVersion = await getSeedVersion();
       const seedRepairs = buildSeedRepairs(cloudCollections, user.id, {
-        force: localSeedVersion < CURRENT_SEED_VERSION,
+        force: localSeedVersion > 0 && localSeedVersion < CURRENT_SEED_VERSION,
       });
       if (seedRepairs.length === 0) {
+        if (localSeedVersion < CURRENT_SEED_VERSION) {
+          await setSeedVersion(CURRENT_SEED_VERSION);
+        }
         return cloudCollections;
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,7 +110,11 @@ import { StatusToast, StatusTone, getStatusToastDurationMs } from './components/
 import { StatusBanner } from './components/StatusBanner';
 import { LanguageToggle } from './components/LanguageToggle';
 import { ConflictResolutionModal } from './components/ConflictResolutionModal';
-import { CURRENT_SEED_VERSION, INITIAL_COLLECTIONS } from './services/seedCollections';
+import {
+  buildSeedRepairs,
+  CURRENT_SEED_VERSION,
+  INITIAL_COLLECTIONS,
+} from './services/seedCollections';
 import { trackEvent } from './services/analytics';
 
 /**
@@ -614,33 +618,37 @@ export const AppContent: React.FC = () => {
     async ({
       user,
       isAdmin,
-      localCollections,
       cloudCollections,
     }: {
       user: { id: string } | null;
       isAdmin: boolean;
-      localCollections: UserCollection[];
       cloudCollections: UserCollection[];
     }) => {
-      if (!user || !isAdmin || cloudCollections.length > 0 || localCollections.length > 0) {
+      if (!user || !isAdmin) {
         return cloudCollections;
       }
 
+      // Reconcile the cloud copy of the master sample against the code-defined
+      // seed on every admin load, not just when the cloud is empty — a drifted
+      // copy (toggled private, missing items) could otherwise never self-heal
+      // (CUR-143). A healthy cloud copy makes this a no-op.
       const localSeedVersion = await getSeedVersion();
-      if (localSeedVersion >= CURRENT_SEED_VERSION) {
+      const seedRepairs = buildSeedRepairs(cloudCollections, user.id, {
+        force: localSeedVersion < CURRENT_SEED_VERSION,
+      });
+      if (seedRepairs.length === 0) {
         return cloudCollections;
       }
 
-      const seededCollections = INITIAL_COLLECTIONS.map((seed) => ({
-        ...seed,
-        isPublic: true,
-        ownerId: user.id,
-      }));
-      for (const seedCollection of seededCollections) {
+      for (const seedCollection of seedRepairs) {
         await saveCollection(seedCollection);
       }
       await setSeedVersion(CURRENT_SEED_VERSION);
-      return [...seededCollections];
+      const repairedIds = new Set(seedRepairs.map((collection) => collection.id));
+      return [
+        ...cloudCollections.filter((collection) => !repairedIds.has(collection.id)),
+        ...seedRepairs,
+      ];
     },
     [],
   );
@@ -756,7 +764,6 @@ export const AppContent: React.FC = () => {
       cloudCollections = await maybeSeedCollections({
         user,
         isAdmin,
-        localCollections,
         cloudCollections,
       });
 

--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -249,9 +249,12 @@ export const useCollections = ({
       // copy (toggled private, missing items) could otherwise never self-heal
       // (CUR-143). A healthy cloud copy makes this a no-op.
       if (isAdmin) {
+        // A fresh or cleared device reports seed version 0, which says nothing
+        // about the cloud — only a device that recorded an older version forces
+        // a content re-push; otherwise structural drift alone decides.
         const localSeedVersion = await getSeedVersion();
         const seedRepairs = buildSeedRepairs(cloudCollections, user.id, {
-          force: localSeedVersion < CURRENT_SEED_VERSION,
+          force: localSeedVersion > 0 && localSeedVersion < CURRENT_SEED_VERSION,
         });
         if (seedRepairs.length > 0) {
           for (const seedCollection of seedRepairs) {
@@ -263,6 +266,8 @@ export const useCollections = ({
             ...cloudCollections.filter((collection) => !repairedIds.has(collection.id)),
             ...seedRepairs,
           ];
+        } else if (localSeedVersion < CURRENT_SEED_VERSION) {
+          await setSeedVersion(CURRENT_SEED_VERSION);
         }
       }
 

--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -23,7 +23,7 @@ import {
   type SyncStatus,
 } from '../services/db';
 import type { UserCollection } from '../types';
-import { CURRENT_SEED_VERSION, INITIAL_COLLECTIONS } from '../services/seedCollections';
+import { buildSeedRepairs, CURRENT_SEED_VERSION } from '../services/seedCollections';
 import type { StatusTone } from '../components/StatusToast';
 
 type UseCollectionsArgs = {
@@ -244,19 +244,25 @@ export const useCollections = ({
       const localOnly = hasLocalOnlyData(localCollections, cloudCollections);
       setHasLocalImport(localOnly);
 
-      if (cloudCollections.length === 0 && localCollections.length === 0 && isAdmin) {
+      // Reconcile the cloud copy of the master sample against the code-defined
+      // seed on every admin load, not just when the cloud is empty — a drifted
+      // copy (toggled private, missing items) could otherwise never self-heal
+      // (CUR-143). A healthy cloud copy makes this a no-op.
+      if (isAdmin) {
         const localSeedVersion = await getSeedVersion();
-        if (localSeedVersion < CURRENT_SEED_VERSION) {
-          const seededCollections = INITIAL_COLLECTIONS.map((seed) => ({
-            ...seed,
-            isPublic: true,
-            ownerId: user.id,
-          }));
-          for (const seedCollection of seededCollections) {
+        const seedRepairs = buildSeedRepairs(cloudCollections, user.id, {
+          force: localSeedVersion < CURRENT_SEED_VERSION,
+        });
+        if (seedRepairs.length > 0) {
+          for (const seedCollection of seedRepairs) {
             await saveCollection(seedCollection);
           }
           await setSeedVersion(CURRENT_SEED_VERSION);
-          cloudCollections = [...seededCollections];
+          const repairedIds = new Set(seedRepairs.map((collection) => collection.id));
+          cloudCollections = [
+            ...cloudCollections.filter((collection) => !repairedIds.has(collection.id)),
+            ...seedRepairs,
+          ];
         }
       }
 

--- a/src/services/seedCollections.ts
+++ b/src/services/seedCollections.ts
@@ -1,4 +1,4 @@
-import { UserCollection } from '../types';
+import { CollectionItem, UserCollection } from '../types';
 import { TEMPLATES } from '../constants';
 
 export const CURRENT_SEED_VERSION = 4;
@@ -123,3 +123,42 @@ export const INITIAL_COLLECTIONS: UserCollection[] = [
     updatedAt: SEED_TIMESTAMP,
   },
 ];
+
+type SeedRef = { id: string; seedKey?: string };
+
+const matchesSeed = (candidate: SeedRef, seed: SeedRef) =>
+  candidate.id === seed.id || (Boolean(candidate.seedKey) && candidate.seedKey === seed.seedKey);
+
+const hasSeedDrift = (seed: UserCollection, cloud: UserCollection | undefined): boolean => {
+  if (!cloud) return true;
+  if (!cloud.isPublic) return true;
+  return seed.items.some((seedItem) => {
+    const cloudItem = cloud.items.find((item) => matchesSeed(item, seedItem));
+    if (!cloudItem) return true;
+    // A seed item that lost its photo path (e.g. drifted to NULL in cloud)
+    // renders as a broken card on the exact surface meant to delight.
+    return Boolean(seedItem.photoUrl) && !cloudItem.photoUrl;
+  });
+};
+
+/**
+ * The master sample is code-defined; its cloud copy can drift (rows toggled
+ * private, seed items lost or stripped of photo paths outside the app).
+ * Returns the seed collections whose cloud copy must be re-upserted so the
+ * admin load path can repair drift instead of only seeding an empty cloud
+ * (CUR-143). Curator-added items already in the cloud copy are preserved.
+ * Pass `force` to re-push healthy seeds too (seed-version content upgrades).
+ */
+export const buildSeedRepairs = (
+  cloudCollections: UserCollection[],
+  ownerId: string,
+  { force = false }: { force?: boolean } = {},
+): UserCollection[] =>
+  INITIAL_COLLECTIONS.flatMap((seed) => {
+    const cloud = cloudCollections.find((collection) => matchesSeed(collection, seed));
+    if (!force && !hasSeedDrift(seed, cloud)) return [];
+    const curatorItems: CollectionItem[] = (cloud?.items ?? []).filter(
+      (item) => !seed.items.some((seedItem) => matchesSeed(item, seedItem)),
+    );
+    return [{ ...seed, ownerId, isPublic: true, items: [...seed.items, ...curatorItems] }];
+  });

--- a/src/services/seedCollections.ts
+++ b/src/services/seedCollections.ts
@@ -160,5 +160,19 @@ export const buildSeedRepairs = (
     const curatorItems: CollectionItem[] = (cloud?.items ?? []).filter(
       (item) => !seed.items.some((seedItem) => matchesSeed(item, seedItem)),
     );
-    return [{ ...seed, ownerId, isPublic: true, items: [...seed.items, ...curatorItems] }];
+    // Repair the row where it lives: keep the matched cloud id and owner so a
+    // re-keyed or re-owned copy is fixed in place instead of duplicated.
+    const targetId = cloud?.id ?? seed.id;
+    return [
+      {
+        ...seed,
+        id: targetId,
+        ownerId: cloud?.ownerId || ownerId,
+        isPublic: true,
+        items: [...seed.items, ...curatorItems].map((item) => ({
+          ...item,
+          collectionId: targetId,
+        })),
+      },
+    ];
   });

--- a/tests/hooks/useCollections.test.ts
+++ b/tests/hooks/useCollections.test.ts
@@ -212,6 +212,72 @@ describe('hooks/useCollections.ts (Phase 3.3)', () => {
     expect(result.current.collections).toHaveLength(INITIAL_COLLECTIONS.length);
   });
 
+  it('admin repair (CUR-143): a drifted cloud sample (private, partial) is re-upserted even when the seed version is current', async () => {
+    /**
+     * The cloud copy of the master sample can drift outside the app (toggled
+     * private, seed items lost). The old empty-cloud-only gate could never
+     * repair it. Verifies the admin load path reconciles a drifted copy.
+     */
+    const masterSeed = INITIAL_COLLECTIONS[0];
+    const driftedSample: UserCollection = {
+      ...masterSeed,
+      ownerId: 'admin-1',
+      isPublic: false, // drifted: should be public
+      items: [{ ...masterSeed.items[0] }], // drifted: only 1 of 5 seed items
+    };
+    dbMocks.fetchCloudCollections.mockResolvedValue([driftedSample]);
+    dbMocks.getSeedVersion.mockResolvedValue(CURRENT_SEED_VERSION);
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'admin-1' } as any,
+        isAdmin: true,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(dbMocks.saveCollection).toHaveBeenCalledTimes(1);
+    const repaired = dbMocks.saveCollection.mock.calls[0]?.[0];
+    expect(repaired).toMatchObject({ id: masterSeed.id, ownerId: 'admin-1', isPublic: true });
+    expect(repaired.items).toHaveLength(masterSeed.items.length);
+    expect(dbMocks.setSeedVersion).toHaveBeenCalledWith(CURRENT_SEED_VERSION);
+  });
+
+  it('admin repair (CUR-143): a healthy cloud sample is a no-op — nothing is re-upserted on load', async () => {
+    const masterSeed = INITIAL_COLLECTIONS[0];
+    const healthySample: UserCollection = {
+      ...masterSeed,
+      ownerId: 'admin-1',
+      isPublic: true,
+      items: masterSeed.items.map((item) => ({ ...item })),
+    };
+    dbMocks.fetchCloudCollections.mockResolvedValue([healthySample]);
+    dbMocks.getSeedVersion.mockResolvedValue(CURRENT_SEED_VERSION);
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'admin-1' } as any,
+        isAdmin: true,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(dbMocks.saveCollection).not.toHaveBeenCalled();
+    expect(dbMocks.setSeedVersion).not.toHaveBeenCalled();
+  });
+
   it('edge case: when Supabase is not ready, returns an empty collection list and does not error', async () => {
     /**
      * Verifies a boundary condition:

--- a/tests/hooks/useCollections.test.ts
+++ b/tests/hooks/useCollections.test.ts
@@ -278,6 +278,40 @@ describe('hooks/useCollections.ts (Phase 3.3)', () => {
     expect(dbMocks.setSeedVersion).not.toHaveBeenCalled();
   });
 
+  it('admin repair (CUR-143): a fresh device (seed version 0) does not force-rewrite a healthy cloud sample', async () => {
+    /**
+     * getSeedVersion() is a per-device IndexedDB setting; a fresh or cleared
+     * browser reports 0 even when the cloud seed is perfectly healthy. That
+     * must not force a re-push — it only records the current version locally.
+     */
+    const masterSeed = INITIAL_COLLECTIONS[0];
+    const healthySample: UserCollection = {
+      ...masterSeed,
+      ownerId: 'admin-1',
+      isPublic: true,
+      items: masterSeed.items.map((item) => ({ ...item })),
+    };
+    dbMocks.fetchCloudCollections.mockResolvedValue([healthySample]);
+    dbMocks.getSeedVersion.mockResolvedValue(0);
+
+    const { useCollections } = await import('@/hooks/useCollections');
+    const { result } = renderHook(() =>
+      useCollections({
+        user: { id: 'admin-1' } as any,
+        isAdmin: true,
+        isSupabaseReady: true,
+        fallbackSampleCollections,
+        t,
+        showStatus,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(dbMocks.saveCollection).not.toHaveBeenCalled();
+    expect(dbMocks.setSeedVersion).toHaveBeenCalledWith(CURRENT_SEED_VERSION);
+  });
+
   it('edge case: when Supabase is not ready, returns an empty collection list and does not error', async () => {
     /**
      * Verifies a boundary condition:

--- a/tests/unit/services/seedCollections.test.ts
+++ b/tests/unit/services/seedCollections.test.ts
@@ -1,0 +1,111 @@
+/**
+ * CUR-143: buildSeedRepairs — cloud sample drift reconciliation
+ *
+ * The master sample is code-defined (INITIAL_COLLECTIONS); its cloud copy can
+ * drift (rows toggled private, seed items lost, photo paths nulled). The admin
+ * load path uses buildSeedRepairs to decide which seed collections must be
+ * re-upserted. These tests pin the drift conditions and the non-destructive
+ * repair shape (curator-added items are preserved).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CollectionItem, UserCollection } from '@/types';
+import { buildSeedRepairs, INITIAL_COLLECTIONS } from '@/services/seedCollections';
+
+const ADMIN_ID = 'admin-1';
+const masterSeed = INITIAL_COLLECTIONS[0];
+
+/** A faithful cloud copy of the master seed, as fetchCloudCollections returns it. */
+function healthyCloudSeed(overrides: Partial<UserCollection> = {}): UserCollection {
+  return {
+    ...masterSeed,
+    ownerId: ADMIN_ID,
+    isPublic: true,
+    items: masterSeed.items.map((item) => ({ ...item })),
+    ...overrides,
+  };
+}
+
+describe('seedCollections.ts — buildSeedRepairs (CUR-143)', () => {
+  it('returns no repairs when the cloud copy is healthy', () => {
+    expect(buildSeedRepairs([healthyCloudSeed()], ADMIN_ID)).toEqual([]);
+  });
+
+  it('repairs an entirely missing cloud copy (first-time seeding)', () => {
+    const repairs = buildSeedRepairs([], ADMIN_ID);
+    expect(repairs).toHaveLength(INITIAL_COLLECTIONS.length);
+    expect(repairs[0]).toMatchObject({ id: masterSeed.id, ownerId: ADMIN_ID, isPublic: true });
+    expect(repairs[0].items).toHaveLength(masterSeed.items.length);
+  });
+
+  it('repairs a cloud copy that drifted to private', () => {
+    const repairs = buildSeedRepairs([healthyCloudSeed({ isPublic: false })], ADMIN_ID);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].isPublic).toBe(true);
+  });
+
+  it('repairs a cloud copy missing seed items (partial seed)', () => {
+    // The production drift: only seed-vinyl-1 survived in cloud.
+    const partial = healthyCloudSeed({ items: [{ ...masterSeed.items[0] }] });
+    const repairs = buildSeedRepairs([partial], ADMIN_ID);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].items.map((item) => item.id)).toEqual(
+      masterSeed.items.map((item) => item.id),
+    );
+  });
+
+  it('repairs a cloud seed item that lost its photo path', () => {
+    const items = masterSeed.items.map((item, index) =>
+      index === 0 ? { ...item, photoUrl: '' } : { ...item },
+    );
+    const repairs = buildSeedRepairs([healthyCloudSeed({ items })], ADMIN_ID);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].items[0].photoUrl).toBe(masterSeed.items[0].photoUrl);
+  });
+
+  it('preserves curator-added items when repairing', () => {
+    const curatorItem: CollectionItem = {
+      id: 'curator-pick-1',
+      collectionId: masterSeed.id,
+      photoUrl: '/assets/sample-vinyl.jpg',
+      title: 'Blue Train',
+      rating: 5,
+      data: {},
+      createdAt: new Date().toISOString(),
+      notes: 'A curator addition beyond the code-defined seed.',
+    };
+    const drifted = healthyCloudSeed({
+      isPublic: false,
+      items: [...masterSeed.items.map((item) => ({ ...item })), curatorItem],
+    });
+    const repairs = buildSeedRepairs([drifted], ADMIN_ID);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].items.map((item) => item.id)).toContain('curator-pick-1');
+    expect(repairs[0].items).toHaveLength(masterSeed.items.length + 1);
+  });
+
+  it('matches the cloud copy by seedKey when the id differs, and leaves it alone if healthy', () => {
+    const rekeyed = healthyCloudSeed({ id: 'legacy-id' });
+    rekeyed.items = rekeyed.items.map((item) => ({ ...item, collectionId: 'legacy-id' }));
+    expect(buildSeedRepairs([rekeyed], ADMIN_ID)).toEqual([]);
+  });
+
+  it('force re-pushes healthy seeds (seed-version content upgrades)', () => {
+    const repairs = buildSeedRepairs([healthyCloudSeed()], ADMIN_ID, { force: true });
+    expect(repairs).toHaveLength(INITIAL_COLLECTIONS.length);
+  });
+
+  it('ignores non-seed cloud collections entirely', () => {
+    const personal: UserCollection = {
+      id: 'my-teas',
+      templateId: 'general',
+      name: 'Tea Tins',
+      customFields: [],
+      items: [],
+      ownerId: ADMIN_ID,
+      updatedAt: new Date().toISOString(),
+    };
+    const repairs = buildSeedRepairs([personal, healthyCloudSeed()], ADMIN_ID);
+    expect(repairs).toEqual([]);
+  });
+});

--- a/tests/unit/services/seedCollections.test.ts
+++ b/tests/unit/services/seedCollections.test.ts
@@ -90,6 +90,24 @@ describe('seedCollections.ts — buildSeedRepairs (CUR-143)', () => {
     expect(buildSeedRepairs([rekeyed], ADMIN_ID)).toEqual([]);
   });
 
+  it('repairs a re-keyed cloud copy in place instead of duplicating it under the canonical id', () => {
+    const rekeyed = healthyCloudSeed({ id: 'legacy-id', isPublic: false });
+    rekeyed.items = rekeyed.items.map((item) => ({ ...item, collectionId: 'legacy-id' }));
+    const repairs = buildSeedRepairs([rekeyed], ADMIN_ID);
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].id).toBe('legacy-id');
+    expect(repairs[0].items.every((item) => item.collectionId === 'legacy-id')).toBe(true);
+    expect(repairs[0].items.map((item) => item.id)).toEqual(
+      masterSeed.items.map((item) => item.id),
+    );
+  });
+
+  it('preserves the existing cloud owner when repairing; assigns the caller only for missing copies', () => {
+    const drifted = healthyCloudSeed({ isPublic: false, ownerId: 'original-admin' });
+    expect(buildSeedRepairs([drifted], 'another-admin')[0].ownerId).toBe('original-admin');
+    expect(buildSeedRepairs([], 'another-admin')[0].ownerId).toBe('another-admin');
+  });
+
   it('force re-pushes healthy seeds (seed-version content upgrades)', () => {
     const repairs = buildSeedRepairs([healthyCloudSeed()], ADMIN_ID, { force: true });
     expect(repairs).toHaveLength(INITIAL_COLLECTIONS.length);


### PR DESCRIPTION
## Problem
The cloud copy of the Public Sample Gallery drifted: `collections.sample-vinyl` sits at `is_public = false` and only 1 of 5 seed items survives (with NULL photo paths). RLS therefore hides the sample from everyone but the admin — signed-in users get no reference content, and `#/collection/sample-vinyl` deep links bounce. The admin seeding path (`maybeSeedCollections` in `App.tsx`, mirrored in `hooks/useCollections.ts`) only ran when the cloud was **completely empty**, so it could never repair a partial or misconfigured seed. Protects **Delight before auth** and **Trust before growth**: the sample is the first museum most visitors ever see.

## Approach
- `src/services/seedCollections.ts`: new pure `buildSeedRepairs(cloudCollections, ownerId, { force })`. For each code-defined seed it detects drift — cloud copy missing, not public, missing seed items (matched by id or `seedKey`), or a seed item that lost its photo path — and returns the canonical seed to re-upsert. Repairs happen **in place**: the matched cloud row's `id` and `ownerId` are preserved (seed items' `collectionId` remapped), and curator-added items already in the cloud copy are kept. `force` re-pushes healthy seeds too, so `CURRENT_SEED_VERSION` bumps finally propagate content to a non-empty cloud (the old gate silently dropped seed upgrades as well).
- `src/App.tsx` (`maybeSeedCollections`, the live load path) and `src/hooks/useCollections.ts` (the extracted mirror) both now call it on every admin load. Healthy cloud → zero writes; drift → `saveCollection()` upserts exactly the drifted seeds through the existing IndexedDB + Supabase path, then the repaired copies join the merge input. `force` requires `0 < localSeedVersion < CURRENT_SEED_VERSION` — a fresh or cleared device (version 0) never force-rewrites a healthy cloud; no-op loads stamp the current version so later bumps still propagate (Codex review).
- Tests: `tests/unit/services/seedCollections.test.ts` (11 cases pinning every drift condition, curator-item preservation, in-place repair of re-keyed rows, owner preservation, seedKey matching, force) and three hook-level regressions in `tests/hooks/useCollections.test.ts` (drifted copy repaired with a current seed version — fails on the old gate; healthy copy is a strict no-op; fresh device does not force-rewrite a healthy cloud).

Non-admin users, anonymous visitors, and the fallback sample path are untouched; the repair runs only inside the existing admin-only branch.

## Why this approach
It is the guard CUR-143 explicitly asks for, placed in the seed module so the sample's source of truth (code) and its reconciliation live together. Reusing `saveCollection()` means repairs flow through the exact same local-persist → cloud-upsert → pending-retry machinery as every other write — no new sync surface. The presence-based check makes steady state a no-op, so admin content curation on the sample is never fought unless something is genuinely broken.

## Risks
Medium-low (Yellow: sync-path change, admin-only branch).
- A repair overwrites the 5 seed items with canonical seed content **only when drift is detected** (or on a seed-version bump from a device that recorded the older version) — intended, since the sample is code-defined per CLAUDE.md's "update `seedCollections.ts` and increment `CURRENT_SEED_VERSION`" workflow. Curator-added extra items and the existing cloud `ownerId` are preserved (tested).
- A fresh admin device (local seed version 0) no longer force-pushes anything against a healthy cloud; it just records the current version.
- If the drifted collection row were somehow owned by another user, RLS would reject the upsert and the existing pending-sync retry/error toast surfaces it — no silent failure.

## How to verify
Vercel Preview: https://curio-git-claude-curio-143-repair-d-8af28e-qs-projects-72b20d9d.vercel.app
Steps (staging or local Supabase):
1. In Supabase, set `is_public = false` on `collections.sample-vinyl` and delete 4 of its 5 items (the live production drift).
2. Sign in as the admin and load the app. Console/network shows one collection + items upsert; Table Editor now shows `is_public = true` and 5 rows in `items` for `sample-vinyl`, and IndexedDB → `curio-database` → `collections` holds the repaired sample.
3. Sign in as a **non-admin** user: the Vinyl Vault appears (read-only), and `#/collection/sample-vinyl` renders instead of bouncing Home.
4. Reload as admin: no further upserts (healthy cloud is a no-op).
5. Sample images still show the known CUR-141 placeholder until #338 merges — unrelated to this change.

Production note: after this merges and deploys, one admin sign-in on production repairs the live drift (acceptance criteria 1–2). If you want it fixed before deploy, the equivalent one-time SQL is: `update collections set is_public = true where id = 'sample-vinyl';` plus re-upserting the 5 seed rows — but the app path above does it for you.

Checks (re-run after the review fixes in 867d958):
- [x] npm run format:check
- [x] npm test (892 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF
No visual delta to capture in this environment: the change is data reconciliation with zero UI changes; the user-visible outcome (sample visible to signed-in users, deep links resolving) depends on the drifted production rows and is covered by the verification steps above.

## Linear
Closes CUR-143

## Rollback plan
Revert both commits: `git revert 867d958 6793c73`. No schema, RLS, storage, env-var, or feature-flag changes — reverting restores the old empty-cloud-only gate exactly. Any repair already performed simply leaves the cloud sample in its intended healthy state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UJrKnNts4RD1JCZRmokJh