### PR TITLE
CUR-145: Wrap Item Detail text fields on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1873,6 +1873,7 @@ export const AppContent: React.FC = () => {
     const isApplyingHistoryRef = useRef(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const titleTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const detailFieldTextareaRefs = useRef<Record<string, HTMLTextAreaElement | null>>({});
 
     const collection = collections.find((c) => c.id === id);
     const item = collection?.items.find((i) => i.id === itemId);
@@ -2087,6 +2088,15 @@ export const AppContent: React.FC = () => {
       setDetailStoryPrompts([]);
       setDetailPromptsFetchedFor(null);
     }, [item.id]);
+
+    useEffect(() => {
+      collection.customFields.forEach((field) => {
+        const textarea = detailFieldTextareaRefs.current[field.id];
+        if (!textarea) return;
+        textarea.style.height = 'auto';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+      });
+    }, [collection.customFields, item.data]);
 
     // CUR-135: Cmd/Ctrl+Z, Cmd/Ctrl+Shift+Z, Ctrl+Y drive the app-level
     // undo/redo stacks that the on-screen buttons already use. Text-field
@@ -2651,6 +2661,19 @@ export const AppContent: React.FC = () => {
                   {collection.customFields.map((field) => {
                     const val = item.data[field.id];
                     const label = getLabel(field.id);
+                    const isMultilineText = field.type === 'text' || field.type === 'long_text';
+                    const fieldValue = val || '';
+                    const fieldBaseClass = `${typographyClasses.title} w-full bg-transparent border-none p-0 outline-none focus:text-amber-900 focus:ring-0 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : theme === 'atelier' ? 'text-stone-900 placeholder:text-[#8C7B6B]' : 'text-stone-900 placeholder:text-stone-500'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`;
+                    const handleFieldChange = (
+                      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+                    ) => {
+                      const newData = {
+                        ...item.data,
+                        [field.id]: e.target.value,
+                      };
+                      applyItemUpdate({ data: newData });
+                    };
+
                     return (
                       <div key={field.id} className="group">
                         <dt
@@ -2658,19 +2681,31 @@ export const AppContent: React.FC = () => {
                         >
                           {label}
                         </dt>
-                        <input
-                          className={`${typographyClasses.title} w-full bg-transparent border-none p-0 outline-none focus:text-amber-900 focus:ring-0 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : theme === 'atelier' ? 'text-stone-900 placeholder:text-[#8C7B6B]' : 'text-stone-900 placeholder:text-stone-500'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`}
-                          value={val || ''}
-                          placeholder="—"
-                          onChange={(e) => {
-                            const newData = {
-                              ...item.data,
-                              [field.id]: e.target.value,
-                            };
-                            applyItemUpdate({ data: newData });
-                          }}
-                          disabled={isReadOnly}
-                        />
+                        {isMultilineText ? (
+                          <textarea
+                            ref={(node) => {
+                              detailFieldTextareaRefs.current[field.id] = node;
+                            }}
+                            className={`${fieldBaseClass} min-h-[1.75rem] resize-none overflow-hidden leading-snug break-words whitespace-pre-wrap`}
+                            value={fieldValue}
+                            placeholder="—"
+                            rows={1}
+                            onChange={(e) => {
+                              e.currentTarget.style.height = 'auto';
+                              e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`;
+                              handleFieldChange(e);
+                            }}
+                            disabled={isReadOnly}
+                          />
+                        ) : (
+                          <input
+                            className={fieldBaseClass}
+                            value={fieldValue}
+                            placeholder="—"
+                            onChange={handleFieldChange}
+                            disabled={isReadOnly}
+                          />
+                        )}
                       </div>
                     );
                   })}

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -615,7 +615,7 @@ describe('App Integration Tests', () => {
     expect(fieldLabel.className).toContain('text-stone-500');
     expect(fieldLabel.className).not.toContain('text-stone-300');
 
-    const fieldInput = fieldLabel.parentElement?.querySelector('input[placeholder="—"]');
+    const fieldInput = fieldLabel.parentElement?.querySelector('textarea[placeholder="—"]');
     expect(fieldInput).toBeTruthy();
     // The "—" placeholder must be visible enough to read as "empty, click to edit".
     expect(fieldInput?.className).not.toContain('placeholder:text-stone-100');
@@ -657,11 +657,83 @@ describe('App Integration Tests', () => {
     );
 
     const fieldLabel = await screen.findByText('Format');
-    const fieldInput = fieldLabel.parentElement?.querySelector('input[placeholder="—"]');
+    const fieldInput = fieldLabel.parentElement?.querySelector('textarea[placeholder="—"]');
     expect(fieldInput).toBeTruthy();
     expect(fieldInput?.className).toContain('placeholder:text-stone-400');
     expect(fieldInput?.className).not.toContain('placeholder:text-stone-500');
     expect(fieldInput?.className).not.toContain('placeholder:text-stone-100');
+  });
+
+  it('renders long Item Detail text fields as wrapping textareas and keeps other field types one-line (CUR-145)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    const longFlavorNotes =
+      'Rich, intense cocoa flavors with slight bitterness and a lingering cherry finish after the snap.';
+    const collectionWithMixedFields = {
+      ...mockCollection,
+      customFields: [
+        {
+          id: 'flavor_notes',
+          label: 'Flavor Notes',
+          type: 'text' as const,
+          displayMode: 'detail' as const,
+        },
+        {
+          id: 'abv',
+          label: 'ABV %',
+          type: 'number' as const,
+          displayMode: 'detail' as const,
+        },
+        {
+          id: 'opened_on',
+          label: 'Opened On',
+          type: 'date' as const,
+          displayMode: 'detail' as const,
+        },
+        {
+          id: 'condition',
+          label: 'Condition',
+          type: 'select' as const,
+          displayMode: 'detail' as const,
+          options: ['New', 'Opened'],
+        },
+      ],
+      items: [
+        {
+          ...mockCollection.items[0],
+          data: {
+            flavor_notes: longFlavorNotes,
+            abv: '46',
+            opened_on: '2026-07-06',
+            condition: 'Opened',
+          },
+        },
+      ],
+    };
+    vi.mocked(db.getLocalCollections).mockResolvedValue([collectionWithMixedFields]);
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1/item/item1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    const flavorLabel = await screen.findByText('Flavor Notes');
+    const flavorTextarea = flavorLabel.parentElement?.querySelector('textarea');
+    expect(flavorTextarea).toBeInstanceOf(HTMLTextAreaElement);
+    expect(flavorTextarea).toHaveValue(longFlavorNotes);
+    expect(flavorTextarea?.className).toContain('whitespace-pre-wrap');
+    expect(flavorTextarea?.className).toContain('overflow-hidden');
+    expect(flavorLabel.parentElement?.querySelector('input')).toBeNull();
+
+    for (const labelText of ['ABV %', 'Opened On', 'Condition']) {
+      const label = screen.getByText(labelText);
+      expect(label.parentElement?.querySelector('input')).toBeInstanceOf(HTMLInputElement);
+      expect(label.parentElement?.querySelector('textarea')).toBeNull();
+    }
   });
 
   it('renders Item Detail rating stars with Vault filled and empty contrast tokens (CUR-98)', async () => {


### PR DESCRIPTION
## Summary
- Render Item Detail text and long_text custom fields as autosizing textareas so long values wrap instead of clipping on mobile.
- Keep non-text custom fields on the existing one-line input path.
- Add integration coverage for the CUR-145 rendering contract and update existing placeholder contrast assertions for the new textareas.

## Verification
- npx vitest run tests/integration/AppNavigation.test.tsx
- npm run format
- npm run format:check
- env NODE_OPTIONS=--no-experimental-webstorage npm test (sandboxed run hit listen EPERM; elevated rerun passed)
- npm run build
- env NODE_OPTIONS=--no-experimental-webstorage npm run test:e2e (sandboxed run hit listen EPERM; elevated rerun passed)

Closes CUR-145