### PR TITLE
CUR-101: Hide unsupported Print action in native apps

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { X, Printer, Share2, Download, Maximize2, Minimize2, Loader2, Camera } from 'lucide-react';
 import { toBlob } from 'html-to-image';
+import { Capacitor } from '@capacitor/core';
 import { CollectionItem, FieldDefinition } from '../types';
 import { Button } from './ui/Button';
 import { extractCurioAssetPath, getAsset, getEnhancedAsset } from '../services/db';
@@ -43,6 +44,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   onStatus,
 }) => {
   const { t } = useTranslation();
+  const isNativePlatform = Capacitor.isNativePlatform();
   const [style, setStyle] = useState<TemplateStyle>('minimal');
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('3:4');
   const [imageFit, setImageFit] = useState<ImageFit>('cover');
@@ -696,18 +698,20 @@ export const ExportModal: React.FC<ExportModalProps> = ({
           >
             {exportAction === 'share' ? t('sharing') : t('share')}
           </Button>
-          <div className="flex justify-center">
-            <Button
-              theme="gallery"
-              variant="ghost"
-              size="sm"
-              onClick={() => window.print()}
-              disabled={exportAction !== null || isLoadingImage}
-              icon={<Printer size={14} />}
-            >
-              {t('print')}
-            </Button>
-          </div>
+          {!isNativePlatform && (
+            <div className="flex justify-center">
+              <Button
+                theme="gallery"
+                variant="ghost"
+                size="sm"
+                onClick={() => window.print()}
+                disabled={exportAction !== null || isLoadingImage}
+                icon={<Printer size={14} />}
+              >
+                {t('print')}
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -6,6 +6,7 @@ import type { CollectionItem, FieldDefinition } from '@/types';
 import { toBlob } from 'html-to-image';
 import { getAsset, getEnhancedAsset } from '@/services/db';
 import { trackEvent } from '@/services/analytics';
+import { Capacitor } from '@capacitor/core';
 
 vi.mock('@/services/db', () => ({
   extractCurioAssetPath: vi.fn().mockReturnValue(null),
@@ -21,12 +22,22 @@ vi.mock('@/services/analytics', () => ({
   trackEvent: vi.fn(),
 }));
 
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+  },
+}));
+
 vi.mock('@/theme', async () => {
   const actual = await vi.importActual('@/theme');
   return {
     ...actual,
     useTheme: () => ({ theme: 'gallery', setTheme: vi.fn() }),
   };
+});
+
+beforeEach(() => {
+  vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
 });
 
 const LONG_TITLE = 'Karuna Pipa Barrel Aged Dark Chocolate 75%';
@@ -131,6 +142,25 @@ describe('ExportModal — CUR-83 footer CTA hierarchy', () => {
     } finally {
       window.print = originalPrint;
     }
+  });
+});
+
+describe('ExportModal — CUR-101 native Print availability', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  it('hides Print on native platforms while keeping Save image and Share available', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+
+    renderWithProviders(<ExportModal {...baseProps} />);
+
+    expect(screen.queryByRole('button', { name: /^print$/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save image/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^share$/i })).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- hide the Export Card Print action when Capacitor reports a native platform
- keep Save image and Share available in native apps
- preserve the existing `window.print()` behavior on the web
- add focused component coverage for both native and web behavior

## Why

`window.print()` is a silent no-op in the Android and iOS WebViews used by the Capacitor wrappers. Hiding the unsupported action prevents a dead control while leaving the working native export paths intact.

## Verification

- `npx vitest run tests/components/ExportModal.test.tsx` — 25 passed
- `npm run format:check` — passed
- `env NODE_OPTIONS=--no-experimental-webstorage npm test` — 59 files passed; 883 passed, 2 skipped, 1 todo
- `npm run build` — passed (existing chunk-size warning only)
- `env NODE_OPTIONS=--no-experimental-webstorage npm run test:e2e` — 44 passed, 8 skipped

Closes CUR-101