### PR TITLE
fix: scroll to top on forward navigation (CUR-150)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Routes,
   Route,
   useNavigate,
+  useNavigationType,
   useParams,
   useLocation,
   Link,
@@ -3304,12 +3305,27 @@ const LocalizedErrorBoundary: React.FC<{ children: React.ReactNode }> = ({ child
   );
 };
 
+// Reset scroll on forward navigation so a new screen opens at the top, while
+// leaving POP (browser back/forward) alone to preserve the list position the
+// user is returning to.
+const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+  const navigationType = useNavigationType();
+  useEffect(() => {
+    if (navigationType !== 'POP') {
+      window.scrollTo(0, 0);
+    }
+  }, [pathname, navigationType]);
+  return null;
+};
+
 export const App: React.FC = () => {
   return (
     <ThemeProvider>
       <LanguageProvider>
         <LocalizedErrorBoundary>
           <HashRouter>
+            <ScrollToTop />
             <AppContent />
           </HashRouter>
           <SpeedInsights />


### PR DESCRIPTION
## Problem

Found during the 2026-07-10 live UI/UX review (Linear [CUR-150](https://linear.app/qiuyue/issue/CUR-150)): route changes never reset the window scroll, so a pushed screen inherits the previous screen's offset. Opening an item from a scrolled collection lands mid-page — on mobile the hero photo and title are entirely off-screen, which reads as a broken page. Reproduced on production: with the collection at `scrollY=900`, the item detail opened at `scrollY=900`.

## Fix

Add a `ScrollToTop` component mounted under `HashRouter` that scrolls the window to the top when the pathname changes via `PUSH`/`REPLACE`, and does nothing on `POP` — so browser back/forward still returns to the prior list position.

## Verification

- `npm run format:check`, `npm test` (940 passed), `npm run build`, `npm run test:e2e` (44 passed, 8 skipped) all green.
- Manually verified against a production preview build at 390px: collection scrolled to 800 → open item → `scrollY` is 0; browser back → `scrollY` restored to 800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019y3DZuqKvg2FnS1L2KcN7Y

---
_Generated by [Claude Code](https://claude.ai/code/session_019y3DZuqKvg2FnS1L2KcN7Y)_