### PR TITLE
[CUR-152] Open the auth modal in sign-up mode from first-run CTAs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,6 +233,10 @@ export const AppContent: React.FC = () => {
   const [adminCheckedFor, setAdminCheckedFor] = useState<string | null>(null);
   const [refreshedForKey, setRefreshedForKey] = useState<string | null>(null);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+  // CUR-152: the auth modal opens in the mode matching the triggering intent.
+  // First-run CTAs ("Add your first item", "Start a collection") greet a
+  // brand-new user with sign-up; header/profile entry points keep sign-in.
+  const [authModalMode, setAuthModalMode] = useState<'signin' | 'signup'>('signin');
   const [isPasswordRecovery, setIsPasswordRecovery] = useState(false);
   const [allowPublicBrowse, setAllowPublicBrowse] = useState(false);
   const [hasLocalImport, setHasLocalImport] = useState(false);
@@ -266,6 +270,10 @@ export const AppContent: React.FC = () => {
   const [authActionQueue, setAuthActionQueue] = useState<'add-item' | 'create-collection' | null>(
     null,
   );
+  const openAuthModal = useCallback((mode: 'signin' | 'signup') => {
+    setAuthModalMode(mode);
+    setIsAuthModalOpen(true);
+  }, []);
   const saveTimeoutRef = useRef<Record<string, any>>({});
   const pendingEditedFieldsRef = useRef<Record<string, Set<string>>>({});
   const pendingEditedItemIdsRef = useRef<Record<string, Set<string>>>({});
@@ -1165,7 +1173,7 @@ export const AppContent: React.FC = () => {
   }): boolean => {
     if (!isAuthenticated) {
       setPendingAuthAction('create-collection');
-      setIsAuthModalOpen(true);
+      openAuthModal('signup');
       setIsCreateCollectionOpen(false);
       return false;
     }
@@ -1455,7 +1463,7 @@ export const AppContent: React.FC = () => {
               </p>
               <div className="space-y-2">
                 <Button
-                  onClick={() => setIsAuthModalOpen(true)}
+                  onClick={() => openAuthModal('signin')}
                   size="lg"
                   className="w-full"
                   data-testid="collection-unavailable-sign-in"
@@ -2986,7 +2994,7 @@ export const AppContent: React.FC = () => {
   const handleAddAction = useCallback(() => {
     if (!isAuthenticated) {
       setPendingAuthAction('add-item');
-      setIsAuthModalOpen(true);
+      openAuthModal('signup');
       return;
     }
     if (editableCollections.length === 0) {
@@ -3006,16 +3014,16 @@ export const AppContent: React.FC = () => {
         : undefined;
     setAddModalDefaultCollectionId(presetCollectionId);
     setIsAddModalOpen(true);
-  }, [editableCollections, isAuthenticated, location.pathname]);
+  }, [editableCollections, isAuthenticated, location.pathname, openAuthModal]);
 
   const handleCreateCollectionAction = useCallback(() => {
     if (!isAuthenticated) {
       setPendingAuthAction('create-collection');
-      setIsAuthModalOpen(true);
+      openAuthModal('signup');
       return;
     }
     setIsCreateCollectionOpen(true);
-  }, [isAuthenticated]);
+  }, [isAuthenticated, openAuthModal]);
 
   const handleSignOut = async () => {
     await signOutUser();
@@ -3149,7 +3157,7 @@ export const AppContent: React.FC = () => {
       data-ready={appReady ? 'true' : 'false'}
     >
       <Layout
-        onOpenAuth={() => setIsAuthModalOpen(true)}
+        onOpenAuth={() => openAuthModal('signin')}
         onSignOut={handleSignOut}
         sampleCollectionId={sampleCollectionId}
         user={user}
@@ -3179,7 +3187,7 @@ export const AppContent: React.FC = () => {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setIsAuthModalOpen(true)}
+                onClick={() => openAuthModal('signin')}
                 className="hidden sm:inline-flex motion-fade"
               >
                 {t('login')}
@@ -3275,7 +3283,7 @@ export const AppContent: React.FC = () => {
         isOpen={isAuthModalOpen}
         onClose={handleAuthClose}
         onAuthSuccess={handleAuthSuccess}
-        initialMode={isPasswordRecovery ? 'set-password' : undefined}
+        initialMode={isPasswordRecovery ? 'set-password' : authModalMode}
       />
       <ConflictResolutionModal
         isOpen={isConflictModalOpen}

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -35,7 +35,11 @@ interface AuthModalProps {
   isOpen: boolean;
   onClose: () => void;
   onAuthSuccess?: () => void;
-  /** Forces the modal to open in a specific mode. Used for the password-recovery redirect. */
+  /**
+   * Mode the modal opens in. First-run CTAs pass 'signup' so new users are
+   * greeted with account creation (CUR-152); the password-recovery redirect
+   * passes 'set-password'. Defaults to 'signin'.
+   */
   initialMode?: AuthModalMode;
 }
 
@@ -80,7 +84,9 @@ export const AuthModal: React.FC<AuthModalProps> = ({
     setShowConfirmPassword(false);
     setResendStatus('idle');
     setResendCooldown(0);
-    if (!initialMode) setEmail('');
+    // Keep the email only across the password-recovery redirect; ordinary
+    // sign-in / sign-up opens always start with a blank form.
+    if (initialMode !== 'set-password') setEmail('');
   }, [isOpen, initialMode]);
 
   // Tick the resend cooldown down to zero. Effect cleans itself up when

--- a/tests/components/AuthModal.test.tsx
+++ b/tests/components/AuthModal.test.tsx
@@ -656,6 +656,62 @@ describe('AuthModal', () => {
     });
   });
 
+  describe('CUR-152: intent-based initial mode', () => {
+    it('opens in sign-up mode when initialMode is "signup"', () => {
+      renderWithProviders(<AuthModal {...defaultProps} initialMode="signup" />);
+
+      expect(screen.getByRole('heading', { name: /join the museum/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+      expect(screen.queryByText(/welcome back/i)).not.toBeInTheDocument();
+    });
+
+    it('opens in sign-in mode when initialMode is "signin"', () => {
+      renderWithProviders(<AuthModal {...defaultProps} initialMode="signin" />);
+
+      expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+    });
+
+    it('still lets the user switch from sign-up to sign-in and back', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<AuthModal {...defaultProps} initialMode="signup" />);
+
+      await user.click(screen.getByText(/Already have an account/i));
+      expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+
+      await user.click(screen.getByText(/Don't have an account/i));
+      expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument();
+    });
+
+    it('re-applies the requested mode when the modal reopens with a different intent', async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderWithProviders(
+        <AuthModal {...defaultProps} initialMode="signup" />,
+      );
+
+      // The user wanders off to sign-in, closes, then reopens via a
+      // returning-user entry point — the modal must not remember sign-up.
+      await user.click(screen.getByText(/Already have an account/i));
+      rerender(<AuthModal {...defaultProps} isOpen={false} initialMode="signup" />);
+      rerender(<AuthModal {...defaultProps} isOpen={true} initialMode="signin" />);
+
+      expect(screen.getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+    });
+
+    it('clears a previously typed email when reopening in sign-in or sign-up mode', async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderWithProviders(
+        <AuthModal {...defaultProps} initialMode="signin" />,
+      );
+
+      await user.type(screen.getByPlaceholderText(/curator@museum.com/i), 'stale@example.com');
+      rerender(<AuthModal {...defaultProps} isOpen={false} initialMode="signin" />);
+      rerender(<AuthModal {...defaultProps} isOpen={true} initialMode="signup" />);
+
+      expect(screen.getByPlaceholderText(/curator@museum.com/i)).toHaveValue('');
+    });
+  });
+
   describe('Set Password Mode (recovery redirect)', () => {
     it('opens in set-password mode when initialMode is set', () => {
       renderWithProviders(<AuthModal {...defaultProps} initialMode="set-password" />);

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -445,6 +445,69 @@ describe('App Integration Tests', () => {
     expect(screen.getByTestId('cta-secondary-explore-sample')).toBeInTheDocument();
   });
 
+  it('opens the auth modal in sign-up mode from the first-run "Add your first item" CTA (CUR-152)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as never);
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('access-gate')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cta-primary-add-first'));
+
+    // The likeliest person clicking a first-run CTA has no account yet, so
+    // the modal greets them with sign-up, not "Welcome Back".
+    const modal = await screen.findByTestId('auth-modal');
+    expect(within(modal).getByRole('heading', { name: /join the museum/i })).toBeInTheDocument();
+    expect(within(modal).getByRole('button', { name: /create account/i })).toBeInTheDocument();
+
+    // The manual escape hatch to sign-in stays available.
+    fireEvent.click(within(modal).getByText(/Already have an account/i));
+    expect(within(modal).getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+  });
+
+  it('keeps the header Sign In entry point in sign-in mode (CUR-152)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as never);
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('access-gate')).toBeInTheDocument();
+    });
+
+    const header = screen.getByRole('banner');
+    fireEvent.click(within(header).getByRole('button', { name: 'Sign In' }));
+
+    const modal = await screen.findByTestId('auth-modal');
+    expect(within(modal).getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+    expect(
+      within(modal).queryByRole('heading', { name: /join the museum/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it('hides the bottom-nav Explore tab when no sample collection is loaded (no dead link)', async () => {
     const { ThemeProvider } = await import('@/theme');
     // Authenticated user whose only collection is private and cloud returns no


### PR DESCRIPTION
## Problem

The anonymous welcome gate's primary CTA — "Add your first item" — is aimed at someone who has no account yet, but clicking it opened the auth modal in **sign-in** mode titled **"Welcome Back"**, with sign-up relegated to a footer link. The likeliest clicker must recognize the mismatch, hunt for the switch link, and change modes at exactly the conversion moment the "value in 5 minutes" constraint protects (CUR-152). This is a first-run trust wobble: the product greets a new visitor as a stranger it claims to remember.

## Approach

- `AppContent` now tracks the intent behind opening the auth modal in a small `authModalMode` state (`'signin' | 'signup'`) with an `openAuthModal(mode)` helper, passed to `AuthModal` via its existing `initialMode` prop.
- First-run intents default to sign-up: the "Add your first item" CTA (`handleAddAction`), "Start a collection" (`handleCreateCollectionAction`), and the save-attempt path inside collection creation (`handleCreateCollection`).
- Returning-user entry points keep sign-in: header "Sign In", the profile-sheet Sign In (`Layout onOpenAuth`), and the collection-unavailable gate. The password-recovery redirect (`set-password`) is untouched.
- In `AuthModal`, the open-reset effect now clears the email field for ordinary sign-in/sign-up opens (previously it skipped clearing whenever *any* `initialMode` was set, which only recovery used); email is still preserved across the recovery redirect.
- No copy changes: sign-up mode already renders "Join the Museum" with the Private / Fast / Cloud Sync trust cues and the legal-consent line.

## Why this approach

`AuthModal` already had an `initialMode` prop and `AppContent` already distinguishes triggering intent via `pendingAuthAction`, so this rides both existing mechanisms — no new component, prop contract, or state pattern. It is the issue's recommended solution and the smallest change that makes the first-run greeting match first-run intent.

## Risks

Low. The change only selects which existing mode the modal opens in; auth logic, the queued post-auth action, mode switching, and password recovery are untouched. Watch item: any future entry point that calls `openAuthModal` must pick the intent explicitly, which the helper's signature forces.

## How to verify

Vercel Preview: https://curio-git-claude-curio-152-auth-mod-fa37ce-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview logged out. Click **Add your first item** — the modal reads **"Join the Museum"** with **Create Account** as the primary action and the Private / Fast / Cloud Sync trust cues.
2. Click "Already have an account? Sign in" — sign-in mode still reachable; switch back works too.
3. Close the modal and click the header **Sign In** — the modal reads **"Welcome Back"** (unchanged default). Same for the profile-sheet Sign In.
4. Complete auth from either mode after clicking a first-run CTA — the add/create flow still opens afterwards (pending-action queue unchanged).

Checks:
- [x] npm run format:check
- [x] npm test (61 files, 947 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

| First-run CTA → sign-up (mobile) | Header Sign In → sign-in (desktop) |
| --- | --- |
| Modal opens as "Join the Museum" / Create Account | Modal still opens as "Welcome Back" / Sign In |

(Screenshots captured against a local dev build; the same flows are reproducible in seconds on the Vercel preview, steps 1 and 3 above.)

## Linear

Closes CUR-152

## Rollback plan

Green-tier UI-behavior change, single commit: `git revert ca7e779` restores the sign-in-everywhere default. No data, schema, storage, or env changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbcZct78RTj76br1SNp68Y