### PR TITLE
[UX] Fix invisible Filter button icon on Collection screen

### DIFF
--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -435,7 +435,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
               </div>
               <Button
                 variant={activeFilterCount > 0 ? 'primary' : 'outline'}
-                className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}
+                className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center !p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}
                 onClick={() => setIsFilterModalOpen(true)}
                 aria-label={t('filterCollection')}
                 title={t('filterCollection')}


### PR DESCRIPTION
## Problem

On every collection screen, the Filter button next to the search box renders as an **empty white rounded square** — the `SlidersHorizontal` icon is squeezed to 0 width. Users have no visual affordance that filtering exists, and the "filters active" state is equally blank.

Confirmed live on https://curio.qiuyue.dev (all themes, desktop and mobile widths) during the July 2026 UI/UX review.

## Root cause

`CollectionScreen.tsx` passes `p-0` to the shared `Button`, but Button's `md` size classes include `px-6 py-3`. In Tailwind's generated stylesheet the `px-*`/`py-*` rules come after the `p-*` shorthand, so `px-6` wins over `p-0`. That leaves 48px of horizontal padding inside a 44px-wide (`w-11`) button, and the flexed SVG collapses to 0×18.

## Fix

Use `!p-0` so the padding override actually applies. One line.

Verified against a local production build: the icon now renders 18×18 with `padding: 0`.

## Checks

- `npm run format:check` ✅
- `npm test` ✅ (62 files, 965 passed)
- `npm run build` ✅
- `npm run test:e2e` ✅ (44 passed, 8 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Be5FBt9pH5aDov6Zqr1hT1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Be5FBt9pH5aDov6Zqr1hT1)_