### PR TITLE
[CUR-155] Defer item_images registry rows until the items row has synced

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -17,6 +17,7 @@ type ItemImageStatus = 'none' | 'processing' | 'ready' | 'failed';
 // Keys for pending sync tracking
 const PENDING_SYNC_KEY = 'pending_sync_ids';
 const PENDING_ASSET_UPLOADS_KEY = 'pending_asset_uploads';
+const PENDING_IMAGE_RECORDS_KEY = 'pending_image_records';
 const PENDING_DELETE_KEY = 'pending_deletes';
 const PENDING_DELETE_JOURNAL_KEY = 'curio_pending_delete_journal';
 
@@ -138,6 +139,21 @@ const notifyAssetSyncStatus = (
 type PendingAssetUpload = {
   collectionId: string;
   itemId: string;
+  createdAt?: string;
+  attemptCount?: number;
+  lastError?: string;
+  nextRetryAt?: string;
+};
+
+// item_images registry rows that could not be upserted yet — typically because
+// the owning `items` row had not synced when the asset finished uploading (new
+// items upload their photos before the collection save lands in Supabase).
+// Flushed by syncPendingImageRecords once the item row exists.
+type PendingImageRecord = {
+  collectionId: string;
+  itemId: string;
+  role: ItemImageRole;
+  storagePath: string;
   createdAt?: string;
   attemptCount?: number;
   lastError?: string;
@@ -656,6 +672,77 @@ const removeFromPendingAssetUploads = async (
   tx.objectStore(SETTINGS_STORE).put(filtered, PENDING_ASSET_UPLOADS_KEY);
 };
 
+const getPendingImageRecords = async (): Promise<PendingImageRecord[]> => {
+  const db = await initDB();
+  return new Promise((resolve) => {
+    const tx = db.transaction(SETTINGS_STORE, 'readonly');
+    const req = tx.objectStore(SETTINGS_STORE).get(PENDING_IMAGE_RECORDS_KEY);
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = () => resolve([]);
+  });
+};
+
+const savePendingImageRecords = async (records: PendingImageRecord[]): Promise<void> => {
+  const db = await initDB();
+  const tx = db.transaction(SETTINGS_STORE, 'readwrite');
+  tx.objectStore(SETTINGS_STORE).put(records, PENDING_IMAGE_RECORDS_KEY);
+};
+
+const addToPendingImageRecords = async (
+  collectionId: string,
+  itemId: string,
+  records: { role: ItemImageRole; storagePath: string }[],
+): Promise<void> => {
+  if (records.length === 0) return;
+  const pending = await getPendingImageRecords();
+  const now = new Date().toISOString();
+  for (const record of records) {
+    const existing = pending.find((entry) => entry.itemId === itemId && entry.role === record.role);
+    if (existing) {
+      existing.storagePath = record.storagePath;
+    } else {
+      pending.push({
+        collectionId,
+        itemId,
+        role: record.role,
+        storagePath: record.storagePath,
+        createdAt: now,
+        attemptCount: 0,
+      });
+    }
+  }
+  await savePendingImageRecords(pending);
+};
+
+const removeFromPendingImageRecords = async (
+  itemId: string,
+  role: ItemImageRole,
+): Promise<void> => {
+  const pending = await getPendingImageRecords();
+  const filtered = pending.filter((entry) => !(entry.itemId === itemId && entry.role === role));
+  await savePendingImageRecords(filtered);
+};
+
+const markPendingImageRecordFailure = async (
+  itemId: string,
+  role: ItemImageRole,
+  errorMessage?: string,
+): Promise<void> => {
+  const pending = await getPendingImageRecords();
+  const now = Date.now();
+  const updated = pending.map((entry) => {
+    if (entry.itemId !== itemId || entry.role !== role) return entry;
+    const nextAttempt = (entry.attemptCount ?? 0) + 1;
+    return {
+      ...entry,
+      attemptCount: nextAttempt,
+      lastError: errorMessage || entry.lastError,
+      nextRetryAt: new Date(now + getAssetUploadBackoffMs(nextAttempt)).toISOString(),
+    };
+  });
+  await savePendingImageRecords(updated);
+};
+
 export const hasPendingSyncs = async (): Promise<boolean> => {
   const pending = await getPendingSyncEntries();
   return pending.length > 0;
@@ -762,23 +849,113 @@ const uploadAssetToCloud = async (
     throw new Error(`Storage upload failed: ${originalUpload?.error || displayUpload?.error}`);
   }
 
-  await recordItemImage({
-    itemId,
-    role: 'original',
-    storagePath: originalPath,
-    isCurrent: true,
+  await recordItemImagesOrDefer(collectionId, itemId, [
+    { role: 'original', storagePath: originalPath },
+    { role: 'display', storagePath: displayPath },
+  ]);
+};
+
+const cloudItemRowExists = async (itemId: string): Promise<boolean> => {
+  if (!isSupabaseConfigured() || !supabase) return false;
+  const { data, error } = await supabase.from('items').select('id').eq('id', itemId).maybeSingle();
+  if (error) {
+    throw new Error(`Item lookup failed: ${error.message}`);
+  }
+  return Boolean(data);
+};
+
+const recordItemImagesOrDefer = async (
+  collectionId: string,
+  itemId: string,
+  records: { role: ItemImageRole; storagePath: string }[],
+): Promise<void> => {
+  let itemSynced = false;
+  try {
+    itemSynced = await cloudItemRowExists(itemId);
+  } catch {
+    itemSynced = false;
+  }
+  if (!itemSynced) {
+    // Brand-new items upload their photos before the `items` row syncs with the
+    // collection save. Upserting item_images now would hit the DB trigger's
+    // 'Invalid item_id' — queue the rows and flush once the item row lands.
+    await addToPendingImageRecords(collectionId, itemId, records);
+    return;
+  }
+  const failed: { role: ItemImageRole; storagePath: string }[] = [];
+  for (const record of records) {
+    const recorded = await recordItemImage({
+      itemId,
+      role: record.role,
+      storagePath: record.storagePath,
+      isCurrent: true,
+    });
+    if (!recorded) failed.push(record);
+  }
+  await addToPendingImageRecords(collectionId, itemId, failed);
+};
+
+// Flush deferred item_images rows whose `items` row has since synced. Never
+// throws — callers run it opportunistically after item syncs.
+export const syncPendingImageRecords = async (): Promise<number> => {
+  if (!isSupabaseConfigured() || !supabase) return 0;
+  const pending = await getPendingImageRecords();
+  if (pending.length === 0) return 0;
+
+  const now = Date.now();
+  const dueRecords = pending.filter((entry) => {
+    if (!entry.nextRetryAt) return true;
+    const retryAt = new Date(entry.nextRetryAt).getTime();
+    return Number.isNaN(retryAt) || retryAt <= now;
   });
-  await recordItemImage({
-    itemId,
-    role: 'display',
-    storagePath: displayPath,
-    isCurrent: true,
-  });
+  if (dueRecords.length === 0) return 0;
+
+  let recorded = 0;
+  const itemRowSynced = new Map<string, boolean>();
+  for (const entry of dueRecords) {
+    try {
+      // The display blob is the item's canonical local asset; if it is gone,
+      // the item was deleted before its registry rows could sync — drop them.
+      const display = await readAssetFromStore(DISPLAY_STORE, entry.itemId);
+      if (!display) {
+        await removeFromPendingImageRecords(entry.itemId, entry.role);
+        continue;
+      }
+      let itemExists = itemRowSynced.get(entry.itemId);
+      if (itemExists === undefined) {
+        itemExists = await cloudItemRowExists(entry.itemId);
+        itemRowSynced.set(entry.itemId, itemExists);
+      }
+      if (!itemExists) {
+        await markPendingImageRecordFailure(entry.itemId, entry.role, 'Item row not yet synced');
+        continue;
+      }
+      const ok = await recordItemImage({
+        itemId: entry.itemId,
+        role: entry.role,
+        storagePath: entry.storagePath,
+        isCurrent: true,
+      });
+      if (ok) {
+        await removeFromPendingImageRecords(entry.itemId, entry.role);
+        recorded++;
+      } else {
+        await markPendingImageRecordFailure(entry.itemId, entry.role, 'item_images upsert failed');
+      }
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : 'Unknown error';
+      await markPendingImageRecordFailure(entry.itemId, entry.role, errorMessage).catch(() => {});
+    }
+  }
+  return recorded;
 };
 
 export const syncPendingAssetUploads = async (): Promise<number> => {
   return withSyncLock(async () => {
     if (!isSupabaseConfigured() || !supabase) return 0;
+    // Registry rows deferred while their item row was in flight can usually be
+    // recorded by now (syncPendingChanges runs before this in the app flow).
+    await syncPendingImageRecords();
     const pendingUploads = await getPendingAssetUploads();
     if (pendingUploads.length === 0) return 0;
 
@@ -1417,6 +1594,9 @@ export const saveCollection = async (collection: UserCollection): Promise<void> 
       await saveCollectionToCloud(collectionToSave);
       // Success - remove from pending queue if it was there
       await removeFromPendingSync(collectionToSave.id);
+      // The items rows just landed — record any item_images registry rows that
+      // were deferred because the asset upload raced this sync (new items).
+      await syncPendingImageRecords();
       notifySyncStatus('synced');
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'Sync failed';
@@ -1446,15 +1626,15 @@ const recordItemImage = async ({
   recipe?: Record<string, any>;
   isCurrent?: boolean;
   sourceImageId?: string | null;
-}): Promise<void> => {
-  if (!isSupabaseConfigured() || !supabase) return;
+}): Promise<boolean> => {
+  if (!isSupabaseConfigured() || !supabase) return true;
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) return;
+  if (!user) return false;
 
   const normalizedPath = normalizeStoragePath(storagePath);
-  if (!normalizedPath) return;
+  if (!normalizedPath) return true;
 
   if (isCurrent) {
     await supabase
@@ -1481,7 +1661,9 @@ const recordItemImage = async ({
   const { error } = await supabase.from('item_images').upsert(payload);
   if (error) {
     console.warn('Cloud item image sync failed:', error);
+    return false;
   }
+  return true;
 };
 
 export const saveAsset = async (

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -71,6 +71,10 @@ async function clearStores(db: IDBDatabase, storeNames: string[]) {
 function createSupabaseMock() {
   const collectionsUpsert = vi.fn().mockResolvedValue({ error: null });
   const itemsUpsert = vi.fn().mockResolvedValue({ error: null });
+  const itemImagesUpsert = vi.fn().mockResolvedValue({ error: null });
+  // Asset uploads check whether the item row has synced before recording
+  // item_images rows; default to "row exists" so happy paths record inline.
+  const itemsMaybeSingle = vi.fn().mockResolvedValue({ data: { id: 'exists' }, error: null });
   const upload = vi.fn().mockResolvedValue({ data: { path: 'ok' }, error: null });
   const update = vi.fn(() => {
     const chain: any = {};
@@ -79,11 +83,18 @@ function createSupabaseMock() {
   });
 
   const from = vi.fn((table: string) => {
+    const upsertForTable =
+      table === 'collections'
+        ? collectionsUpsert
+        : table === 'item_images'
+          ? itemImagesUpsert
+          : itemsUpsert;
     return {
-      upsert: table === 'collections' ? collectionsUpsert : itemsUpsert,
+      upsert: upsertForTable,
       update,
-      // present for completeness; not used directly by these tests
-      select: vi.fn().mockReturnThis(),
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: itemsMaybeSingle })),
+      })),
       or: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       in: vi.fn().mockReturnThis(),
@@ -102,6 +113,8 @@ function createSupabaseMock() {
     },
     collectionsUpsert,
     itemsUpsert,
+    itemImagesUpsert,
+    itemsMaybeSingle,
     upload,
     from,
   };
@@ -380,6 +393,152 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     const pendingAfterSync = await readFromStore<any[]>(db, 'settings', 'pending_asset_uploads');
     expect(pendingAfterSync).toEqual([]);
     expect(upload).toHaveBeenCalledTimes(2);
+  });
+
+  it('saveAsset: defers item_images rows for a brand-new item until its items row syncs (CUR-155)', async () => {
+    /**
+     * New items upload their photos before the `items` row syncs with the
+     * collection save. Upserting item_images at that point always fails with
+     * the DB trigger's "Invalid item_id" — instead the rows must be queued and
+     * recorded right after the collection sync lands the item row.
+     */
+    const { supabase, itemImagesUpsert, itemsMaybeSingle, upload } = createSupabaseMock();
+    // The items row has not synced yet.
+    itemsMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const original = new Blob(['orig'], { type: 'image/jpeg' });
+    const display = new Blob(['disp'], { type: 'image/jpeg' });
+
+    await expect(
+      dbMod.saveAsset('col-1', 'item-new-1', original, display),
+    ).resolves.toBeUndefined();
+
+    // Files are uploaded, but no item_images upsert is attempted (it would 400).
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(itemImagesUpsert).not.toHaveBeenCalled();
+
+    const queued = await readFromStore<any[]>(db, 'settings', 'pending_image_records');
+    expect(queued).toEqual([
+      expect.objectContaining({ collectionId: 'col-1', itemId: 'item-new-1', role: 'original' }),
+      expect.objectContaining({ collectionId: 'col-1', itemId: 'item-new-1', role: 'display' }),
+    ]);
+
+    // The collection save now syncs the items row; the deferred registry rows
+    // must be recorded in the same flow.
+    itemsMaybeSingle.mockResolvedValue({ data: { id: 'item-new-1' }, error: null });
+    const collection: UserCollection = {
+      id: 'col-1',
+      templateId: 'vinyl',
+      name: 'My Collection',
+      icon: '🎵',
+      customFields: [],
+      items: [
+        {
+          id: 'item-new-1',
+          collectionId: 'col-1',
+          photoUrl: 'asset',
+          title: 'New item',
+          rating: 0,
+          data: {},
+          createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+          updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+          notes: '',
+        },
+      ],
+      ownerId: 'test-user-id',
+      updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+    };
+    await expect(dbMod.saveCollection(collection)).resolves.toBeUndefined();
+
+    expect(itemImagesUpsert).toHaveBeenCalledTimes(2);
+    const payloads = itemImagesUpsert.mock.calls.map((c) => c[0]);
+    expect(payloads).toEqual([
+      expect.objectContaining({
+        item_id: 'item-new-1',
+        role: 'original',
+        storage_path: 'test-user-id/collections/col-1/item-new-1/original.jpg',
+        is_current: true,
+      }),
+      expect.objectContaining({
+        item_id: 'item-new-1',
+        role: 'display',
+        storage_path: 'test-user-id/collections/col-1/item-new-1/display.jpg',
+        is_current: true,
+      }),
+    ]);
+
+    const drained = await readFromStore<any[]>(db, 'settings', 'pending_image_records');
+    expect(drained).toEqual([]);
+  });
+
+  it('syncPendingImageRecords: retries a transient item_images failure after backoff', async () => {
+    const { supabase, itemImagesUpsert } = createSupabaseMock();
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const original = new Blob(['orig'], { type: 'image/jpeg' });
+    const display = new Blob(['disp'], { type: 'image/jpeg' });
+
+    // Item row exists (mock default), but the first registry upsert fails.
+    itemImagesUpsert.mockResolvedValueOnce({ error: { message: 'transient' } });
+    await dbMod.saveAsset('col-1', 'item-retry-1', original, display);
+
+    const queued = await readFromStore<any[]>(db, 'settings', 'pending_image_records');
+    expect(queued).toEqual([
+      expect.objectContaining({
+        itemId: 'item-retry-1',
+        role: 'original',
+        attemptCount: 0,
+      }),
+    ]);
+
+    // A fresh queue entry is immediately due; the flush retries and succeeds.
+    itemImagesUpsert.mockClear();
+    await expect(dbMod.syncPendingImageRecords()).resolves.toBe(1);
+    expect(itemImagesUpsert).toHaveBeenCalledTimes(1);
+
+    const drained = await readFromStore<any[]>(db, 'settings', 'pending_image_records');
+    expect(drained).toEqual([]);
+
+    consoleWarn.mockRestore();
+  });
+
+  it('syncPendingImageRecords: drops queued rows for items deleted before the registry synced', async () => {
+    const { supabase, itemImagesUpsert, itemsMaybeSingle, upload } = createSupabaseMock();
+    itemsMaybeSingle.mockResolvedValue({ data: null, error: null });
+    // deleteAsset's cloud cleanup exercises chains this mock does not model.
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const original = new Blob(['orig'], { type: 'image/jpeg' });
+    const display = new Blob(['disp'], { type: 'image/jpeg' });
+    await dbMod.saveAsset('col-1', 'item-deleted-1', original, display);
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    // The user deletes the item before its rows are recorded.
+    await dbMod.deleteAsset('col-1', 'item-deleted-1');
+
+    itemsMaybeSingle.mockResolvedValue({ data: { id: 'item-deleted-1' }, error: null });
+    await expect(dbMod.syncPendingImageRecords()).resolves.toBe(0);
+
+    expect(itemImagesUpsert).not.toHaveBeenCalled();
+    const drained = await readFromStore<any[]>(db, 'settings', 'pending_image_records');
+    expect(drained).toEqual([]);
+
+    consoleWarn.mockRestore();
   });
 
   it.todo('exports saveItem(item, session) as a function (roadmap API - not yet implemented)');


### PR DESCRIPTION
## Problem

Adding a new item with a photo uploads both image files to Storage and immediately upserts `item_images` rows — but the `items` row itself only syncs with the collection save. The `item_images` BEFORE-trigger (`set_item_image_user_id_from_item()`) can't find the owning item and raises `Invalid item_id` (P0001). The client warn-and-dropped that failure, so **every brand-new item permanently lost its `original`/`display` registry rows**, while logging two 400s per save and still telling the user "backed up". This violates the **Explicit outcomes / trust** principle: the app claimed a full backup while part of the sync silently failed. (Verified in production: only 10 of the tester's 37+ items have `item_images` rows.)

## Approach

Client-side ordering fix in `src/services/db.ts`, reusing the existing pending-queue house style:

- `uploadAssetToCloud` now checks whether the cloud `items` row exists (one cheap `select ... maybeSingle`) before recording registry rows. If the row hasn't synced yet (the brand-new-item race), the `original`/`display` records are **deferred** into a new persisted `pending_image_records` queue in the IndexedDB settings store — no guaranteed-400 upsert is fired.
- `recordItemImage` now reports success/failure instead of swallowing errors; transient upsert failures are queued with the same exponential backoff used for pending asset uploads.
- New `syncPendingImageRecords()` flushes the queue. It runs (a) right after a successful `saveCollectionToCloud` inside `saveCollection` — at that moment the items rows just landed, so in the normal add-item flow the registry rows are recorded within the same save flow — and (b) at the start of `syncPendingAssetUploads()`, which covers app-relaunch and retry paths with **zero App.tsx changes** (it already runs after `syncPendingChanges` in the background sync block and on force sync).
- Queue entries whose local display blob is gone are dropped, so items deleted before their registry synced don't retry forever.

## Why this approach

It's the fix the issue recommends (client-side ordering, not a trigger change) and the smallest one that satisfies "no 400s" — a retry-only fix would still fire the doomed first upsert on every new item. It reuses the existing pending-uploads machinery style rather than inventing new sync concepts, and it never re-uploads image blobs just to record registry rows. No schema, RLS, or UI changes.

## Risks

- `saveCollection`'s success path now runs a queue flush; it is written to never throw (per-entry try/catch), so a flush problem cannot mark a successful sync as failed.
- One extra lightweight `items` SELECT per asset upload (RLS-scoped by id).
- If a queued record can never be flushed (item never syncs), it retries with capped backoff (30s → 10min) rather than being dropped — bounded, low-noise.

## How to verify

Vercel Preview: https://curio-git-claude-cur-155-defer-item-ce1bca-qs-projects-72b20d9d.vercel.app

Steps (manual, sync change — IndexedDB + Supabase):

1. Sign in on the preview URL with the tester account, open DevTools (Console + Network filtered to `item_images`).
2. Add an item with a photo to any private collection and save.
3. **Before:** two `HTTP 400 …/rest/v1/item_images` (`P0001 Invalid item_id`) + `Cloud item image sync failed` warnings. **After:** no 400s and no warnings; the upserts fire once after the items upsert.
4. In Supabase Table Editor, query `item_images` for the new item id — rows for `original` and `display` exist with `is_current = true`.
5. IndexedDB check: DevTools → Application → IndexedDB → CurioDatabase → settings → `pending_image_records` is empty after the save settles. (Mid-save, between asset upload and collection sync, it briefly holds the two deferred rows.)
6. Transient-failure path: block `rest/v1/item_images` via DevTools request blocking, add an item — rows are queued; unblock, wait for backoff / trigger a sync — rows are recorded and the queue drains.

Checks:

- [x] npm run format:check
- [x] npm test (62 files, 968 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No visible UI change — the fix is sync-layer only (console/network/DB behavior); verification is via the steps above.

## Linear

Closes CUR-155

## Rollback plan

Pure client-side change, no migrations: revert the single commit (`git revert 71f018d`) and redeploy. Any `pending_image_records` entries left in users' IndexedDB settings store are simply never read by reverted code and are harmless.