### PR TITLE
[CUR-110] Theme the batch info card and batch error banner on Vault/Atelier

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -147,6 +147,19 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     vault: 'text-amber-100 hover:text-white',
     atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]',
   }[theme];
+  // CUR-110: the batch-mode info card shares the warn-banner surface; its
+  // title and icon need their own amber steps so the hierarchy survives on
+  // Vault/Atelier instead of flipping back to the Gallery pastel card.
+  const batchInfoTitleClass = {
+    gallery: 'text-amber-900',
+    vault: 'text-amber-100',
+    atelier: 'text-amber-950',
+  }[theme];
+  const batchInfoIconClass = {
+    gallery: 'text-amber-600',
+    vault: 'text-amber-300',
+    atelier: 'text-amber-700',
+  }[theme];
   const lowConfidenceSurfaceClass = {
     gallery: 'bg-stone-100 text-stone-700 border-stone-200',
     vault: 'bg-white/5 text-stone-300 border-white/10',
@@ -1112,17 +1125,20 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     const hasMoreBatchItems = batchVisibleCount < batchItems.length;
     return (
       <div className="space-y-6">
-        <div className="bg-amber-50 p-4 rounded-2xl flex gap-3 border border-amber-100">
-          <Zap className="text-amber-600 shrink-0" size={20} />
+        <div
+          data-testid="add-item-batch-info"
+          className={`p-4 rounded-2xl flex gap-3 border ${warnBannerClass}`}
+        >
+          <Zap className={`shrink-0 ${batchInfoIconClass}`} size={20} />
           <div>
-            <h4 className="text-sm font-bold text-amber-900">{t('batchMode')}</h4>
-            <p className="text-[11px] text-amber-700">{t('batchModeDesc')}</p>
+            <h4 className={`text-sm font-bold ${batchInfoTitleClass}`}>{t('batchMode')}</h4>
+            <p className="text-[11px]">{t('batchModeDesc')}</p>
           </div>
         </div>
         {error && (
           <div
             id="add-item-error"
-            className="p-3 bg-amber-50 text-amber-700 text-xs rounded-xl border border-amber-100 font-medium"
+            className={`p-3 text-xs rounded-xl border font-medium ${warnBannerClass}`}
           >
             {error}
           </div>

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -1113,4 +1113,86 @@ describe('AddItemModal', () => {
       expect(tile).toHaveClass('border-stone-100');
     });
   });
+
+  describe('Batch surfaces theme contrast (CUR-110)', () => {
+    const uploadBatchFile = async (user: ReturnType<typeof userEvent.setup>) => {
+      const file = new File(['fake'], 'artifact.png', { type: 'image/png' });
+      const input = screen.getByTestId('add-item-batch-input') as HTMLInputElement;
+      await user.upload(input, file);
+      return screen.findByTestId('add-item-batch-info');
+    };
+
+    beforeEach(() => {
+      mockRefreshAiEnabled.mockResolvedValue(true);
+      mockAnalyzeImage.mockResolvedValue({
+        status: 'success',
+        title: 'Mock Artifact',
+        notes: '',
+        data: {},
+      });
+    });
+
+    it('renders the batch info card with Vault warn tones, not the Gallery pastel', async () => {
+      setMockTheme('vault');
+      const user = userEvent.setup();
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection({ name: 'Artifacts', customFields: [] })]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      const infoCard = await uploadBatchFile(user);
+      // The Gallery-only pastel card collapses against Vault's dark panel.
+      expect(infoCard).not.toHaveClass('bg-amber-50');
+      expect(infoCard).toHaveClass('bg-amber-500/10');
+      expect(infoCard).toHaveClass('border-amber-400/20');
+      const title = infoCard.querySelector('h4');
+      expect(title).not.toBeNull();
+      expect(title!.className).toMatch(/text-amber-100/);
+      expect(title!.className).not.toMatch(/text-amber-900/);
+    });
+
+    it('renders the batch error banner with Vault warn tones after a failed save', async () => {
+      setMockTheme('vault');
+      const user = userEvent.setup();
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection({ name: 'Artifacts', customFields: [] })]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      await uploadBatchFile(user);
+      mockOnSave.mockReset();
+      mockOnSave.mockRejectedValueOnce(new Error('Could not save image. Please try again.'));
+      await user.click(screen.getByRole('button', { name: /Save \d+ pieces?/ }));
+
+      const banner = await screen.findByText('Could not save image. Please try again.');
+      expect(banner).not.toHaveClass('bg-amber-50');
+      expect(banner).toHaveClass('bg-amber-500/10');
+      expect(banner).toHaveClass('text-amber-200');
+    });
+
+    it('preserves the Gallery tones for the batch info card on the default theme', async () => {
+      setMockTheme('gallery');
+      const user = userEvent.setup();
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection({ name: 'Artifacts', customFields: [] })]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      const infoCard = await uploadBatchFile(user);
+      expect(infoCard).toHaveClass('bg-amber-50');
+      expect(infoCard).toHaveClass('border-amber-100');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The batch-verify step of AddItemModal still hardcoded Gallery-only pastels (`bg-amber-50` / `border-amber-100` / `text-amber-*`) on two surfaces:

1. the **batch-mode info card** (Zap icon + "Batch Mode" explainer), and
2. the **batch error banner** (shown when a batch save fails).

On Vault both rendered as a bright cream card inside the dark modal; on Atelier they clashed with the warm cream palette. Error feedback during batch import must stay clearly legible on all themes (trust before growth / explicit outcomes). This is the remaining scope of CUR-110 — the third spot in the issue (the "Skip and add manually" link) was already fixed by CUR-22 via `subtleLinkHoverClass`.

## Approach

- Batch error banner now uses the existing `warnBannerClass` tone map (introduced for CUR-92, mirroring the StatusBanner palette from CUR-81) — a drop-in for the previous hardcoded Gallery classes.
- Batch info card reuses `warnBannerClass` for its surface/border/body text, plus two small new maps (`batchInfoTitleClass`, `batchInfoIconClass`) so the title/icon keep a stronger amber step per theme. Gallery output is unchanged.
- Added a `data-testid="add-item-batch-info"` hook and three component tests: Vault info card, Vault error banner after a failed save, and a Gallery regression guard.

## Why this approach

It reuses the exact theme-token pattern this file already established for the analyzing/verify screens (CUR-92) and the upload/picker surfaces (CUR-22), so batch mode stops being the odd one out. No new tokens, no design-system changes, Gallery rendering is byte-identical. Smallest change that makes all three themes coherent on the batch path.

## Risks

Low — presentational-only change scoped to two elements on the batch-verify step; Gallery classes are preserved verbatim and covered by a regression test.

## How to verify

Vercel Preview: https://curio-git-claude-eloquent-meitner-0xf9wm-qs-projects-72b20d9d.vercel.app

Steps:
1. Open Add Item → choose **Batch Mode** and select 2+ photos.
2. On the batch-verify step, switch to **Vault**: the info card should be a soft amber tint over the dark panel (not a cream card), with legible amber title/body.
3. Trigger a failed save (e.g. offline) — the error banner should use the same dark-friendly amber warn tone.
4. Switch to **Atelier** and confirm both surfaces blend with the warm palette; switch to **Gallery** and confirm nothing changed.

Checks:
- [x] npm run format:check
- [x] npm test (971 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Theme-token change verified by component tests asserting the rendered classes per theme; see the Vercel preview above for a visual pass (batch-verify step on Vault/Atelier).

## Linear

Closes CUR-110

## Rollback plan

Green-tier presentational change — `git revert d7090e1`, or hand-revert the two class substitutions in `src/components/AddItemModal.tsx` and drop the `Batch surfaces theme contrast (CUR-110)` describe block from `tests/components/AddItemModal.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)