### PR TITLE
Allow deselecting a preset card in the collection setup flow

### DIFF
--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -154,14 +154,17 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   };
 
   const handleTemplateSelect = (templateId: string) => {
-    setSelectedTemplateId(templateId);
+    // Tapping the already-selected preset clears it, returning the user to
+    // the free-text suggestion flow without closing the modal.
+    const nextTemplateId = selectedTemplateId === templateId ? '' : templateId;
+    setSelectedTemplateId(nextTemplateId);
     setSuggestedFields([]);
     setSelectedFields([]);
     setPinnedFields([]);
     setStatusMessage(null);
-    const template = TEMPLATES.find((temp) => temp.id === templateId);
-    if (template && !hasCustomIcon) {
-      setIcon(template.icon);
+    if (!hasCustomIcon) {
+      const template = TEMPLATES.find((temp) => temp.id === nextTemplateId);
+      setIcon(template ? template.icon : DEFAULT_ICON);
     }
   };
 

--- a/tests/components/CreateCollectionModal.test.tsx
+++ b/tests/components/CreateCollectionModal.test.tsx
@@ -99,6 +99,36 @@ describe('CreateCollectionModal', () => {
       expect(screen.getByTestId('suggested-field-3')).toHaveTextContent('Genre');
     });
 
+    it('clears a selected preset when the same card is tapped again', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      const vinylCard = screen.getByTestId('collection-preset-vinyl');
+      await user.click(vinylCard);
+      expect(vinylCard).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByTestId('collection-continue-btn')).toBeEnabled();
+
+      await user.click(vinylCard);
+      expect(vinylCard).toHaveAttribute('aria-pressed', 'false');
+      // With no preset and no description, Continue is disabled again.
+      expect(screen.getByTestId('collection-continue-btn')).toBeDisabled();
+    });
+
+    it('follows the free-text suggestion flow after deselecting a preset', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      await user.type(screen.getByTestId('collection-description-input'), 'fountain pens');
+      const vinylCard = screen.getByTestId('collection-preset-vinyl');
+      await user.click(vinylCard);
+      await user.click(vinylCard);
+      await user.click(screen.getByTestId('collection-continue-btn'));
+
+      // Free-text path shows the suggestion loading state, not the template fields.
+      expect(screen.getByTestId('collection-loading-spinner')).toBeInTheDocument();
+      expect(screen.queryByText('Artist')).not.toBeInTheDocument();
+    });
+
     it('creates the collection and launches Add Item for the new collection', async () => {
       const user = userEvent.setup();
       renderWithProviders(<CreateCollectionModal {...defaultProps} />);


### PR DESCRIPTION
Addresses the P2 review comment on #351 ([discussion](https://github.com/Akkkkkkki/curio/pull/351#discussion_r3561795796)): once a preset card was tapped, `handleTemplateSelect` could only ever set a template id and the shelf removed the old empty `<option>`, so there was no way back to the free-text suggestion flow without closing the modal — `handleContinueFromEntry` always took the selected-template path.

## Summary
- tapping the already-selected preset card now clears the selection, restoring the free-text suggestion flow (and re-disabling Continue when there's no description)
- clearing the selection restores the default icon unless the user picked a custom one
- adds tests for toggle-off and for the free-text path after deselecting

## Verification
- `npm run format:check`
- `npm test` (61 files, 945 passed)
- `npm run build`
- `npm run test:e2e` (44 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sgMYz5CCWcToxDrV9KZMK

---
_Generated by [Claude Code](https://claude.ai/code/session_019sgMYz5CCWcToxDrV9KZMK)_