### PR TITLE
[#149] Escalate repeatedly failing photo uploads to a visible error state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import { ErrorBoundary } from './components/ui/ErrorBoundary';
 import {
   fetchCloudCollections,
   getLocalCollections,
-  getPendingAssetUploadCount,
+  getPendingAssetUploadSummary,
   getPendingDeletes,
   getPendingSyncIds,
   hasLocalOnlyData,
@@ -49,6 +49,7 @@ import {
   syncPendingChanges,
   syncPendingAssetUploads,
   syncPendingDeletes,
+  type PendingAssetUploadSummary,
   type SyncStatus,
 } from './services/db';
 import { processImage } from './services/imageProcessor';
@@ -124,7 +125,10 @@ export const AppContent: React.FC = () => {
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
   const [syncError, setSyncError] = useState<string | null>(null);
   const [itemSaveStates, setItemSaveStates] = useState<Record<string, ItemSaveState>>({});
-  const [pendingAssetUploads, setPendingAssetUploads] = useState(0);
+  const [pendingAssetUploads, setPendingAssetUploads] = useState<PendingAssetUploadSummary>({
+    total: 0,
+    stalled: 0,
+  });
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
   const [conflicts, setConflicts] = useState<ReturnType<typeof detectConflicts>>([]);
   const [isConflictModalOpen, setIsConflictModalOpen] = useState(false);
@@ -187,8 +191,8 @@ export const AppContent: React.FC = () => {
 
   const refreshPendingAssetUploads = useCallback(async () => {
     try {
-      const count = await getPendingAssetUploadCount();
-      setPendingAssetUploads(count);
+      const summary = await getPendingAssetUploadSummary();
+      setPendingAssetUploads(summary);
     } catch (error) {
       console.warn('Pending upload count check failed:', error);
     }
@@ -236,7 +240,7 @@ export const AppContent: React.FC = () => {
   const handleRetrySync = useCallback(async () => {
     try {
       const synced = await syncPendingChanges({ force: true });
-      const assetsSynced = await syncPendingAssetUploads();
+      const assetsSynced = await syncPendingAssetUploads({ force: true });
       const deletesSynced = await syncPendingDeletes();
       void refreshPendingAssetUploads();
       const dataSynced = synced + deletesSynced;
@@ -1335,11 +1339,22 @@ export const AppContent: React.FC = () => {
     if (isOffline || syncStatus === 'offline') {
       return <StatusBanner title={t('offlineTitle')} message={t('offlineDesc')} tone="warning" />;
     }
-    if (pendingAssetUploads > 0) {
+    if (pendingAssetUploads.stalled > 0) {
       return (
         <StatusBanner
-          title={t('pendingUploadsTitle', { count: pendingAssetUploads })}
-          message={t('pendingUploadsDesc', { count: pendingAssetUploads })}
+          title={t('pendingUploadsErrorTitle', { count: pendingAssetUploads.stalled })}
+          message={t('pendingUploadsErrorDesc')}
+          tone="error"
+          actionLabel={t('actionRetry')}
+          onAction={handleRetrySync}
+        />
+      );
+    }
+    if (pendingAssetUploads.total > 0) {
+      return (
+        <StatusBanner
+          title={t('pendingUploadsTitle', { count: pendingAssetUploads.total })}
+          message={t('pendingUploadsDesc', { count: pendingAssetUploads.total })}
           tone="warning"
           actionLabel={t('actionRetry')}
           onAction={handleRetrySync}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -249,6 +249,9 @@ export const translations = {
     statusSaved: 'Saved',
     pendingUploadsTitle: '{count} upload(s) pending',
     pendingUploadsDesc: 'Photos will sync automatically when you are back online.',
+    pendingUploadsErrorTitle: '{count} photo(s) could not be backed up',
+    pendingUploadsErrorDesc:
+      'Your photos are safe on this device. We will keep retrying, or you can retry now.',
     statusSynced: 'Saved & backed up',
     itemSaveStatusSaving: 'Saving…',
     itemSaveStatusSaved: 'Saved & backed up',
@@ -771,6 +774,8 @@ export const translations = {
     statusSaved: '已保存',
     pendingUploadsTitle: '{count} 个上传待处理',
     pendingUploadsDesc: '照片会在网络恢复后自动同步。',
+    pendingUploadsErrorTitle: '{count} 张照片尚未备份成功',
+    pendingUploadsErrorDesc: '照片已安全保存在本设备上。我们会继续重试，你也可以立即重试。',
     statusSynced: '已保存并备份',
     itemSaveStatusSaving: '保存中…',
     itemSaveStatusSaved: '已保存并备份',

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -162,6 +162,9 @@ type PendingImageRecord = {
 
 const ASSET_UPLOAD_BACKOFF_BASE_MS = 30_000;
 const ASSET_UPLOAD_BACKOFF_MAX_MS = 10 * 60_000;
+// After this many consecutive failures an upload is surfaced to the UI as
+// failing rather than merely pending. Retries still continue in the background.
+const ASSET_UPLOAD_STALLED_ATTEMPTS = 3;
 
 // Exported for testing
 export const compareTimestamps = (a?: string, b?: string) => {
@@ -541,9 +544,19 @@ const getPendingAssetUploads = async (): Promise<PendingAssetUpload[]> => {
   });
 };
 
-export const getPendingAssetUploadCount = async (): Promise<number> => {
+export type PendingAssetUploadSummary = {
+  total: number;
+  /** Uploads that have failed ASSET_UPLOAD_STALLED_ATTEMPTS or more times in a row. */
+  stalled: number;
+};
+
+export const getPendingAssetUploadSummary = async (): Promise<PendingAssetUploadSummary> => {
   const pending = await getPendingAssetUploads();
-  return pending.length;
+  return {
+    total: pending.length,
+    stalled: pending.filter((entry) => (entry.attemptCount ?? 0) >= ASSET_UPLOAD_STALLED_ATTEMPTS)
+      .length,
+  };
 };
 
 const addToPendingAssetUploads = async (collectionId: string, itemId: string): Promise<void> => {
@@ -950,7 +963,7 @@ export const syncPendingImageRecords = async (): Promise<number> => {
   return recorded;
 };
 
-export const syncPendingAssetUploads = async (): Promise<number> => {
+export const syncPendingAssetUploads = async (options?: { force?: boolean }): Promise<number> => {
   return withSyncLock(async () => {
     if (!isSupabaseConfigured() || !supabase) return 0;
     // Registry rows deferred while their item row was in flight can usually be
@@ -960,11 +973,14 @@ export const syncPendingAssetUploads = async (): Promise<number> => {
     if (pendingUploads.length === 0) return 0;
 
     const now = Date.now();
-    const dueUploads = pendingUploads.filter((entry) => {
-      if (!entry.nextRetryAt) return true;
-      const retryAt = new Date(entry.nextRetryAt).getTime();
-      return Number.isNaN(retryAt) || retryAt <= now;
-    });
+    // A user-initiated retry skips the backoff window; scheduled passes respect it.
+    const dueUploads = options?.force
+      ? pendingUploads
+      : pendingUploads.filter((entry) => {
+          if (!entry.nextRetryAt) return true;
+          const retryAt = new Date(entry.nextRetryAt).getTime();
+          return Number.isNaN(retryAt) || retryAt <= now;
+        });
     if (dueUploads.length === 0) {
       return 0;
     }

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -11,7 +11,7 @@ import * as supabaseService from '@/services/supabase';
 vi.mock('@/services/db', () => ({
   getLocalCollections: vi.fn(),
   fetchCloudCollections: vi.fn(),
-  getPendingAssetUploadCount: vi.fn(),
+  getPendingAssetUploadSummary: vi.fn(),
   getPendingDeletes: vi.fn(),
   getPendingSyncIds: vi.fn(),
   hasLocalOnlyData: vi.fn(),
@@ -154,7 +154,7 @@ describe('App Integration Tests', () => {
     vi.mocked(db.mergeCollections).mockImplementation((local, cloud) =>
       cloud.length ? cloud : local,
     );
-    vi.mocked(db.getPendingAssetUploadCount).mockResolvedValue(0);
+    vi.mocked(db.getPendingAssetUploadSummary).mockResolvedValue({ total: 0, stalled: 0 });
     vi.mocked(db.syncPendingChanges).mockResolvedValue(0);
     vi.mocked(db.syncPendingAssetUploads).mockResolvedValue(0);
     vi.mocked(db.syncPendingDeletes).mockResolvedValue(0);
@@ -316,6 +316,58 @@ describe('App Integration Tests', () => {
     await waitFor(() => {
       expect(db.syncPendingDeletes).toHaveBeenCalled();
     });
+  });
+
+  // #149: photo uploads that keep failing must escalate from the calm
+  // "pending" notice to an explicit error state — an eternal "will retry"
+  // is fake certainty about photos that are not backed up.
+  it('escalates the pending-uploads banner to an error once uploads have repeatedly failed (#149)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    vi.mocked(db.getPendingAssetUploadSummary).mockResolvedValue({ total: 3, stalled: 2 });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('2 photo(s) could not be backed up')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/photos are safe on this device/i)).toBeInTheDocument();
+    // The stalled state outranks the calm pending copy.
+    expect(screen.queryByText('3 upload(s) pending')).not.toBeInTheDocument();
+
+    // The banner's Retry must force an immediate attempt — stalled entries
+    // sit behind a backoff window that a scheduled pass would skip.
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await waitFor(() => {
+      expect(db.syncPendingAssetUploads).toHaveBeenCalledWith({ force: true });
+    });
+  });
+
+  it('keeps the calm pending-uploads notice while uploads are only queued (#149)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    vi.mocked(db.getPendingAssetUploadSummary).mockResolvedValue({ total: 2, stalled: 0 });
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('2 upload(s) pending')).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/could not be backed up/)).not.toBeInTheDocument();
   });
 
   it('shows the first-run Home with a sample path instead of a dead-end gate when cloud is not configured', async () => {

--- a/tests/integration/AppReadOnlySave.test.tsx
+++ b/tests/integration/AppReadOnlySave.test.tsx
@@ -69,7 +69,7 @@ vi.mock('@/components/AddItemModal', async () => {
 vi.mock('@/services/db', () => ({
   getLocalCollections: vi.fn(),
   fetchCloudCollections: vi.fn(),
-  getPendingAssetUploadCount: vi.fn(),
+  getPendingAssetUploadSummary: vi.fn(),
   getPendingDeletes: vi.fn(),
   getPendingSyncIds: vi.fn(),
   hasLocalOnlyData: vi.fn(),
@@ -192,7 +192,7 @@ describe('App read-only save handling', () => {
     vi.mocked(db.getPendingSyncIds).mockResolvedValue([]);
     vi.mocked(db.getPendingDeletes).mockResolvedValue([]);
     vi.mocked(db.hasLocalOnlyData).mockReturnValue(false);
-    vi.mocked(db.getPendingAssetUploadCount).mockResolvedValue(0);
+    vi.mocked(db.getPendingAssetUploadSummary).mockResolvedValue({ total: 0, stalled: 0 });
     vi.mocked(db.syncPendingChanges).mockResolvedValue(0);
     vi.mocked(db.syncPendingAssetUploads).mockResolvedValue(0);
     vi.mocked(db.syncPendingDeletes).mockResolvedValue(0);

--- a/tests/integration/AppTypingStability.test.tsx
+++ b/tests/integration/AppTypingStability.test.tsx
@@ -19,7 +19,7 @@ import * as supabaseService from '@/services/supabase';
 vi.mock('@/services/db', () => ({
   getLocalCollections: vi.fn(),
   fetchCloudCollections: vi.fn(),
-  getPendingAssetUploadCount: vi.fn(),
+  getPendingAssetUploadSummary: vi.fn(),
   getPendingDeletes: vi.fn(),
   getPendingSyncIds: vi.fn(),
   hasLocalOnlyData: vi.fn(),
@@ -160,7 +160,7 @@ describe('Typing stability across app re-renders (CUR-149)', () => {
     vi.mocked(db.mergeCollections).mockImplementation((local, cloud) =>
       cloud.length ? cloud : local,
     );
-    vi.mocked(db.getPendingAssetUploadCount).mockResolvedValue(0);
+    vi.mocked(db.getPendingAssetUploadSummary).mockResolvedValue({ total: 0, stalled: 0 });
     vi.mocked(db.syncPendingChanges).mockResolvedValue(0);
     vi.mocked(db.syncPendingAssetUploads).mockResolvedValue(0);
     vi.mocked(db.syncPendingDeletes).mockResolvedValue(0);

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -395,6 +395,43 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     expect(upload).toHaveBeenCalledTimes(2);
   });
 
+  it('syncPendingAssetUploads: repeated failures surface as stalled and force retry bypasses backoff (#149)', async () => {
+    const { supabase, upload } = createSupabaseMock();
+    upload.mockResolvedValue({ data: null, error: new Error('Upload failed') });
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const original = new Blob(['orig'], { type: 'image/jpeg' });
+    const display = new Blob(['disp'], { type: 'image/jpeg' });
+
+    // Attempt 1 fails during save and queues the upload with a backoff window.
+    await expect(
+      dbMod.saveAsset('col-1', 'item-asset-stalled', original, display),
+    ).resolves.toBeUndefined();
+    await expect(dbMod.getPendingAssetUploadSummary()).resolves.toEqual({ total: 1, stalled: 0 });
+
+    // A scheduled pass respects the backoff window and attempts nothing.
+    upload.mockClear();
+    await expect(dbMod.syncPendingAssetUploads()).resolves.toBe(0);
+    expect(upload).not.toHaveBeenCalled();
+
+    // A user-initiated retry runs immediately; attempts 2 and 3 fail too.
+    await expect(dbMod.syncPendingAssetUploads({ force: true })).resolves.toBe(0);
+    expect(upload).toHaveBeenCalled();
+    await expect(dbMod.syncPendingAssetUploads({ force: true })).resolves.toBe(0);
+
+    // Three consecutive failures cross the stalled threshold.
+    await expect(dbMod.getPendingAssetUploadSummary()).resolves.toEqual({ total: 1, stalled: 1 });
+
+    // A later forced retry that succeeds clears the queue and the stalled state.
+    upload.mockResolvedValue({ data: { path: 'ok' }, error: null });
+    await expect(dbMod.syncPendingAssetUploads({ force: true })).resolves.toBe(1);
+    await expect(dbMod.getPendingAssetUploadSummary()).resolves.toEqual({ total: 0, stalled: 0 });
+  });
+
   it('saveAsset: defers item_images rows for a brand-new item until its items row syncs (CUR-155)', async () => {
     /**
      * New items upload their photos before the `items` row syncs with the


### PR DESCRIPTION
## Problem

Most of #149 already shipped: a warning banner shows the pending photo-upload count, offers Retry, and clears when uploads complete. But the last acceptance criterion — **"Error state shown if uploads repeatedly fail"** — was unmet. Upload entries track `attemptCount`/`lastError` with exponential backoff, yet the UI showed the same calm "upload(s) pending / will sync" warning forever; repeated failure surfaced only as a console warning and an analytics event. That is exactly the fake certainty the **Trust before growth** principle forbids: the user's photos are not backed up and nothing tells them.

A second, related honesty gap: the banner's Retry action called `syncPendingAssetUploads()` without bypassing the backoff window, so clicking Retry on entries waiting out a backoff (up to 10 minutes) could silently do nothing.

## Approach

- `services/db.ts`: replaced `getPendingAssetUploadCount` with `getPendingAssetUploadSummary()` returning `{ total, stalled }`, where an upload is *stalled* after `ASSET_UPLOAD_STALLED_ATTEMPTS = 3` consecutive failures (background retries continue — the state is about visibility, not giving up).
- `services/db.ts`: `syncPendingAssetUploads` now accepts `{ force?: boolean }`; forced (user-initiated) passes skip the `nextRetryAt` filter, mirroring the existing `syncPendingChanges({ force: true })` pattern.
- `App.tsx`: when `stalled > 0`, the status banner renders `tone="error"` with honest copy ("{count} photo(s) could not be backed up · Your photos are safe on this device. We will keep retrying, or you can retry now.") and a Retry action that forces the pass. Otherwise the existing calm warning renders unchanged. The offline banner still outranks both — failing to upload while offline is expected, not an error.
- `i18n.ts`: `pendingUploadsErrorTitle` / `pendingUploadsErrorDesc` in EN and ZH.

## Why this approach

It completes the one unmet acceptance criterion with the smallest surface: no new components, no new patterns — the summary rides the existing pending-queue metadata, the error state rides the existing `StatusBanner` tones, and `force` mirrors an established sync option. The 3-attempt threshold means escalation happens ~3.5 minutes after the first failure (30s/60s backoffs), late enough to ignore transient blips, early enough to be honest.

## Risks

- `force: true` retries all queued uploads immediately on every banner Retry click; rapid clicking re-attempts uploads without backoff. Bounded: uploads run under `withSyncLock`, so concurrent passes are prevented.
- The renamed export (`getPendingAssetUploadCount` → `getPendingAssetUploadSummary`) would break any external caller; a repo-wide grep shows App.tsx and test mocks were the only consumers.
- Copy promises "photos are safe on this device", which holds as long as IndexedDB persists — consistent with the existing storage-quota warning that fires when that assumption weakens.

## How to verify

Vercel Preview: https://curio-git-claude-eloquent-meitner-nr460y-qs-projects-72b20d9d.vercel.app (deployed, per the Vercel bot below)

Manual verification (IndexedDB + Supabase behavior):
1. Sign in, open DevTools → Network, and block requests to the Supabase Storage host (right-click → block request domain).
2. Add an item with a photo. The photo save queues: IndexedDB → `curio-database` → `settings` → `pending_asset_uploads` shows the entry with `attemptCount: 1`; the amber "1 upload(s) pending" banner appears.
3. Click the banner's **Retry** twice (each click now genuinely re-attempts — watch the blocked requests appear in the Network tab). After the third failed attempt, the banner turns red: "1 photo(s) could not be backed up".
4. Unblock the Storage host and click **Retry**. The upload succeeds, the entry leaves `pending_asset_uploads`, the banner clears, and the object appears in the Supabase Storage bucket.
5. Toggle ZH and repeat step 3 to see the translated error copy. Verify banner contrast on all three themes (error tone is pre-existing `StatusBanner` styling).
6. Offline check: with pending uploads and the network fully offline, the offline banner shows (not the error banner) — failure while offline is expected.

Checks:
- [x] npm run format:check
- [x] npm test (62 files, 965 passed, 2 skipped, 1 todo)
- [x] npm run build (pre-existing chunk-size warning only)
- [x] npm run test:e2e (44 passed, 8 skipped)

Note: `npm ci` ran with `--ignore-scripts` in this sandbox because the egress proxy blocks sharp's libvips binary (transitive dep of `@capacitor/assets`, unused by these checks) — same workaround as #332. CI installs normally.

## Screenshot / GIF

Could not capture in this headless environment; the state is reproducible in under a minute on the preview via steps 1–3 above (DevTools request blocking). The error banner is the existing `StatusBanner` error tone already used by the sync-failure banner.

## Linear / Issue

Closes #149

(The "integrates with sync status in Layout header" criterion is satisfied by the existing implementation: the banner renders through `Layout`'s `statusBanner` slot directly under the header.)

## Rollback plan

Single revert of this commit (`git revert 811461b`) restores the always-warning banner and the backoff-respecting retry. No schema, storage, env, or flag changes; the two i18n keys are additive and harmless after revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD77f7T3AijDqQP18hUJk5