### PR TITLE
[#79] Trap and restore focus in CreateCollectionModal

### DIFF
--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/Button';
 import { useTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
 import { suggestCollectionFields } from '../services/geminiService';
+import { useModalA11y } from '../hooks/useModalA11y';
 import {
   FIELD_LABEL_MAX_LENGTH,
   FIELD_MAX_COUNT,
@@ -85,6 +86,8 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   const suggestRunRef = useRef(0);
   const iconPickerRef = useRef<HTMLDivElement | null>(null);
   const iconButtonRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const descriptionInputRef = useRef<HTMLInputElement | null>(null);
 
   const selectedTemplate = useMemo(
     () => (selectedTemplateId ? TEMPLATES.find((temp) => temp.id === selectedTemplateId) : null),
@@ -152,6 +155,20 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     resetState();
     onClose();
   };
+
+  // The icon picker owns Escape while open, so the first Escape collapses it
+  // and only the next one dismisses the modal.
+  const handleDismissRequest = () => {
+    if (isIconPickerOpen) {
+      setIsIconPickerOpen(false);
+      return;
+    }
+    handleClose();
+  };
+
+  useModalA11y(dialogRef, isOpen, handleDismissRequest, {
+    initialFocusRef: descriptionInputRef,
+  });
 
   const handleTemplateSelect = (templateId: string) => {
     // Tapping the already-selected preset clears it, returning the user to
@@ -368,16 +385,9 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       }
       setIsIconPickerOpen(false);
     };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setIsIconPickerOpen(false);
-      }
-    };
     document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isIconPickerOpen]);
 
@@ -387,21 +397,6 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       setIsIconPickerOpen(false);
     }
   }, [step, isIconPickerOpen]);
-
-  // The icon-picker effect above owns Escape while the picker is open, so this
-  // top-level handler stays unregistered in that state to preserve picker-only dismissal.
-  useEffect(() => {
-    if (!isOpen) return;
-    if (isIconPickerOpen) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return;
-      event.preventDefault();
-      handleClose();
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, isIconPickerOpen]);
 
   if (!isOpen) return null;
 
@@ -414,6 +409,7 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
           {t('collectionPrompt')}
         </label>
         <input
+          ref={descriptionInputRef}
           type="text"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -421,7 +417,6 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
           maxLength={DESCRIPTION_MAX_LENGTH}
           data-testid="collection-description-input"
           className={`w-full p-3.5 rounded-xl focus:ring-2 focus:ring-amber-200 outline-none font-medium ${inputSurface}`}
-          autoFocus
         />
       </div>
 
@@ -861,6 +856,7 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       className={`fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 ${overlayClass} backdrop-blur-sm`}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="create-collection-title"

--- a/tests/components/CreateCollectionModal.test.tsx
+++ b/tests/components/CreateCollectionModal.test.tsx
@@ -73,6 +73,48 @@ describe('CreateCollectionModal', () => {
     });
   });
 
+  // #79: modal a11y baseline — focus is trapped inside the dialog and
+  // restored to the trigger on close, matching the other modals.
+  describe('focus management (#79)', () => {
+    it('moves initial focus to the collector prompt input', async () => {
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(screen.getByTestId('collection-description-input'));
+      });
+    });
+
+    it('wraps Tab from the last control back to the first instead of escaping the dialog', async () => {
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      // Continue starts disabled on a fresh entry step, so Cancel is the last
+      // focusable control.
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      cancelButton.focus();
+
+      fireEvent.keyDown(document, { key: 'Tab' });
+
+      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Close' }));
+    });
+
+    it('restores focus to the previously focused element when the modal closes', async () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      const { rerender } = renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(document.activeElement).not.toBe(trigger);
+      });
+
+      rerender(<CreateCollectionModal {...defaultProps} isOpen={false} />);
+
+      expect(document.activeElement).toBe(trigger);
+      trigger.remove();
+    });
+  });
+
   describe('CUR-126 collection setup flow', () => {
     it('starts with the collector prompt and preset shelf instead of field rows', () => {
       renderWithProviders(<CreateCollectionModal {...defaultProps} />);


### PR DESCRIPTION
## Problem
CreateCollectionModal was the last modal on the #79 audit list without a Tab focus trap or focus restore. Escape-to-close worked, but a keyboard or screen-reader user could Tab out of the open dialog into the page behind it, and dismissing the modal dropped focus back to `<body>` instead of the trigger. Modals are Curio's primary interaction pattern, so inconsistent keyboard support here directly undermines the accessibility baseline (trust before growth).

## Approach
- Adopt the shared `useModalA11y` hook (Escape + focus trap + initial focus + focus restore) in CreateCollectionModal, the same primitive every other modal already uses.
- Fold the icon-picker Escape precedence into the dismiss callback: while the picker is open, the first Escape collapses it; the next one dismisses the modal — identical behavior to before, now with one Escape owner instead of two competing document listeners.
- Keep initial focus on the collector prompt input via `initialFocusRef`, replacing the `autoFocus` attribute.
- Add three regression tests: initial focus, Tab wrap at the dialog boundary, and focus restore on close. The existing Escape tests (including picker precedence) pass unchanged.

## Why this approach
The hook exists precisely so all dialogs feel the same to keyboard users; this deletes two hand-rolled Escape effects and replaces them with the house pattern. Net source change is ~20 lines. No visual change of any kind.

## Risks
Low. Behavior-only change covered by 6 tests (3 existing Escape tests + 3 new focus tests); the full unit, build, and e2e suites pass. The one behavioral nuance — Escape while the icon picker is open closes only the picker — is preserved and tested.

## How to verify
Vercel Preview: https://curio-git-claude-eloquent-meitner-sn3u8y-qs-projects-72b20d9d.vercel.app
Steps:
1. Open **New Archive** (create collection) from Home.
2. Press Tab repeatedly — focus should cycle inside the dialog and never reach the page behind it.
3. Open the icon picker, press Escape — only the picker closes; press Escape again — the modal closes.
4. After the modal closes, focus returns to the element that opened it.

Checks:
- [x] npm run format:check
- [x] npm test (62 files, 968 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF
Not applicable — keyboard/focus behavior only, zero visual change.

## Linear
Linear was unavailable in this session (requires interactive auth); this work comes from the GitHub queue per `docs/GITHUB_ISSUES_PROTOCOL.md`.
Closes #79

Note: the mobile profile bottom sheet in `Layout.tsx` (outside this issue's audit list) has Escape + focus restore but no Tab trap — flagged as a possible small follow-up.

## Rollback plan
`git revert` the single commit on this branch; no data, schema, or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoJZKLbF4qsQiogE3Ey29V