### PR TITLE
Give batch analyzing a real manual escape (#366)

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -108,6 +108,12 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
   // True while the scroll area has more content below the fold, so we can fade
   // the bottom edge as an affordance that more fields exist (CUR-45).
   const [canScrollDown, setCanScrollDown] = useState(false);
+  // #366: set when the user chooses manual entry while a batch is analyzing.
+  // runBatchAnalysis reads the ref between photos so the run stops early; the
+  // state swaps the analyzing step's escape copy for an honest "wrapping up"
+  // acknowledgment while the in-flight photo finishes.
+  const [batchManualRequested, setBatchManualRequested] = useState(false);
+  const batchManualRef = useRef(false);
 
   const batchInputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -359,6 +365,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     setAnalysisNeedsReview(false);
     setLowConfidence(false);
     setBatchProgress(null);
+    batchManualRef.current = false;
+    setBatchManualRequested(false);
     setTitleError(null);
     setBatchTitleErrors({});
     setIsImageEditorOpen(false);
@@ -548,6 +556,15 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     setStep('verify');
   };
 
+  // #366: during a batch run, "Enter manually" stops the remaining analysis
+  // instead of jumping to the single-item form. The in-flight photo still
+  // finishes (the request can't be aborted mid-flight), then the batch lands
+  // on batch-verify where every photo is manually editable.
+  const switchBatchToManual = () => {
+    batchManualRef.current = true;
+    setBatchManualRequested(true);
+  };
+
   const takePicture = async () => {
     try {
       const image = await Camera.getPhoto({
@@ -610,10 +627,19 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     ...overrides,
   });
 
-  const runBatchAnalysis = async (images: string[], existingIds: string[] = []) => {
+  const runBatchAnalysis = async (
+    images: string[],
+    existingIds: string[] = [],
+    // #366: ties the run to the analysis session it started in. A reset
+    // (close/reopen, switch to single manual) abandons the run silently; a
+    // manual-entry request stops the loop and leaves the unreached photos to
+    // the caller, which decides what those rows should hold.
+    runId = analysisRunId.current,
+  ) => {
     if (!currentCollection) return images.map((image) => createBatchItem(image));
     const collection = currentCollection;
     const aiEnabled = await refreshAiEnabled();
+    if (analysisRunId.current !== runId) return [];
     if (!aiEnabled) {
       setError(t('aiUnavailableManual'));
       setAnalysisError(true);
@@ -624,6 +650,8 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     const analyzed: BatchItem[] = [];
     let hadError = false;
     for (let idx = 0; idx < images.length; idx += 1) {
+      if (analysisRunId.current !== runId) return analyzed;
+      if (batchManualRef.current) break;
       const image = images[idx];
       setBatchProgress((prev) =>
         prev
@@ -678,7 +706,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
         analyzed.push(createBatchItem(image, existingIds[idx] ? { id: existingIds[idx] } : {}));
       }
     }
-    setAnalysisError(hadError);
+    if (analysisRunId.current === runId) setAnalysisError(hadError);
     return analyzed;
   };
 
@@ -702,12 +730,21 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
       });
 
     const loadBatch = async () => {
+      // #366: capture the analysis session so a late-finishing batch can't
+      // touch state after the modal was reset or the user navigated away.
+      const runId = analysisRunId.current;
+      batchManualRef.current = false;
+      setBatchManualRequested(false);
       setError(null);
       setAnalysisError(false);
       setBatchTitleErrors({});
       setStep('analyzing');
+      // Show batch progress immediately so the analyzing step reads as a
+      // batch run (and offers the batch escape) even while files are reading.
+      setBatchProgress({ current: 0, total: files.length });
       try {
         const results = await Promise.allSettled(Array.from(files).map(readFileAsDataUrl));
+        if (analysisRunId.current !== runId) return;
         const images = results
           .filter(
             (result): result is PromiseFulfilledResult<string> => result.status === 'fulfilled',
@@ -725,16 +762,28 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
           return;
         }
         setBatchProgress({ current: 0, total: images.length });
-        const newItems = await runBatchAnalysis(images);
+        const analyzed = await runBatchAnalysis(images, [], runId);
+        if (analysisRunId.current !== runId) return;
+        // Photos the run never reached (manual-entry escape) become blank,
+        // manually editable rows — the user keeps every photo they picked.
+        const newItems = [
+          ...analyzed,
+          ...images.slice(analyzed.length).map((image) => createBatchItem(image)),
+        ];
         setBatchItems((prev) => [...prev, ...newItems]);
         setStep('batch-verify');
       } catch (err) {
         console.error(err);
+        if (analysisRunId.current !== runId) return;
         setError(t('analysisFailedManual'));
         setAnalysisError(true);
         setStep('batch-verify');
       } finally {
-        setBatchProgress(null);
+        if (analysisRunId.current === runId) {
+          setBatchProgress(null);
+          batchManualRef.current = false;
+          setBatchManualRequested(false);
+        }
         e.target.value = '';
       }
     };
@@ -869,6 +918,9 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
 
   const retryBatchAnalysis = async () => {
     if (!currentCollection || batchItems.length === 0) return;
+    const runId = analysisRunId.current;
+    batchManualRef.current = false;
+    setBatchManualRequested(false);
     setError(null);
     setAnalysisError(false);
     setBatchTitleErrors({});
@@ -877,16 +929,24 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     try {
       const images = batchItems.map((item) => item.image);
       const ids = batchItems.map((item) => item.id);
-      const updatedItems = await runBatchAnalysis(images, ids);
-      setBatchItems(updatedItems);
+      const updatedItems = await runBatchAnalysis(images, ids, runId);
+      if (analysisRunId.current !== runId) return;
+      // Items the retry never reached (manual-entry escape) keep their
+      // previous titles and edits instead of being re-blanked.
+      setBatchItems((prev) => [...updatedItems, ...prev.slice(updatedItems.length)]);
       setStep('batch-verify');
     } catch (err) {
       console.error(err);
+      if (analysisRunId.current !== runId) return;
       setError(t('analysisFallback'));
       setAnalysisError(true);
       setStep('batch-verify');
     } finally {
-      setBatchProgress(null);
+      if (analysisRunId.current === runId) {
+        setBatchProgress(null);
+        batchManualRef.current = false;
+        setBatchManualRequested(false);
+      }
     }
   };
 
@@ -1315,24 +1375,37 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
           </p>
         )}
         {/* Wrapper stays mounted so the live region exists before the notice
-            lands and screen readers announce it. Single-item analysis only:
-            the notice promises the manual path, and during a batch run
-            switchToManual is a dead-end (loadBatch keeps going and forces
-            batch-verify when it lands). Batch already shows its own per-item
-            progress line above. */}
+            lands and screen readers announce it. Batch runs have a real
+            manual escape now (#366), so the slow notice shows for them too.
+            Once the user has asked for manual entry, the "wrapping up" line
+            replaces it — we shouldn't offer a skip that already happened. */}
         <div role="status">
-          {analysisSlow && !batchProgress && (
+          {batchManualRequested ? (
             <p
-              data-testid="analysis-slow-notice"
+              data-testid="batch-manual-pending"
               className={`text-xs sm:text-sm mt-3 ${mutedText}`}
             >
-              {t('analysisTakingLong')}
+              {t('batchManualPending')}
             </p>
+          ) : (
+            analysisSlow && (
+              <p
+                data-testid="analysis-slow-notice"
+                className={`text-xs sm:text-sm mt-3 ${mutedText}`}
+              >
+                {t('analysisTakingLong')}
+              </p>
+            )
           )}
         </div>
       </div>
       <div className="flex justify-center">
-        <Button variant="ghost" size="sm" onClick={switchToManual}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={batchProgress ? switchBatchToManual : switchToManual}
+          disabled={batchManualRequested}
+        >
           {t('enterManually')}
         </Button>
       </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -110,6 +110,7 @@ export const translations = {
     geminiExtracting: 'Gemini is extracting details for your collection.',
     analysisTakingLong:
       'Taking longer than usual. You can skip the wait and enter the details yourself.',
+    batchManualPending: 'Finishing the current photo — the rest are yours to fill in.',
     takePhoto: 'Take Photo',
     uploadPhoto: 'Upload Photo',
     changePhoto: 'Change Photo',
@@ -636,6 +637,7 @@ export const translations = {
     analyzingPhoto: '正在分析照片...',
     geminiExtracting: 'Gemini 正在为您提取馆藏细节。',
     analysisTakingLong: '比平时慢一些。您可以跳过等待，改为手动填写。',
+    batchManualPending: '正在完成当前照片，其余的交给您手动填写。',
     takePhoto: '拍摄照片',
     uploadPhoto: '上传照片',
     changePhoto: '更换照片',

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -719,8 +719,7 @@ describe('AddItemModal', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
-      // Single-photo path (Camera.getPhoto → analyze) — the notice is gated
-      // to it because batch analyzing has no working manual escape.
+      // Single-photo path (Camera.getPhoto → analyze).
       mockGetPhoto.mockResolvedValue({ dataUrl: 'data:image/png;base64,ZmFrZQ==' });
       await user.click(screen.getAllByRole('button', { name: 'Upload Photo' })[0]);
 
@@ -749,7 +748,7 @@ describe('AddItemModal', () => {
     }
   });
 
-  it('keeps the slow-analysis notice out of batch analyzing, which has no manual escape (#73)', async () => {
+  it('shows the slow-analysis notice during batch analyzing now that the escape is real (#366)', async () => {
     mockRefreshAiEnabled.mockResolvedValue(true);
     mockAnalyzeImage.mockReturnValue(new Promise<never>(() => {}));
 
@@ -775,13 +774,113 @@ describe('AddItemModal', () => {
       act(() => {
         vi.advanceTimersByTime(10_000);
       });
-      // …but must not show the notice: its "enter the details yourself"
-      // promise is a dead-end while loadBatch is still running (it forces
-      // batch-verify when it resolves).
+      // …and the notice's "enter the details yourself" promise is now kept
+      // during batch runs (#366), so it shows here too.
+      expect(screen.getByTestId('analysis-slow-notice')).toBeInTheDocument();
+
+      // Asking for manual entry replaces the notice with the wrapping-up
+      // acknowledgment — we shouldn't offer a skip that already happened.
+      await user.click(screen.getByRole('button', { name: 'Enter manually' }));
       expect(screen.queryByTestId('analysis-slow-notice')).not.toBeInTheDocument();
+      expect(screen.getByTestId('batch-manual-pending')).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('cancels the rest of a batch when the user enters manually during analyzing (#366)', async () => {
+    const user = userEvent.setup();
+    mockRefreshAiEnabled.mockResolvedValue(true);
+    let resolveFirst: (value: unknown) => void = () => {};
+    mockAnalyzeImage.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const collection = createMockCollection({ name: 'Artifacts', customFields: [] });
+    renderWithProviders(
+      <AddItemModal isOpen onClose={mockOnClose} collections={[collection]} onSave={mockOnSave} />,
+    );
+
+    const files = [
+      new File(['a'], 'a.png', { type: 'image/png' }),
+      new File(['b'], 'b.png', { type: 'image/png' }),
+    ];
+    const input = screen.getByTestId('add-item-batch-input') as HTMLInputElement;
+    await user.upload(input, files);
+
+    // First photo is in flight.
+    await screen.findByRole('heading', { name: 'Analyzing photo...' });
+    await waitFor(() => expect(mockAnalyzeImage).toHaveBeenCalledTimes(1));
+
+    // Escape during the batch: acknowledged immediately, button disarmed.
+    const escape = screen.getByRole('button', { name: 'Enter manually' });
+    await user.click(escape);
+    expect(screen.getByTestId('batch-manual-pending')).toBeInTheDocument();
+    expect(escape).toBeDisabled();
+
+    // The in-flight photo finishes; the batch must stop there and land on
+    // batch-verify with the second photo as a blank, manually editable row.
+    resolveFirst({ status: 'success', title: 'First Artifact', data: {} });
+    await screen.findByTestId('add-item-batch-info');
+    expect(await screen.findByDisplayValue('First Artifact')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save 2 pieces' })).toBeInTheDocument();
+    // The second photo was never sent to analysis.
+    expect(mockAnalyzeImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a late-finishing batch replace the step after the modal was reset (#366)', async () => {
+    const user = userEvent.setup();
+    mockRefreshAiEnabled.mockResolvedValue(true);
+    let resolveFirst: (value: unknown) => void = () => {};
+    mockAnalyzeImage.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+    );
+
+    const collection = createMockCollection({ name: 'Artifacts', customFields: [] });
+    const { rerender } = renderWithProviders(
+      <AddItemModal isOpen onClose={mockOnClose} collections={[collection]} onSave={mockOnSave} />,
+    );
+
+    const files = [
+      new File(['a'], 'a.png', { type: 'image/png' }),
+      new File(['b'], 'b.png', { type: 'image/png' }),
+    ];
+    const input = screen.getByTestId('add-item-batch-input') as HTMLInputElement;
+    await user.upload(input, files);
+    await screen.findByRole('heading', { name: 'Analyzing photo...' });
+    await waitFor(() => expect(mockAnalyzeImage).toHaveBeenCalledTimes(1));
+
+    // Close and reopen: the reset claims a new analysis session.
+    rerender(
+      <AddItemModal
+        isOpen={false}
+        onClose={mockOnClose}
+        collections={[collection]}
+        onSave={mockOnSave}
+      />,
+    );
+    rerender(
+      <AddItemModal isOpen onClose={mockOnClose} collections={[collection]} onSave={mockOnSave} />,
+    );
+    await screen.findByRole('heading', { name: 'Upload Photo' });
+
+    // The stale batch resolves late — it must not yank the user to
+    // batch-verify or leak its items into the fresh session.
+    resolveFirst({ status: 'success', title: 'Stale Artifact', data: {} });
+    // Let the abandoned loadBatch chain fully settle before asserting.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(mockAnalyzeImage).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('heading', { name: 'Upload Photo' })).toBeInTheDocument();
+    expect(screen.queryByTestId('add-item-batch-info')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Stale Artifact')).not.toBeInTheDocument();
   });
 
   it('fades the verify-step scroll edge while fields remain below the fold (CUR-45)', async () => {


### PR DESCRIPTION
## Problem

During a **batch** photo analysis, the analyzing step offered the shared "Enter manually" button, but it was a dead-end: `switchToManual` bumped `analysisRunId` and jumped to the **single-item** verify step, while `runBatchAnalysis`/`loadBatch` never checked that id — the batch kept running in the background and its unconditional `setStep('batch-verify')` yanked the user out of whatever manual entry they had started. A control that appears usable but fails later is exactly what the **Explicit outcomes** constraint (and **Trust before growth**) says to avoid. Surfaced by Codex review on #365, filed as #366.

## Approach

- **The escape now routes by mode.** During a batch run (`batchProgress` set), "Enter manually" calls a new `switchBatchToManual` that requests manual entry instead of jumping to the single-item form: the analysis loop stops after the in-flight photo (the HTTP request can't be aborted mid-flight), and the batch lands on batch-verify where every photo is manually editable.
- **No photo is lost.** Photos the run never reached become blank, editable rows in batch-verify; on a *retry* run they keep their previous titles and edits instead of being re-blanked.
- **Honest feedback while wrapping up.** After the click the button disables and the live region swaps the slow notice for a "Finishing the current photo — the rest are yours to fill in." line (new `batchManualPending` key, EN + ZH), so we never offer a skip that already happened.
- **Late batches can't hijack the UI.** `loadBatch`/`retryBatchAnalysis`/`runBatchAnalysis` now capture the analysis session (`analysisRunId`) and bail out of every state write when it has moved on — a batch resolving after the modal was closed/reopened no longer forces `batch-verify` or leaks its items into the fresh session.
- **Slow notice un-gated for batch** (#365 follow-up, sanctioned by the issue notes): now that the escape is real, `analysisTakingLong` shows during batch analyzing too.

## Why this approach

The acceptance criteria allowed either cancelling the batch or hiding the affordance; cancelling into batch-verify keeps the *Recoverable AI* promise — the user completes creation manually without losing the photos they picked. It reuses the existing `analysisRunId` session pattern the single-photo path already relies on, so no new abstractions. Aborting the in-flight request was deliberately left out to keep the diff small; the escape is acknowledged instantly and takes effect at the next loop boundary.

## Risks

- The escape's effect during a very slow in-flight photo is "acknowledged now, lands when the current photo finishes" — mitigated by the disabled button + wrapping-up line, but it is not an instant transition.
- `retryBatchAnalysis` now merges by position (`[...updated, ...prev.slice(updated.length)]`); order is stable because both lists derive from `batchItems` and the batch-verify list isn't editable while analyzing.
- No data-flow, sync, storage, or permission changes; AI remains fully skippable (this PR strengthens that).

## How to verify

Vercel Preview: https://curio-git-claude-eloquent-meitner-iw92l2-qs-projects-72b20d9d.vercel.app

Steps:
1. Open Add Item → Batch Mode → select several photos.
2. While "Analyzing photo…" shows, click **Enter manually** — the button disables and the "Finishing the current photo…" line appears.
3. When the in-flight photo resolves you land on batch-verify: analyzed photos keep their AI titles, unreached photos are blank editable rows; the remaining photos were never sent to analysis (Network tab: no further `/api/gemini/analyze` calls).
4. Let a batch run past ~10s without clicking — the slow-analysis notice now shows for batch too.
5. AI fallback unchanged: with the AI flag off, batch upload still lands on batch-verify with manual rows (existing behavior, covered by existing tests).

Checks:
- [x] npm run format:check
- [x] npm test (62 files, 972 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

New regression tests (all 3 fail on `main`, verified by stashing the src diff):
- cancels the rest of a batch when the user enters manually during analyzing
- does not let a late-finishing batch replace the step after the modal was reset
- shows the slow-analysis notice during batch analyzing now that the escape is real

## Screenshot / GIF

This headless session has nowhere to host image uploads (Linear attachment flow unavailable). The visible delta is small and fully scripted in verify steps 2–4 above; happy to add captures on request.

## Linear

Closes #366 (GitHub issue — Linear was not reachable from this session).

## Rollback plan

Single revert of this PR's commit (`git revert ac51085`) restores the previous behavior (and the dead-end bug). No schema, storage, flag, or env changes; the added i18n keys are additive and harmless after revert.