### PR TITLE
[UX] Hide collection card description when it duplicates the name

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -63,8 +63,12 @@ export const CollectionCard: React.FC<CollectionCardProps> = React.memo(function
         .join(' • ')
     : '';
   const trimmedDescription = collection.collectionDescription?.trim();
-  const descriptionText = trimmedDescription
-    ? trimmedDescription
+  // The create flow can persist the collection name as its description; showing
+  // it would repeat the name directly under the card title.
+  const meaningfulDescription =
+    trimmedDescription && trimmedDescription !== collection.name.trim() ? trimmedDescription : '';
+  const descriptionText = meaningfulDescription
+    ? meaningfulDescription
     : tagPreview
       ? `${t('fieldsLabel')}: ${tagPreview}`
       : template.description;

--- a/tests/components/CollectionCard.test.tsx
+++ b/tests/components/CollectionCard.test.tsx
@@ -92,6 +92,35 @@ describe('CollectionCard Component', () => {
         screen.getByText('Track terroir, cocoa percentages, and nuanced flavor profiles.'),
       ).toBeInTheDocument();
     });
+
+    it('displays a custom collection description', () => {
+      const collection = createMockCollection({
+        templateId: 'chocolate',
+        collectionDescription: 'Bars from every trip abroad.',
+      });
+      const onClick = vi.fn();
+
+      renderWithProviders(<CollectionCard collection={collection} onClick={onClick} />);
+
+      expect(screen.getByText('Bars from every trip abroad.')).toBeInTheDocument();
+    });
+
+    it('does not repeat the collection name when the description duplicates it', () => {
+      const collection = createMockCollection({
+        templateId: 'chocolate',
+        name: 'Supplement',
+        collectionDescription: 'Supplement',
+      });
+      const onClick = vi.fn();
+
+      renderWithProviders(<CollectionCard collection={collection} onClick={onClick} />);
+
+      // Name renders as the heading (plus its hover tooltip), never as the description.
+      expect(screen.queryAllByText('Supplement')).toHaveLength(2);
+      expect(
+        screen.getByText('Track terroir, cocoa percentages, and nuanced flavor profiles.'),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Item Count Display', () => {


### PR DESCRIPTION
## Problem

The create-collection flow persists the "what are you collecting" prompt as `collectionDescription`. Custom collections created that way (e.g. name **Supplement**, description **Supplement**) render the collection name twice on the home-screen card — once as the title and again directly beneath it as the description. The live tester account shows this on three of five collections (`Supplement`, `古钱币`, `Antique toys`).

## Fix

In `CollectionCard`, treat a description identical to the collection name (after trimming) as absent, falling back to the existing chain: custom-field preview → template description.

## Testing

- Added two unit tests: custom description still renders; a name-duplicating description falls back instead of repeating the name.
- `npm run format:check`, `npm test` (974 passed), `npm run build`, `npm run test:e2e` (44 passed, 8 auth-gated skipped) all pass.

Found during the recurring UI/UX review (2026-07-17), which was run against a local build wired to the production Supabase project because this environment's egress proxy resets browser TLS to external hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnMk2w7LAK9Bg6zmkuYfcv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnMk2w7LAK9Bg6zmkuYfcv)_