### PR TITLE
[CURIO-374] Use future-tense AI copy on the idle Add Item upload step

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1149,7 +1149,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
           {t('uploadPhoto')}
         </h3>
         <p className={`text-sm sm:text-base ${mutedText} max-w-xs mx-auto`}>
-          {t('geminiExtracting')}
+          {t('geminiWillExtract')}
         </p>
       </div>
       <div className="flex flex-col gap-2 sm:gap-3">

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -107,6 +107,7 @@ export const translations = {
     discardItemAction: 'Discard',
     keepEditing: 'Keep editing',
     analyzingPhoto: 'Analyzing photo...',
+    geminiWillExtract: 'Add a photo and Gemini will suggest the details.',
     geminiExtracting: 'Gemini is extracting details for your collection.',
     analysisTakingLong:
       'Taking longer than usual. You can skip the wait and enter the details yourself.',
@@ -637,6 +638,7 @@ export const translations = {
     discardItemAction: '舍弃',
     keepEditing: '继续编辑',
     analyzingPhoto: '正在分析照片...',
+    geminiWillExtract: '添加照片，Gemini 会为您推荐馆藏细节。',
     geminiExtracting: 'Gemini 正在为您提取馆藏细节。',
     analysisTakingLong: '比平时慢一些。您可以跳过等待，改为手动填写。',
     batchManualPending: '正在完成当前照片，其余的交给您手动填写。',

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -179,6 +179,29 @@ describe('AddItemModal', () => {
     expect(screen.queryByText('Start a collection')).not.toBeInTheDocument();
   });
 
+  it('describes AI in the future tense on the idle upload step, before any photo (#374)', () => {
+    const c1 = createMockCollection({ id: 'c1', name: 'Vinyl Vault' });
+
+    renderWithProviders(
+      <AddItemModal
+        isOpen
+        onClose={mockOnClose}
+        collections={[c1]}
+        defaultCollectionId="c1"
+        onSave={mockOnSave}
+      />,
+    );
+
+    // Idle upload state: nothing is being extracted yet, so the copy must
+    // promise the future rather than claim analysis is already running.
+    expect(
+      screen.getByText('Add a photo and Gemini will suggest the details.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Gemini is extracting details for your collection.'),
+    ).not.toBeInTheDocument();
+  });
+
   it('falls back to collection picker when defaultCollectionId does not match any collection', async () => {
     const c1 = createMockCollection({ id: 'c1', name: 'Vinyl Vault' });
     const c2 = createMockCollection({ id: 'c2', name: 'Chocolate Vault' });


### PR DESCRIPTION
## Problem

The Add Item modal's initial state (before any photo is selected) showed the subtitle **"Gemini is extracting details for your collection."** under the *Upload Photo* header. Nothing is being extracted at that point — the same `geminiExtracting` i18n string was reused for both the idle upload prompt (`AddItemModal.tsx:1152`) and the live analysis state (`:1367`). Present-tense "is extracting" before an upload makes users think AI is already running, which works against the "AI states explained" trust goal.

Protects the **Trust before growth** and **Acceleration before automation** principles: the UI should never imply the AI is doing something it isn't.

## Approach

- Added a new future-tense i18n key `geminiWillExtract` — EN: *"Add a photo and Gemini will suggest the details."*, ZH: *"添加照片，Gemini 会为您推荐馆藏细节。"*
- Idle upload prompt now uses `geminiWillExtract`; the in-progress analyzing state keeps `geminiExtracting` (present tense) unchanged.
- Added a regression test asserting the idle upload step renders the future-tense copy and **not** the analyzing copy.

## Why this approach

Splitting the one overloaded string into idle/in-progress keys is the smallest change that fixes the tense mismatch without touching layout, state, or the AI flow. It mirrors the existing i18n pattern (adjacent EN/ZH keys) and keeps both usage sites correct. No behavior beyond copy changes.

## Risks

Low. Copy-only change plus one new i18n key. Both usage sites were checked; the analyzing state is untouched. The `t()` helper already falls back to EN for any missing key, so no runtime risk if a locale lacks the key (both are provided).

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-3xiydy-qs-projects-72b20d9d.vercel.app

Steps:
1. Open any collection → **Add Item**.
2. Before selecting a photo, read the subtitle under **Upload Photo** → now reads "Add a photo and Gemini will suggest the details."
3. Select a photo and let analysis run → the analyzing state still reads "Gemini is extracting details for your collection."
4. Toggle language to ZH and repeat steps 2–3 → localized future-tense idle copy, present-tense analyzing copy.

Checks (run locally on this branch):
- [x] npm run format:check
- [x] npm test (979 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Copy-only change. Before → after (idle upload subtitle):
- Before: "Gemini is extracting details for your collection."
- After: "Add a photo and Gemini will suggest the details."

## Linear

Closes #374

## Rollback plan

Green tier. Revert the single commit: `git revert 8625aa6` (or restore the two `geminiExtracting` usage sites and drop the `geminiWillExtract` keys).