### PR TITLE
[CUR-102] Make index.css the single source of truth for printed card width

### DIFF
--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -390,10 +390,14 @@ export const ExportModal: React.FC<ExportModalProps> = ({
       // ratio whenever the container is shorter than the natural card height
       // — most visibly when the bottom sheet is expanded on a phone, where
       // it also baked the squash into `renderCardToBlob()`'s export.
+      // CUR-102: the printed card width lives solely in the `#card-preview` print
+      // rule in index.css. A `print:!w-[100mm]` utility used to sit here but was
+      // dead code — the ID selector outspecifies the Tailwind class, so it never
+      // applied. Don't re-add a `print:w-*` utility; edit index.css instead.
       <div
         id="card-preview"
         ref={cardRef}
-        className={`isolate shadow-2xl transition-all duration-300 overflow-hidden relative group select-none mx-auto print:h-auto print:!w-[100mm]`}
+        className={`isolate shadow-2xl transition-all duration-300 overflow-hidden relative group select-none mx-auto print:h-auto`}
         style={{
           aspectRatio: `${ratioW} / ${ratioH}`,
           height: '100%',

--- a/src/index.css
+++ b/src/index.css
@@ -184,6 +184,10 @@ body {
     left: 50% !important;
     top: 10mm !important;
     transform: translateX(-50%) !important;
+    /* CUR-102: single source of truth for the printed card width. ~80mm (≈3.1")
+       keeps the keepsake card centered with generous margins on A4/Letter and
+       leaves the tallest 9:16 ratio comfortably within one page. Do not re-add a
+       competing `print:w-*` utility in ExportModal — the ID selector wins here. */
     width: 80mm !important;
     max-width: none !important;
     max-height: none !important;

--- a/tests/components/ExportModal.test.tsx
+++ b/tests/components/ExportModal.test.tsx
@@ -145,6 +145,29 @@ describe('ExportModal — CUR-83 footer CTA hierarchy', () => {
   });
 });
 
+describe('ExportModal — CUR-102 single source of truth for print width', () => {
+  const baseProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    item: makeItem(),
+    fields: FIELDS,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not carry a competing print-width utility on the card node', () => {
+    const { container } = renderWithProviders(<ExportModal {...baseProps} />);
+    const card = container.querySelector('#card-preview');
+    expect(card).not.toBeNull();
+    // The printed width is defined once, in the `#card-preview` print rule in
+    // index.css (80mm). A `print:w-*` utility here would be dead code (the ID
+    // selector outspecifies it) and a second, misleading source of truth.
+    expect(card!.className).not.toMatch(/print:.*w-\[/);
+  });
+});
+
 describe('ExportModal — CUR-101 native Print availability', () => {
   const baseProps = {
     isOpen: true,


### PR DESCRIPTION
## Problem

The printed export-card width was defined in two competing places:

- `src/components/ExportModal.tsx` — a `print:!w-[100mm]` Tailwind utility on the `#card-preview` node
- `src/index.css` — `#card-preview { width: 80mm !important }` in the print media query

Both use `!important`, but the ID selector (`#card-preview`) outspecifies the Tailwind utility class, so the card **always** printed at 80mm and the `print:!w-[100mm]` utility was dead code. Anyone editing the utility to change print size would see no effect, and it was unclear whether 80mm or 100mm was intended. This protects *beauty before bureaucracy* / trust: a single, honest source of truth for what the keepsake card actually does.

## Approach

- Deleted the dead `print:!w-[100mm]` utility from the card node so print width lives in exactly one place.
- Kept the effective, already-shipping value (80mm) — no change to what users print today.
- Documented the intended physical size and the "don't re-add a competing utility" reasoning in both files.
- Added a regression test asserting the `#card-preview` node carries no `print:w-*` utility.

## Why this approach

The issue asks for exactly one rule to define print width; keeping the existing 80mm avoids silently changing anyone's printed output while removing the footgun. The docs make the single source of truth discoverable, and the test would have failed before this change (the utility was present), guarding against reintroduction. Two-line behavioral change plus a comment and a test — the smallest fix that fully satisfies the acceptance criteria.

## Risks

Low. No visible change to printed output (80mm was already the effective width). Purely removes dead CSS and adds documentation + a regression test. Screen preview is untouched (the utility only applied under `@media print`, where it never won anyway).

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-jnqxhh-qs-projects-72b20d9d.vercel.app

Steps:
1. Open any item detail → export/print icon → Export card modal.
2. Ctrl/Cmd+P (desktop). The card prints centered at ~80mm wide — identical to before.
3. Confirm no regression to the on-screen preview or aspect-ratio picker.

Checks:
- [x] npm run format:check
- [x] npm test (980 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No user-visible change — printed width is unchanged (80mm), only the redundant/dead rule and its ambiguity are removed.

## Linear

Closes CUR-102

## Rollback plan

Green-tier presentational/dead-code change. Revert with `git revert 54720ad`, or hand-revert by re-adding `print:!w-[100mm]` to the `#card-preview` className in `src/components/ExportModal.tsx`, removing the two CUR-102 comments, and deleting the `CUR-102 single source of truth for print width` describe block in `tests/components/ExportModal.test.tsx`.