### PR TITLE
[CUR-97] Gate bottom-nav clearance and footer fade to mobile viewports

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -461,13 +461,12 @@ export const Layout: React.FC<LayoutProps> = ({
 
       {statusBanner && <div className="max-w-4xl mx-auto px-4 pt-4 sm:pt-5">{statusBanner}</div>}
 
+      {/* CUR-97: reserve clearance for the bottom nav only where it actually
+          renders (< sm). On desktop the nav is `sm:hidden`, so `sm:pb-8` drops
+          the ~5.5rem of dead space back to the standard `py-8` rhythm. */}
       <main
         id="main-content"
-        className="max-w-4xl mx-auto px-4 py-8"
-        style={{
-          paddingBottom:
-            'calc(var(--bottom-nav-height, 5.5rem) + env(safe-area-inset-bottom, 0px))',
-        }}
+        className="max-w-4xl mx-auto px-4 py-8 pb-[calc(var(--bottom-nav-height,5.5rem)+env(safe-area-inset-bottom,0px))] sm:pb-8"
       >
         {children}
       </main>
@@ -565,8 +564,10 @@ export const Layout: React.FC<LayoutProps> = ({
         </div>
       )}
 
+      {/* CUR-97: the fade only reads as intentional above the bottom nav, so it
+          rides the same `sm:hidden` breakpoint and is not drawn on desktop. */}
       <footer
-        className={`fixed bottom-0 left-0 w-full bg-gradient-to-t ${footerGradient} pointer-events-none h-12 z-10`}
+        className={`fixed bottom-0 left-0 w-full bg-gradient-to-t ${footerGradient} pointer-events-none h-12 z-10 sm:hidden`}
       />
     </div>
   );

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -645,6 +645,29 @@ describe('Layout Component', () => {
     });
   });
 
+  describe('CUR-97 desktop bottom clearance', () => {
+    it('gates the bottom-nav padding to mobile with a desktop override', () => {
+      renderWithProviders(<Layout {...defaultProps} />);
+
+      const main = document.getElementById('main-content')!;
+      // Mobile reserves clearance for the bottom nav; desktop drops back to py-8.
+      expect(main.className).toContain(
+        'pb-[calc(var(--bottom-nav-height,5.5rem)+env(safe-area-inset-bottom,0px))]',
+      );
+      expect(main.className).toContain('sm:pb-8');
+      // The reservation must not leak in as an unconditional inline style.
+      expect(main.style.paddingBottom).toBe('');
+    });
+
+    it('does not draw the decorative footer fade on desktop', () => {
+      renderWithProviders(<Layout {...defaultProps} />);
+
+      const footer = document.querySelector('footer')!;
+      expect(footer).not.toBeNull();
+      expect(footer.className).toContain('sm:hidden');
+    });
+  });
+
   describe('Theme Support', () => {
     describe.each([
       { theme: 'gallery' as const, bgPattern: /bg-white/, description: 'light background' },


### PR DESCRIPTION
## Problem

`Layout.tsx` reserved space for the mobile bottom navigation regardless of viewport size. The bottom nav is `sm:hidden`, yet:

1. `<main>` carried an inline `padding-bottom: calc(var(--bottom-nav-height, 5.5rem) + …)` at **every** breakpoint — so desktop pages had ~88px of dead space at the bottom that no nav ever filled.
2. The decorative footer fade (`<footer>` gradient) was `fixed` at the bottom on **every** screen size, creating an always-on "is there something below the fold?" cue that corresponded to no real content.

This is a small "beauty before bureaucracy" cost: on desktop (most visibly in Vault/Atelier) every page wasted vertical rhythm the Home hero can least afford.

## Approach

Two scoped changes in `src/components/Layout.tsx`:

- Move the nav clearance off the inline `style` and onto a responsive Tailwind utility: `pb-[calc(var(--bottom-nav-height,5.5rem)+env(safe-area-inset-bottom,0px))] sm:pb-8`. Below `sm` the clearance (and its iOS safe-area inset) is preserved exactly; at `sm`+ it drops back to the standard `py-8` rhythm.
- Add `sm:hidden` to the footer fade so it only renders alongside the nav it belongs to.

Added two `Layout` tests (`CUR-97 desktop bottom clearance`) asserting the responsive padding classes / absence of the inline style and the gated footer.

## Why this approach

It's the minimal, design-token-free fix the issue itself recommends — no new components, no `DESIGN.md` change, ~2 substantive lines. The `pb-[calc(var(--…)+env(…))]` arbitrary-value pattern already exists in this codebase (ExportModal, and the nav's own safe-area padding), so it reads as native. Verified the arbitrary class compiles into `dist` CSS as `padding-bottom:calc(var(--bottom-nav-height,5.5rem) + env(safe-area-inset-bottom,0px))` behind the base layer with an `sm:` override.

## Risks

Low. Presentational-only, ≤50 LOC. Gallery/Vault/Atelier all share this layout so the change is uniform. Mobile (<640px) clearance and the iOS safe-area inset are byte-for-byte unchanged; Item Detail's own `sm:mb-20` is independent and unaffected. Full e2e (including first-run single-CTA, read-only sample labeling, and export-modal flows) stays green.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-jlbzg7-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview at a desktop viewport (≥640px). Scroll any page (Home, a collection, an item) to the bottom — no ~88px empty band and no fixed fade at the viewport bottom.
2. Resize below 640px — the bottom nav reappears with full clearance and the fade returns above it.
3. On iOS Safari (or emulated safe-area), confirm the bottom nav still clears the home indicator.

Checks (run locally on this branch):
- [x] npm run format:check
- [x] npm test (982 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not captured in this headless run — the change is the *removal* of empty bottom space + a decorative fade on desktop; see the Vercel preview verification steps above. Mobile is visually unchanged.

## Linear

Closes CUR-97

## Rollback plan

Green-tier presentational change. Revert with `git revert 1cd4213`, or hand-revert: restore the inline `paddingBottom` style on `<main>` and drop `sm:pb-8`, remove `sm:hidden` from the `<footer>`, and delete the `CUR-97 desktop bottom clearance` describe block in `tests/components/Layout.test.tsx`.