### PR TITLE
[CUR-32] Add optional auto-advance slideshow to Exhibition mode

### DIFF
--- a/src/components/ExhibitionView.tsx
+++ b/src/components/ExhibitionView.tsx
@@ -1,10 +1,15 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { X, ChevronLeft, ChevronRight, Star } from 'lucide-react';
+import { X, ChevronLeft, ChevronRight, Star, Play, Pause } from 'lucide-react';
 import { UserCollection } from '../types';
 import { ItemImage } from './ItemImage';
 import { useTranslation, getFieldTranslation } from '../i18n';
 import { useModalA11y } from '../hooks/useModalA11y';
+
+// CUR-32: optional auto-advance for ambient / passive display. Off by default;
+// the exhibition stays a manual, deliberate walk unless the user opts in.
+const AUTOPLAY_INTERVALS_MS = [5000, 10000, 30000] as const;
+const DEFAULT_AUTOPLAY_INTERVAL_MS = 10000;
 
 interface ExhibitionViewProps {
   collection: UserCollection;
@@ -22,19 +27,67 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
   const { t } = useTranslation();
   const [index, setIndex] = useState(initialIndex);
   const [showInfo, setShowInfo] = useState(true);
+  // CUR-32: auto-play state. `interactionNonce` restarts the countdown whenever
+  // the user takes over (nav / dot / swipe / toggle) so a manual move never
+  // triggers an immediate auto-advance and the progress indicator resets.
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [intervalMs, setIntervalMs] = useState<number>(DEFAULT_AUTOPLAY_INTERVAL_MS);
+  const [interactionNonce, setInteractionNonce] = useState(0);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const getFieldLabel = (fieldId: string, fallback: string) =>
     getFieldTranslation(t, fieldId, fallback);
 
-  const next = useCallback(
-    () => setIndex((i) => (i + 1) % collection.items.length),
-    [collection.items.length],
+  const registerInteraction = useCallback(() => setInteractionNonce((n) => n + 1), []);
+
+  const next = useCallback(() => {
+    registerInteraction();
+    setIndex((i) => (i + 1) % collection.items.length);
+  }, [collection.items.length, registerInteraction]);
+  const prev = useCallback(() => {
+    registerInteraction();
+    setIndex((i) => (i - 1 + collection.items.length) % collection.items.length);
+  }, [collection.items.length, registerInteraction]);
+  const jumpTo = useCallback(
+    (target: number) => {
+      registerInteraction();
+      setIndex(target);
+    },
+    [registerInteraction],
   );
-  const prev = useCallback(
-    () => setIndex((i) => (i - 1 + collection.items.length) % collection.items.length),
-    [collection.items.length],
+
+  const canAutoplay = collection.items.length > 1;
+
+  const toggleAutoplay = useCallback(() => {
+    registerInteraction();
+    setIsPlaying((p) => !p);
+  }, [registerInteraction]);
+
+  const selectInterval = useCallback(
+    (ms: number) => {
+      registerInteraction();
+      setIntervalMs(ms);
+      setIsPlaying(true);
+    },
+    [registerInteraction],
   );
+
+  // Advance on a timer while playing. The timer reschedules from scratch on any
+  // interaction (via `interactionNonce`) or interval change, so it never fires
+  // right after the user has just moved. Auto-advance itself uses `setIndex`
+  // directly (not `next`) so it doesn't reset its own countdown.
+  useEffect(() => {
+    if (!isOpen || !isPlaying || !canAutoplay) return;
+    const id = window.setInterval(() => {
+      setIndex((i) => (i + 1) % collection.items.length);
+    }, intervalMs);
+    return () => window.clearInterval(id);
+  }, [isOpen, isPlaying, canAutoplay, intervalMs, interactionNonce, collection.items.length]);
+
+  // Closing the exhibition stops playback so re-opening always starts calm.
+  useEffect(() => {
+    if (!isOpen) setIsPlaying(false);
+  }, [isOpen]);
 
   // Esc-to-close, focus trap and focus restore live in the shared modal a11y
   // primitive; only arrow-key navigation is bespoke to the exhibition view.
@@ -71,6 +124,57 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
 
   const dialogLabel = `${collection.name} — ${t('exhibitNo', { n: index + 1, total: collection.items.length })}`;
 
+  // CUR-32: the auto-play cluster (play/pause + interval pills) lives in both
+  // the mobile and desktop layouts, mirroring how the close button, arrows and
+  // dots are duplicated per breakpoint. `variant` only tweaks sizing.
+  const renderAutoplayControls = (variant: 'mobile' | 'desktop') => {
+    if (!canAutoplay) return null;
+    const btnSize = variant === 'desktop' ? 'w-10 h-10' : 'w-9 h-9';
+    return (
+      <div className="flex items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={toggleAutoplay}
+          aria-pressed={isPlaying}
+          aria-label={isPlaying ? t('exhibitionAutoplayPause') : t('exhibitionAutoplayStart')}
+          className={`${btnSize} rounded-full flex items-center justify-center transition-all active:scale-90 ${
+            isPlaying ? 'bg-amber-500 text-stone-950' : 'bg-white/10 text-white hover:bg-white/20'
+          }`}
+        >
+          {isPlaying ? (
+            <Pause size={16} fill="currentColor" />
+          ) : (
+            <Play size={16} fill="currentColor" />
+          )}
+        </button>
+        {isPlaying && (
+          <div className="flex items-center gap-1">
+            {AUTOPLAY_INTERVALS_MS.map((ms) => {
+              const seconds = ms / 1000;
+              const active = intervalMs === ms;
+              return (
+                <button
+                  key={ms}
+                  type="button"
+                  onClick={() => selectInterval(ms)}
+                  aria-pressed={active}
+                  aria-label={t('exhibitionAutoplayInterval', { n: seconds })}
+                  className={`px-2 py-1 rounded-full text-[10px] font-mono tracking-wider transition-all ${
+                    active
+                      ? 'bg-amber-500 text-stone-950'
+                      : 'bg-white/10 text-white/70 hover:bg-white/20'
+                  }`}
+                >
+                  {t('exhibitionAutoplaySeconds', { n: seconds })}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  };
+
   const content = (
     <div
       ref={dialogRef}
@@ -81,6 +185,22 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >
+      {/* CUR-32: countdown to the next auto-advance. Decorative (position is
+          already announced via the dialog's accessible name), keyed so the
+          fill restarts cleanly on every advance, interaction or interval
+          change. */}
+      {isPlaying && canAutoplay && (
+        <div
+          className="absolute top-0 inset-x-0 h-0.5 bg-white/10 z-20 print:hidden"
+          aria-hidden="true"
+        >
+          <div
+            key={`${index}-${interactionNonce}-${intervalMs}`}
+            className="h-full bg-amber-500 animate-exhibition-progress"
+            style={{ animationDuration: `${intervalMs}ms` }}
+          />
+        </div>
+      )}
       {/* ── MOBILE LAYOUT (< sm) ── */}
       <div className="flex flex-col h-full sm:hidden">
         {/* Image: hero, fills most of the screen */}
@@ -177,22 +297,25 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
           </div>
         </div>
 
-        {/* Pagination dots */}
-        <div className="flex justify-center items-center gap-1.5 py-2.5">
-          {collection.items.slice(0, 10).map((_, i) => (
-            <button
-              key={i}
-              onClick={() => setIndex(i)}
-              aria-label={t('exhibitionJumpTo', { n: i + 1 })}
-              aria-current={i === index ? 'true' : undefined}
-              className={`h-1 rounded-full transition-all ${
-                i === index ? 'w-6 bg-amber-500' : 'w-1.5 bg-white/20 hover:bg-white/30'
-              }`}
-            />
-          ))}
-          {collection.items.length > 10 && (
-            <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
-          )}
+        {/* Auto-play + pagination dots */}
+        <div className="flex flex-col items-center gap-2 py-2.5">
+          {renderAutoplayControls('mobile')}
+          <div className="flex justify-center items-center gap-1.5">
+            {collection.items.slice(0, 10).map((_, i) => (
+              <button
+                key={i}
+                onClick={() => jumpTo(i)}
+                aria-label={t('exhibitionJumpTo', { n: i + 1 })}
+                aria-current={i === index ? 'true' : undefined}
+                className={`h-1 rounded-full transition-all ${
+                  i === index ? 'w-6 bg-amber-500' : 'w-1.5 bg-white/20 hover:bg-white/30'
+                }`}
+              />
+            ))}
+            {collection.items.length > 10 && (
+              <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
+            )}
+          </div>
         </div>
       </div>
 
@@ -293,13 +416,14 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
           </button>
         </div>
 
-        {/* Footer pagination */}
-        <footer className="py-6 px-8 flex justify-center">
+        {/* Footer: auto-play + pagination */}
+        <footer className="py-6 px-8 flex flex-col items-center gap-3">
+          {renderAutoplayControls('desktop')}
           <div className="flex gap-2 items-center">
             {collection.items.slice(0, 10).map((_, i) => (
               <button
                 key={i}
-                onClick={() => setIndex(i)}
+                onClick={() => jumpTo(i)}
                 aria-label={t('exhibitionJumpTo', { n: i + 1 })}
                 aria-current={i === index ? 'true' : undefined}
                 className={`h-1.5 rounded-full transition-all ${

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -62,6 +62,10 @@ export const translations = {
     add: 'Add',
     exhibitNo: 'Exhibit No. {n} of {total}',
     exhibitionJumpTo: 'Jump to exhibit {n}',
+    exhibitionAutoplayStart: 'Start auto-play',
+    exhibitionAutoplayPause: 'Pause auto-play',
+    exhibitionAutoplayInterval: 'Auto-advance every {n} seconds',
+    exhibitionAutoplaySeconds: '{n}s',
     updatePhoto: 'Update photo',
     exportCard: 'Export Card',
     archiveNarrative: 'Story', // alias kept for one release; storyLabel is canonical
@@ -595,6 +599,10 @@ export const translations = {
     add: '添加',
     exhibitNo: '展品 第 {n} 件 / 共 {total} 件',
     exhibitionJumpTo: '跳转到第 {n} 件展品',
+    exhibitionAutoplayStart: '开始自动播放',
+    exhibitionAutoplayPause: '暂停自动播放',
+    exhibitionAutoplayInterval: '每 {n} 秒自动切换',
+    exhibitionAutoplaySeconds: '{n}秒',
     updatePhoto: '更新照片',
     exportCard: '导出馆藏卡片',
     archiveNarrative: '故事', // alias kept for one release; story is canonical

--- a/src/index.css
+++ b/src/index.css
@@ -152,6 +152,28 @@ body {
   animation: float 6s ease-in-out infinite;
 }
 
+/* CUR-32: Exhibition auto-play countdown. The bar fills across the interval
+   and is re-mounted (keyed) on each advance to restart cleanly. Duration is
+   set inline from the selected interval. */
+@keyframes exhibitionProgress {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+.animate-exhibition-progress {
+  transform-origin: left center;
+  animation: exhibitionProgress linear forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-exhibition-progress {
+    animation: none;
+    transform: scaleX(1);
+  }
+}
+
 /* Print styles */
 /* CUR-103: scope the card-only print rules to when the Export modal is open.
    `#card-preview` only exists while `<ExportModal data-export-modal>` is

--- a/tests/components/ExhibitionView.test.tsx
+++ b/tests/components/ExhibitionView.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, setMockTheme } from '../utils/test-utils';
 import { ExhibitionView } from '@/components/ExhibitionView';
 import { UserCollection } from '@/types';
@@ -154,6 +154,104 @@ describe('ExhibitionView', () => {
         expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*2/);
       });
       expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auto-play (CUR-32)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('offers no auto-play controls for a single-item collection', () => {
+      const single: UserCollection = { ...collection, items: [collection.items[0]] };
+      renderWithProviders(<ExhibitionView collection={single} isOpen={true} onClose={vi.fn()} />);
+      expect(screen.queryByRole('button', { name: 'Start auto-play' })).not.toBeInTheDocument();
+    });
+
+    it('advances on the selected interval and stops when paused', () => {
+      vi.useFakeTimers();
+      renderWithProviders(
+        <ExhibitionView collection={collection} isOpen={true} onClose={vi.fn()} />,
+      );
+
+      // Both layouts mount, so the toggle exists twice; either drives shared state.
+      const play = screen.getAllByRole('button', { name: 'Start auto-play' });
+      expect(play).toHaveLength(2);
+      act(() => {
+        fireEvent.click(play[0]);
+      });
+
+      // Default cadence is 10s; nothing should advance before it elapses.
+      act(() => {
+        vi.advanceTimersByTime(9000);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*2/);
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/2.*2/);
+
+      // Pausing halts the timer.
+      const pause = screen.getAllByRole('button', { name: 'Pause auto-play' });
+      act(() => {
+        fireEvent.click(pause[0]);
+      });
+      act(() => {
+        vi.advanceTimersByTime(20000);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/2.*2/);
+    });
+
+    it('honors a shorter selected interval', () => {
+      vi.useFakeTimers();
+      renderWithProviders(
+        <ExhibitionView collection={collection} isOpen={true} onClose={vi.fn()} />,
+      );
+
+      act(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'Start auto-play' })[0]);
+      });
+      act(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'Auto-advance every 5 seconds' })[0]);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/2.*2/);
+    });
+
+    it('restarts the countdown when the user navigates manually', () => {
+      vi.useFakeTimers();
+      renderWithProviders(
+        <ExhibitionView collection={collection} isOpen={true} onClose={vi.fn()} />,
+      );
+
+      act(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'Start auto-play' })[0]);
+      });
+      // Part-way through the interval, the user jumps ahead themselves.
+      act(() => {
+        vi.advanceTimersByTime(6000);
+      });
+      act(() => {
+        fireEvent.click(screen.getAllByRole('button', { name: 'Jump to exhibit 2' })[0]);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/2.*2/);
+
+      // The remaining 4s of the old countdown must not trigger an advance —
+      // the timer restarts from the interaction.
+      act(() => {
+        vi.advanceTimersByTime(4000);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/2.*2/);
+
+      // A full interval after the interaction does advance (wrapping to 1).
+      act(() => {
+        vi.advanceTimersByTime(6000);
+      });
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*2/);
     });
   });
 });


### PR DESCRIPTION
## Problem

Exhibition mode only advanced on a manual swipe / click / arrow key, so it couldn't be used as an ambient, hands-off display — e.g. a collection playing on a screen at home or during an event. CUR-32 asks for an **optional** auto-advance timer. This is a "beauty before bureaucracy" enhancement to the exhibition — the museum's show-off surface — without adding any new product surface elsewhere.

## Approach

Add an opt-in auto-play control to `ExhibitionView`, off by default so the standard experience stays a deliberate, manual walk:

- **Play/pause toggle + interval selector** (5s / 10s / 30s), rendered in both the mobile and desktop layouts next to the existing pagination dots (mirroring how close / arrows / dots are already duplicated per breakpoint). A shared `renderAutoplayControls()` helper keeps the two in sync.
- **Pause on interaction, resume after idle:** any manual move (arrows, swipe, keyboard, dot jump, interval change) bumps an interaction nonce that restarts the timer, so the slideshow never jumps right after the viewer takes over. Auto-advance itself uses `setIndex` directly so it doesn't reset its own countdown.
- **Visual state indicator:** a thin amber countdown bar across the top shows auto-play is active and how long until the next advance. It's keyed to restart cleanly on each advance/interaction, respects `prefers-reduced-motion`, and is `aria-hidden` (position is already announced via the dialog's accessible name).
- Auto-play stops when the exhibition closes; controls are hidden for single-item collections.
- EN + ZH strings added; controls reuse the exhibition's existing amber-500 accent (the view is always the fixed cinematic dark surface, so no theme branching is needed).

## Why this approach

It's the smallest change that satisfies all three acceptance criteria and lives entirely in one component + its strings + one CSS keyframe — no data flow, sync, auth, or routing changes. It reuses the existing per-breakpoint control pattern and amber accent so it reads as native to the exhibition. Off-by-default keeps the default experience unchanged.

## Risks

Low. Green-tier, presentational + a timer, scoped to `ExhibitionView`. No impact on sync, storage, AI, auth, or read-only boundaries. The timer is guarded on `isOpen`/`isPlaying`/multi-item and cleaned up on unmount and close, so it can't run in the background. Reduced-motion users get a static bar.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-kh8ake-qs-projects-72b20d9d.vercel.app

Steps:
1. Open a collection with ≥2 items → **Enter Exhibition**.
2. Press the play button (bottom controls). Items advance every 10s by default; the amber bar across the top counts down.
3. Tap **5s** / **30s** to change cadence; press pause to stop.
4. While playing, swipe / arrow / tap a dot — the countdown restarts instead of immediately jumping.
5. Confirm single-item collections show no auto-play control, and closing the exhibition resets it to paused.
6. Switch language to 中文 — the control labels are localized (screen-reader labels: 开始自动播放 / 暂停自动播放 / 每 N 秒自动切换).

Checks (run locally on this branch):
- [x] npm run format:check
- [x] npm test (984 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not captured in this headless run. The change is an opt-in play/pause + interval control and a top countdown bar in Exhibition mode; mobile and desktop are visually unchanged until the user presses play. See the Vercel preview and verification steps above.

## Linear

Closes CUR-32

## Rollback plan

Green-tier, self-contained. Revert with `git revert <merge_or_commit_sha>`, or hand-revert: remove the auto-play state/effects, `renderAutoplayControls`, the countdown bar, and `jumpTo` wiring in `src/components/ExhibitionView.tsx`; drop the `exhibitionAutoplay*` keys (EN + ZH) in `src/i18n.ts`; remove the `exhibitionProgress` keyframe / `.animate-exhibition-progress` block in `src/index.css`; and delete the `auto-play (CUR-32)` describe block in `tests/components/ExhibitionView.test.tsx`.