### PR TITLE
[CUR-48] Localize collection template presets in ZH mode

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UserCollection } from '../types';
 import { ChevronRight, Search } from 'lucide-react';
 import { TEMPLATES } from '../constants';
-import { useTranslation, getFieldTranslation } from '../i18n';
+import { useTranslation, getFieldTranslation, getTemplateDescription } from '../i18n';
 import {
   useTheme,
   cardSurfaceClasses,
@@ -71,7 +71,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = React.memo(function
     ? meaningfulDescription
     : tagPreview
       ? `${t('fieldsLabel')}: ${tagPreview}`
-      : template.description;
+      : getTemplateDescription(t, template.id, template.description);
 
   return (
     <div

--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, ChevronDown, GripVertical, Loader2, Pin, X } from 'lucide-react';
 import { TEMPLATES } from '../constants';
 import { Button } from './ui/Button';
-import { useTranslation } from '../i18n';
+import { useTranslation, getTemplateName, getTemplateDescription } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
 import { suggestCollectionFields } from '../services/geminiService';
 import { useModalA11y } from '../hooks/useModalA11y';
@@ -148,7 +148,9 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     if (!isOpen) resetState();
   }, [isOpen]);
 
-  const nameFallback = selectedTemplate?.name || t('newArchive');
+  const nameFallback = selectedTemplate
+    ? getTemplateName(t, selectedTemplate.id, selectedTemplate.name)
+    : t('newArchive');
   const displayName = collectionName.trim() || description.trim() || nameFallback;
 
   const handleClose = () => {
@@ -362,11 +364,11 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
       return;
     }
     if (selectedTemplate) {
-      setCollectionName(selectedTemplate.name);
+      setCollectionName(getTemplateName(t, selectedTemplate.id, selectedTemplate.name));
       return;
     }
     setCollectionName('');
-  }, [description, selectedTemplate, hasEditedName, isOpen]);
+  }, [description, selectedTemplate, hasEditedName, isOpen, t]);
 
   useEffect(() => {
     if (step !== 'loading') return;
@@ -501,7 +503,9 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
                 <span className="mb-2 block text-xl" aria-hidden="true">
                   {temp.icon}
                 </span>
-                <span className="block text-sm font-semibold leading-tight">{temp.name}</span>
+                <span className="block text-sm font-semibold leading-tight">
+                  {getTemplateName(t, temp.id, temp.name)}
+                </span>
               </button>
             );
           })}
@@ -520,10 +524,10 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
                 <p
                   className={`text-sm font-semibold ${theme === 'vault' ? 'text-white' : 'text-stone-800'}`}
                 >
-                  {selectedTemplate.name}
+                  {getTemplateName(t, selectedTemplate.id, selectedTemplate.name)}
                 </p>
                 <p className={`text-[12px] ${mutedText} leading-snug`}>
-                  {selectedTemplate.description}
+                  {getTemplateDescription(t, selectedTemplate.id, selectedTemplate.description)}
                 </p>
               </div>
             </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -377,6 +377,11 @@ export const translations = {
     label_age: 'Age',
     label_abv: 'ABV %',
     label_region: 'Region',
+    // Collection template preset names/descriptions are authored in English in
+    // constants.ts (the single source of truth). Only non-English overrides are
+    // added below in each locale; getTemplateName/getTemplateDescription fall
+    // back to the constants string when no override exists (e.g. English, or a
+    // future custom template).
     // Image Enhancement
     enhanceImage: 'Enhance Image',
     enhanceImageDesc: 'Improve photo quality with AI',
@@ -907,6 +912,19 @@ export const translations = {
     label_age: '年份/年份',
     label_abv: '酒精度 %',
     label_region: '产区',
+    // Chinese overrides for the template presets authored in constants.ts.
+    template_general_name: '综合收藏',
+    template_general_desc: '收藏门票、邮票以及各种有趣的珍奇之物。',
+    template_chocolate_name: '巧克力典藏',
+    template_chocolate_desc: '记录产地风土、可可含量与细腻的风味层次。',
+    template_vinyl_name: '黑胶收藏',
+    template_vinyl_desc: '按艺术家、压制版本与品相整理你的黑胶唱片。',
+    template_perfume_name: '香水典藏',
+    template_perfume_desc: '管理你的香水、香调与香水屋。',
+    template_sneakers_name: '球鞋收藏',
+    template_sneakers_desc: '策展你的球鞋轮换与限量配色。',
+    template_spirits_name: '烈酒收藏',
+    template_spirits_desc: '记录珍稀酒款、年份与蒸馏细节。',
     // Image Enhancement
     enhanceImage: '优化图片',
     enhanceImageDesc: '用 AI 提升照片质量',
@@ -1099,6 +1117,35 @@ export const getFieldTranslation = (
   if (translated === key) return fallbackLabel ?? fieldId;
   return translated;
 };
+
+/**
+ * Look up a collection template's localized name / description
+ * (`template_<id>_name`, `template_<id>_desc`). Falls back to the template's
+ * built-in English string so custom or future templates render unchanged.
+ */
+const getTemplateString = (
+  t: (key: TranslationKey | (string & {}), params?: Record<string, string | number>) => string,
+  templateId: string,
+  kind: 'name' | 'desc',
+  fallback?: string,
+): string => {
+  const key = `template_${templateId}_${kind}`;
+  const translated = t(key);
+  if (translated === key) return fallback ?? '';
+  return translated;
+};
+
+export const getTemplateName = (
+  t: (key: TranslationKey | (string & {}), params?: Record<string, string | number>) => string,
+  templateId: string,
+  fallbackName?: string,
+): string => getTemplateString(t, templateId, 'name', fallbackName);
+
+export const getTemplateDescription = (
+  t: (key: TranslationKey | (string & {}), params?: Record<string, string | number>) => string,
+  templateId: string,
+  fallbackDesc?: string,
+): string => getTemplateString(t, templateId, 'desc', fallbackDesc);
 
 interface LanguageContextType {
   language: Language;

--- a/tests/unit/templateTranslation.test.tsx
+++ b/tests/unit/templateTranslation.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * CUR-48 — template presets must localize in ZH mode.
+ *
+ * The collection preset shelf (CreateCollectionModal) and the CollectionCard
+ * description fallback used to render the English `template.name` /
+ * `template.description` from constants.ts even in Chinese mode, leaving a
+ * visibly mixed EN/ZH UI. `getTemplateName` / `getTemplateDescription` now look
+ * up a per-locale override and fall back to the English source of truth.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { translations, getTemplateName, getTemplateDescription } from '@/i18n';
+import { TEMPLATES } from '@/constants';
+
+type Lang = keyof typeof translations;
+
+// Mirror the LanguageProvider's lookup (locale dict → English fallback → key)
+// without standing up the React context, so we can exercise both locales.
+const makeT =
+  (lang: Lang) =>
+  (key: string): string => {
+    const dict = translations[lang] as Record<string, string>;
+    const fallback = translations.en as Record<string, string>;
+    return dict[key] || fallback[key] || key;
+  };
+
+describe('CUR-48 — collection template localization', () => {
+  it('every template preset has a Chinese name and description override', () => {
+    const missing: string[] = [];
+    for (const template of TEMPLATES) {
+      const zh = translations.zh as Record<string, string>;
+      if (!zh[`template_${template.id}_name`]) missing.push(`template_${template.id}_name`);
+      if (!zh[`template_${template.id}_desc`]) missing.push(`template_${template.id}_desc`);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('resolves the Chinese override in ZH mode', () => {
+    const t = makeT('zh');
+    expect(getTemplateName(t, 'vinyl', 'Vinyl Archives')).toBe('黑胶收藏');
+    expect(getTemplateDescription(t, 'chocolate', 'ignored')).toBe(
+      '记录产地风土、可可含量与细腻的风味层次。',
+    );
+  });
+
+  it('falls back to the English source of truth when no override exists', () => {
+    const t = makeT('en');
+    const vinyl = TEMPLATES.find((tpl) => tpl.id === 'vinyl')!;
+    expect(getTemplateName(t, vinyl.id, vinyl.name)).toBe(vinyl.name);
+    expect(getTemplateDescription(t, vinyl.id, vinyl.description)).toBe(vinyl.description);
+    // Unknown / future custom templates also fall through to the fallback.
+    expect(getTemplateName(t, 'not-a-template', 'My Collection')).toBe('My Collection');
+  });
+
+  it('Chinese template overrides contain no leftover English text', () => {
+    const zh = translations.zh as Record<string, string>;
+    const offenders = Object.entries(zh)
+      .filter(([key]) => key.startsWith('template_'))
+      .filter(([, value]) => /[A-Za-z]/.test(value))
+      .map(([key, value]) => `${key} → ${value}`);
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Switching the app to Chinese still left the **collection template presets** in English. The preset shelf in `CreateCollectionModal` and the `CollectionCard` description fallback rendered the raw English `template.name` / `template.description` from `constants.ts` regardless of language, so a ZH user saw "Vinyl Archives" / "Organize your analog sound library…" mixed into an otherwise Chinese UI. Mixed EN/ZH copy reads as half-finished and quietly erodes trust in localization (**Trust before growth**). This is one of the concrete gaps called out in CUR-48 ("preset names… template names not fully translated").

## Approach

- Add `getTemplateName` / `getTemplateDescription` helpers to `i18n.ts`, mirroring the existing `getFieldTranslation` pattern: they look up a per-locale `template_<id>_name` / `template_<id>_desc` override and fall back to the passed-in English string.
- Add Chinese overrides for all six presets (general, chocolate, vinyl, perfume, sneakers, spirits).
- Wire the create flow (preset shelf label, selected-preset name + description, and the default collection-name prefill) and the `CollectionCard` description fallback through the helpers.
- Keep `constants.ts` as the **single English source of truth** — no English strings are duplicated into the `en` dict, so English rendering is byte-identical and a future custom template falls through unchanged.

## Why this approach

It reuses the established `getFieldTranslation` convention rather than inventing new plumbing, and it avoids duplicating the English template copy in two places (which would be a drift hazard, and would also trip the CUR-122 warm-vocabulary guard on "Archive"). The change is additive and locale-scoped, so English behavior is provably untouched.

## Risks

Low. This is an i18n/presentational change. English output is unchanged because the helpers fall back to the existing `constants.ts` strings (verified by test and by the unchanged `CreateCollectionModal` default-name assertion). No data, sync, auth, or AI paths are touched.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-ybnxxk-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview and switch language to 中文.
2. Start a new collection → the preset shelf now shows 黑胶收藏 / 香水典藏 / 烈酒收藏 etc., and the selected preset's name + description are in Chinese.
3. Pick a preset without editing the name → the prefilled collection name is the Chinese preset name.
4. On Home, a collection with no custom description shows the Chinese template description.
5. Switch back to English → all preset names/descriptions read exactly as before.

Checks:
- [x] npm run format:check
- [x] npm test (990 passed, 2 skipped)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not captured in this headless run — the preset shelf lives inside the authenticated create-collection flow. The change is copy-only; before/after is: preset name `Vinyl Archives` → `黑胶收藏` (and the five other presets) when the language toggle is set to 中文. Covered by `tests/unit/templateTranslation.test.tsx`.

## Tests

`tests/unit/templateTranslation.test.tsx` (new) asserts: every preset has a ZH name + description override, the helpers resolve the ZH override in `zh` mode and fall back to the English constant in `en` mode (and for unknown ids), and no ZH template override contains leftover ASCII text.

## Linear

Closes CUR-48

## Rollback plan

Green-tier, but if needed: `git revert 68d51cf` (single commit) fully restores prior behavior — no migrations, flags, or data changes involved.