### PR TITLE
[CUR-52] Add optional field-level hints for template fields

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -22,6 +22,7 @@ import { compressImageForAi } from '../services/imageProcessor';
 import { trackEvent, storyLengthBucket } from '../services/analytics';
 import { Button } from './ui/Button';
 import { useTranslation, getFieldTranslation, getFieldHint } from '../i18n';
+import { isBuiltInTemplateField } from '../constants';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
 import { ImageEditModal } from './ImageEditModal';
 
@@ -1641,8 +1642,19 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
         {detailsOpen && (
           <div data-testid="add-item-more-details" className="space-y-3 sm:space-y-4">
             {currentCollection?.customFields.map((field) => {
-              const value = formData.data?.[field.id] || '';
-              const hint = getFieldHint(t, field.id, field.hint);
+              const rawValue = formData.data?.[field.id];
+              const value = rawValue || '';
+              // Explicit empty check so a stored `false`/`0` still counts as
+              // filled; built-in hints are scoped to real template fields so a
+              // custom field whose id happens to match never inherits domain copy.
+              const isEmpty = rawValue === undefined || rawValue === null || rawValue === '';
+              const hint =
+                (isBuiltInTemplateField(currentCollection?.templateId, field.id)
+                  ? getFieldHint(t, field.id)
+                  : '') ||
+                field.hint ||
+                '';
+              const showHint = Boolean(hint) && isEmpty;
               return (
                 <div key={field.id}>
                   <label
@@ -1655,7 +1667,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
                     id={`add-item-field-${field.id}`}
                     className={`w-full p-2 sm:p-2.5 rounded-lg sm:rounded-xl text-sm ${inputSurface}`}
                     value={value}
-                    aria-describedby={hint && !value ? `add-item-hint-${field.id}` : undefined}
+                    aria-describedby={showHint ? `add-item-hint-${field.id}` : undefined}
                     onChange={(e) => {
                       setFormData({
                         ...formData,
@@ -1669,7 +1681,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
                       });
                     }}
                   />
-                  {hint && !value && (
+                  {showHint && (
                     <p
                       id={`add-item-hint-${field.id}`}
                       className={`mt-1 text-[11px] leading-snug ${mutedText}`}

--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -21,7 +21,7 @@ import { analyzeImage, fetchStoryPrompts, refreshAiEnabled } from '../services/g
 import { compressImageForAi } from '../services/imageProcessor';
 import { trackEvent, storyLengthBucket } from '../services/analytics';
 import { Button } from './ui/Button';
-import { useTranslation, getFieldTranslation } from '../i18n';
+import { useTranslation, getFieldTranslation, getFieldHint } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
 import { ImageEditModal } from './ImageEditModal';
 
@@ -1640,31 +1640,46 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
 
         {detailsOpen && (
           <div data-testid="add-item-more-details" className="space-y-3 sm:space-y-4">
-            {currentCollection?.customFields.map((field) => (
-              <div key={field.id}>
-                <label
-                  className={`block text-[11px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-0.5 sm:mb-1`}
-                >
-                  {getFieldLabel(field.id, field.label)}
-                </label>
-                <input
-                  className={`w-full p-2 sm:p-2.5 rounded-lg sm:rounded-xl text-sm ${inputSurface}`}
-                  value={formData.data?.[field.id] || ''}
-                  onChange={(e) => {
-                    setFormData({
-                      ...formData,
-                      data: { ...formData.data, [field.id]: e.target.value },
-                    });
-                    setAiFieldSuggestions((prev) => {
-                      if (!(field.id in prev)) return prev;
-                      const next = { ...prev };
-                      delete next[field.id];
-                      return next;
-                    });
-                  }}
-                />
-              </div>
-            ))}
+            {currentCollection?.customFields.map((field) => {
+              const value = formData.data?.[field.id] || '';
+              const hint = getFieldHint(t, field.id, field.hint);
+              return (
+                <div key={field.id}>
+                  <label
+                    htmlFor={`add-item-field-${field.id}`}
+                    className={`block text-[11px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-0.5 sm:mb-1`}
+                  >
+                    {getFieldLabel(field.id, field.label)}
+                  </label>
+                  <input
+                    id={`add-item-field-${field.id}`}
+                    className={`w-full p-2 sm:p-2.5 rounded-lg sm:rounded-xl text-sm ${inputSurface}`}
+                    value={value}
+                    aria-describedby={hint && !value ? `add-item-hint-${field.id}` : undefined}
+                    onChange={(e) => {
+                      setFormData({
+                        ...formData,
+                        data: { ...formData.data, [field.id]: e.target.value },
+                      });
+                      setAiFieldSuggestions((prev) => {
+                        if (!(field.id in prev)) return prev;
+                        const next = { ...prev };
+                        delete next[field.id];
+                        return next;
+                      });
+                    }}
+                  />
+                  {hint && !value && (
+                    <p
+                      id={`add-item-hint-${field.id}`}
+                      className={`mt-1 text-[11px] leading-snug ${mutedText}`}
+                    >
+                      {hint}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
             <div>
               <label
                 className={`block text-[11px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-0.5 sm:mb-1`}

--- a/src/components/ItemDetailScreen.tsx
+++ b/src/components/ItemDetailScreen.tsx
@@ -15,7 +15,7 @@ import {
   Trash2,
   Undo2,
 } from 'lucide-react';
-import { useTranslation, getFieldTranslation } from '../i18n';
+import { useTranslation, getFieldTranslation, getFieldHint } from '../i18n';
 import {
   useTheme,
   typographyClasses,
@@ -933,6 +933,10 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                   const label = getLabel(field.id);
                   const isMultilineText = field.type === 'text' || field.type === 'long_text';
                   const fieldValue = val || '';
+                  // Guide an empty, editable field; hide once filled or read-only so
+                  // the museum placard stays uncluttered (beauty before bureaucracy).
+                  const hint = getFieldHint(t, field.id, field.hint);
+                  const showHint = Boolean(hint) && !isReadOnly && !fieldValue;
                   const fieldBaseClass = `${typographyClasses.title} w-full bg-transparent border-none p-0 outline-none focus:text-amber-900 focus:ring-0 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : theme === 'atelier' ? 'text-stone-900 placeholder:text-[#8C7B6B]' : 'text-stone-900 placeholder:text-stone-500'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`;
                   const handleFieldChange = (
                     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -960,6 +964,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                           value={fieldValue}
                           placeholder="—"
                           rows={1}
+                          aria-describedby={showHint ? `item-field-hint-${field.id}` : undefined}
                           onChange={(e) => {
                             e.currentTarget.style.height = 'auto';
                             e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`;
@@ -972,9 +977,18 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                           className={fieldBaseClass}
                           value={fieldValue}
                           placeholder="—"
+                          aria-describedby={showHint ? `item-field-hint-${field.id}` : undefined}
                           onChange={handleFieldChange}
                           disabled={isReadOnly}
                         />
+                      )}
+                      {showHint && (
+                        <p
+                          id={`item-field-hint-${field.id}`}
+                          className={`mt-1 text-[11px] leading-snug ${mutedTextClasses[theme]}`}
+                        >
+                          {hint}
+                        </p>
                       )}
                     </div>
                   );

--- a/src/components/ItemDetailScreen.tsx
+++ b/src/components/ItemDetailScreen.tsx
@@ -27,6 +27,7 @@ import {
   ratingEmptyClasses,
 } from '../theme';
 import { UserCollection, CollectionItem } from '../types';
+import { isBuiltInTemplateField } from '../constants';
 import { Button } from './ui/Button';
 import { ItemDetailSkeleton } from './ui/Skeleton';
 import { ItemImage } from './ItemImage';
@@ -935,8 +936,18 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                   const fieldValue = val || '';
                   // Guide an empty, editable field; hide once filled or read-only so
                   // the museum placard stays uncluttered (beauty before bureaucracy).
-                  const hint = getFieldHint(t, field.id, field.hint);
-                  const showHint = Boolean(hint) && !isReadOnly && !fieldValue;
+                  // Built-in hints are scoped to real template fields so a custom
+                  // field whose id happens to match (e.g. "Origin") never inherits
+                  // domain copy. Empty is checked explicitly so a stored `false`/`0`
+                  // still counts as filled.
+                  const isEmpty = val === undefined || val === null || val === '';
+                  const hint =
+                    (isBuiltInTemplateField(collection.templateId, field.id)
+                      ? getFieldHint(t, field.id)
+                      : '') ||
+                    field.hint ||
+                    '';
+                  const showHint = Boolean(hint) && !isReadOnly && isEmpty;
                   const fieldBaseClass = `${typographyClasses.title} w-full bg-transparent border-none p-0 outline-none focus:text-amber-900 focus:ring-0 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : theme === 'atelier' ? 'text-stone-900 placeholder:text-[#8C7B6B]' : 'text-stone-900 placeholder:text-stone-500'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`;
                   const handleFieldChange = (
                     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -153,3 +153,15 @@ export const TEMPLATES: CollectionTemplate[] = [
     ],
   },
 ];
+
+/**
+ * True only when `fieldId` is a genuine field of the given built-in template.
+ * Custom fields are slugified from their label (see `buildFieldId` in App.tsx),
+ * so a user-created field named "Origin", "Condition", "Batch", etc. can collide
+ * with a built-in `hint_<id>` key. This scopes built-in field hints to real
+ * template fields so a custom collection never inherits domain-specific copy.
+ */
+export const isBuiltInTemplateField = (templateId: string | undefined, fieldId: string): boolean =>
+  TEMPLATES.some(
+    (template) => template.id === templateId && template.fields.some((f) => f.id === fieldId),
+  );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -377,6 +377,22 @@ export const translations = {
     label_age: 'Age',
     label_abv: 'ABV %',
     label_region: 'Region',
+    // Field Hints (optional one-liners shown under an empty input; keyed by field id)
+    hint_cocoa_percent: 'The share of cocoa solids — usually printed on the wrapper.',
+    hint_origin: 'Where the beans were grown — a country, region, or single estate.',
+    hint_batch: "The maker's batch or lot number, often on the back label.",
+    hint_concentration: 'How concentrated the scent is — e.g. EDT, EDP, or Parfum.',
+    hint_notes_top: 'The first impression — what you smell in the opening minutes.',
+    hint_notes_heart: 'The scent at its core, once the opening settles.',
+    hint_notes_base: 'What lingers hours later — the dry-down.',
+    hint_style_code: "The maker's style or SKU code, usually on the box label.",
+    hint_colorway: 'The official name of this colour combination.',
+    hint_deadstock: 'Never worn, still in original condition.',
+    hint_speed: 'Playback speed in RPM — 33⅓, 45, or 78.',
+    hint_condition: 'Record grading — e.g. Mint, VG+, or Good.',
+    hint_abv: 'Alcohol by volume — the percentage listed on the bottle.',
+    hint_age: 'Years matured, if the bottle states one.',
+    hint_region: 'Where it was made — e.g. Islay, Kentucky, or Jalisco.',
     // Image Enhancement
     enhanceImage: 'Enhance Image',
     enhanceImageDesc: 'Improve photo quality with AI',
@@ -907,6 +923,22 @@ export const translations = {
     label_age: '年份/年份',
     label_abv: '酒精度 %',
     label_region: '产区',
+    // Field Hints (optional one-liners shown under an empty input; keyed by field id)
+    hint_cocoa_percent: '可可固形物的比例——通常印在包装上。',
+    hint_origin: '可可豆的种植地——国家、地区或单一庄园。',
+    hint_batch: '制作者的批次或批号，通常在背标上。',
+    hint_concentration: '香水的浓度——如淡香水（EDT）、浓香水（EDP）或香精（Parfum）。',
+    hint_notes_top: '最初的印象——喷洒后几分钟内闻到的气息。',
+    hint_notes_heart: '前调散去后，香气的核心。',
+    hint_notes_base: '数小时后留下的余韵——尾调。',
+    hint_style_code: '制作者的款式或 SKU 代码，通常在鞋盒标签上。',
+    hint_colorway: '这一配色的官方名称。',
+    hint_deadstock: '全新未穿着，保持原始状态。',
+    hint_speed: '播放转速（RPM）——33⅓、45 或 78。',
+    hint_condition: '唱片品相评级——如 Mint、VG+ 或 Good。',
+    hint_abv: '酒精体积含量——瓶身标注的百分比。',
+    hint_age: '陈酿年数（若瓶身有标注）。',
+    hint_region: '产地——如艾雷岛、肯塔基或哈利斯科。',
     // Image Enhancement
     enhanceImage: '优化图片',
     enhanceImageDesc: '用 AI 提升照片质量',
@@ -1097,6 +1129,23 @@ export const getFieldTranslation = (
   const key = `label_${fieldId}`;
   const translated = t(key);
   if (translated === key) return fallbackLabel ?? fieldId;
+  return translated;
+};
+
+/**
+ * Look up an optional one-line field hint like `hint_cocoa_percent`.
+ * Mirrors {@link getFieldTranslation}: returns the localized hint when one
+ * exists, otherwise the field's own `hint` (for custom fields), otherwise ''.
+ * An empty string means "no hint" so callers can render conditionally.
+ */
+export const getFieldHint = (
+  t: (key: TranslationKey | (string & {}), params?: Record<string, string | number>) => string,
+  fieldId: string,
+  fallbackHint?: string,
+): string => {
+  const key = `hint_${fieldId}`;
+  const translated = t(key);
+  if (translated === key) return fallbackHint ?? '';
   return translated;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,12 @@ export interface FieldDefinition {
   options?: string[]; // For select types
   required?: boolean;
   displayMode: FieldDisplayMode; // Where this field appears in the UI
+  // Optional one-line help shown under an empty input while capturing or editing
+  // (e.g. "Cocoa %" → "usually printed on the wrapper"). For the built-in
+  // templates the copy lives in i18n as `hint_<id>` (keyed by field id, like
+  // `label_<id>`); this field is the source for custom/flexible-template fields
+  // and the fallback for `getFieldHint`.
+  hint?: string;
 }
 
 export interface CollectionTemplate {

--- a/tests/unit/fieldHint.test.tsx
+++ b/tests/unit/fieldHint.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * CUR-52 — optional field-level hints.
+ *
+ * Guards the `getFieldHint` lookup and the built-in hint copy: hints resolve
+ * per-locale (keyed by field id, like `label_<id>`), fall back to a custom
+ * field's own `hint`, and return '' when there is nothing to show so callers
+ * can render conditionally.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { translations, getFieldHint } from '@/i18n';
+import type { Language, TranslationKey } from '@/i18n';
+
+// Minimal stand-in for the provider's `t`: same dict → fallback → key lookup,
+// which is all `getFieldHint` depends on (it detects "missing" via `t(key) === key`).
+const makeT =
+  (lang: Language) =>
+  (key: TranslationKey | (string & {})): string => {
+    const dict = translations[lang] as Record<string, string>;
+    const fallback = translations.en as Record<string, string>;
+    return dict[key] ?? fallback[key] ?? String(key);
+  };
+
+const tEn = makeT('en');
+const tZh = makeT('zh');
+
+// Fields that carry hint copy in i18n. Kept in sync with the `hint_*` keys.
+const HINTED_FIELDS = [
+  'cocoa_percent',
+  'origin',
+  'batch',
+  'concentration',
+  'notes_top',
+  'notes_heart',
+  'notes_base',
+  'style_code',
+  'colorway',
+  'deadstock',
+  'speed',
+  'condition',
+  'abv',
+  'age',
+  'region',
+];
+
+describe('CUR-52 — getFieldHint', () => {
+  it('resolves the English hint for a built-in jargon field', () => {
+    expect(getFieldHint(tEn, 'cocoa_percent')).toBe(translations.en.hint_cocoa_percent);
+    expect(getFieldHint(tEn, 'cocoa_percent')).toMatch(/cocoa/i);
+  });
+
+  it('resolves a localized (Chinese) hint that differs from English', () => {
+    const en = getFieldHint(tEn, 'abv');
+    const zh = getFieldHint(tZh, 'abv');
+    expect(zh).toBe(translations.zh.hint_abv);
+    expect(zh).not.toBe(en);
+  });
+
+  it('every hinted field has both an EN and a ZH hint', () => {
+    for (const id of HINTED_FIELDS) {
+      expect(getFieldHint(tEn, id), `EN hint for ${id}`).not.toBe('');
+      expect(getFieldHint(tZh, id), `ZH hint for ${id}`).not.toBe('');
+    }
+  });
+
+  it('falls back to a custom field hint when no localized key exists', () => {
+    const custom = 'The maker printed this on the sleeve.';
+    expect(getFieldHint(tEn, 'made_up_field', custom)).toBe(custom);
+  });
+
+  it('returns an empty string when there is no hint and no fallback', () => {
+    expect(getFieldHint(tEn, 'made_up_field')).toBe('');
+    // A plain label field with no hint copy stays hintless.
+    expect(getFieldHint(tEn, 'category')).toBe('');
+  });
+});

--- a/tests/unit/fieldHint.test.tsx
+++ b/tests/unit/fieldHint.test.tsx
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { translations, getFieldHint } from '@/i18n';
 import type { Language, TranslationKey } from '@/i18n';
+import { isBuiltInTemplateField } from '@/constants';
 
 // Minimal stand-in for the provider's `t`: same dict → fallback → key lookup,
 // which is all `getFieldHint` depends on (it detects "missing" via `t(key) === key`).
@@ -72,5 +73,24 @@ describe('CUR-52 — getFieldHint', () => {
     expect(getFieldHint(tEn, 'made_up_field')).toBe('');
     // A plain label field with no hint copy stays hintless.
     expect(getFieldHint(tEn, 'category')).toBe('');
+  });
+});
+
+describe('CUR-52 — isBuiltInTemplateField (built-in hint scoping)', () => {
+  it('is true for a genuine field of that template', () => {
+    expect(isBuiltInTemplateField('chocolate', 'origin')).toBe(true);
+    expect(isBuiltInTemplateField('spirits', 'abv')).toBe(true);
+  });
+
+  it('is false for custom collections whose slugified field id collides', () => {
+    // A user field named "Origin" slugs to `origin` (see buildFieldId); it must
+    // not inherit the chocolate-origin hint.
+    expect(isBuiltInTemplateField('custom', 'origin')).toBe(false);
+    expect(isBuiltInTemplateField(undefined, 'condition')).toBe(false);
+  });
+
+  it('is false for a template that does not own the field', () => {
+    // Vinyl has no `origin` field, so a vinyl collection must not show it.
+    expect(isBuiltInTemplateField('vinyl', 'origin')).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Newcomers to a template can hit fields whose meaning isn't obvious — **"Cocoa %"**, **"ABV %"**, **"Style Code"**, **"Deadstock"**, perfume **"Top/Heart/Base Notes"**. Nothing tells them what to put there, so the blank input becomes a small moment of friction at exactly the point Curio promises _acceleration before automation_. This protects that principle: gently reduce the blank-page cost of capture without turning the form into a questionnaire.

## Approach

- Add an optional `hint?: string` to `FieldDefinition`. For the six built-in templates the hint copy lives in `i18n.ts` as `hint_` keyed by field id — exactly mirroring how `label_` already works — so hints also reach collections created **before** this change and are translatable (EN + ZH provided for ~15 jargon-y fields).
- Add a `getFieldHint(t, fieldId, fallback)` helper mirroring `getFieldTranslation`.
- Render the hint as a small muted line **only under an empty, editable field** — in Add Item's "More details" section and in Item Detail's field list. It vanishes once the field is filled and never renders on the read-only museum placard (public/sample collections), keeping the detail view uncluttered (_beauty before bureaucracy_). Wired via `aria-describedby` for screen readers; the Add Item input/label also gained a proper `htmlFor`/`id` pairing.
- **Built-in hints are scoped to genuine template fields** (`isBuiltInTemplateField`): custom field ids are slugified from their label, so a user field named "Origin"/"Condition"/etc. could otherwise collide with a built-in `hint_`; scoping prevents a custom collection from inheriting domain copy. A custom field's own `field.hint` still shows.
- **Empty is checked explicitly** (`undefined/null/''`) so a stored boolean `false` or numeric `0` counts as filled and doesn't surface a hint over a populated field.

## Why this approach

It reuses the established `label_` field-i18n convention rather than inventing new plumbing, and keying by field id means the hints work for existing stored collections. Gating on "genuinely-empty + editable + real template field" makes the hint self-minimizing and correct for custom collections.

## Risks

Low–moderate (Yellow because it touches the Add Item flow). Presentational/i18n only — no data, sync, auth, or AI paths change. Hints are additive and only appear under empty editable built-in-template fields. All 1004 unit tests and the e2e suite pass. The warm-vocabulary guard (`i18nVocabulary.test.tsx`) still passes — no hint copy uses archivist words.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-dtfrrb-qs-projects-72b20d9d.vercel.app

Steps:
1. Open a **private** collection (e.g. Chocolate Vault) → **Add Item** → skip/complete AI → expand **"More details"**.
2. Confirm a muted one-liner appears under empty fields like _Cocoa %_ ("The share of cocoa solids — usually printed on the wrapper."); type a value and confirm the hint disappears.
3. Open an item's detail view: empty spec fields show the same hint; filled fields and any **read-only** sample-collection field show **no** hint.
4. In a **custom** collection, add a field literally named "Origin" → confirm it shows **no** built-in hint.
5. Toggle language to **中文** and confirm the hints are localized.

Checks (re-run after merging `main`):
- [x] npm run format:check
- [x] npm test (1004 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not captured in this headless run — the hints live inside the authenticated Add Item / Item Detail field inputs (private collections), which aren't reachable without sign-in. The change is a muted one-line caption under empty template fields; behavior is covered by `tests/unit/fieldHint.test.tsx`.

## Tests

`tests/unit/fieldHint.test.tsx` (new) covers `getFieldHint` (EN/ZH resolution, custom-field fallback, empty-string default) and `isBuiltInTemplateField` (true for a real template field; false for custom-collection id collisions and for a template that doesn't own the field). These would not compile before this change.

## Linear

Refs CUR-52. Implements the hint capability and acceptance criteria 1–3 (optional `hint` on `FieldDefinition`, inline help in Add Item + Item Detail, translatable). **Deferred:** AC 4, the per-user "hide hints" preference — hints are already self-minimizing (empty editable fields only), so a global settings toggle would add management UI for little gain; left as a follow-up for the maintainer to schedule if wanted.

## Rollback plan

Three commits on this branch: `5e4b10b` (feature), `0913785` (review fixes), `7ae23b3` (merge of `main`). Revert with `git revert -m 1 7ae23b3 && git revert 0913785 5e4b10b`. No migrations, RLS, storage, feature-flag, env-var, or data changes are involved.