### PR TITLE
[CUR-38] Handle IndexedDB QuotaExceededError with an honest save-item message

### DIFF
--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -70,9 +70,9 @@ Primary stores:
 - `display`: downsampled display blobs
 - `settings`: preferences and retry queue metadata
 
-Known remaining gap:
+Storage quota handling:
 
-- storage quota warnings are still not implemented and remain tracked in issue [#83](https://github.com/Akkkkkkki/curio/issues/83)
+- `App.tsx` polls `navigator.storage.estimate()` and surfaces a near-limit warning toast (`statusStorageNearLimit`); a write that still fails with `QuotaExceededError` is caught and reported honestly via `statusStorageFull` rather than a generic retry prompt (see `isQuotaExceededError` in `services/db.ts`).
 
 ## 3. Asset Pipeline
 
@@ -321,7 +321,6 @@ Key columns added for the public sample flow:
 
 These are known gaps that should be closed before a full production launch. They are tracked in GitHub Issues.
 
-- **Storage quota warnings** for large local caches.
 - **AI gateway hardening** (CORS restrictions, auth/signed requests, rate limiting).
 - **Operational monitoring** for the AI gateway and sync error rates (metrics + alerting).
 - **Documentation alignment** so testing status reflects actual E2E coverage.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
   shouldPreserveLocalOnlyCollection,
   saveAllCollections,
   saveAsset,
+  isQuotaExceededError,
   deleteAsset,
   deleteCloudItem,
   deleteCollection,
@@ -946,12 +947,17 @@ export const AppContent: React.FC = () => {
         hasPhoto = true;
       } catch (e) {
         console.error('Image processing failed', e);
+        // CUR-38: a full device disk (IndexedDB quota) never recovers on retry,
+        // so surface an honest "free up space" message instead of the generic
+        // "please try again" — the latter implies a transient failure.
+        const storageFull = isQuotaExceededError(e);
         trackEvent('upload_failed', {
           operation: 'local_image_processing',
-          retryable: true,
+          retryable: !storageFull,
         });
-        showStatus(t('saveImageFailed'), 'error');
-        throw new Error(t('saveImageFailed'));
+        const message = storageFull ? t('statusStorageFull') : t('saveImageFailed');
+        showStatus(message, 'error');
+        throw new Error(message);
       }
     }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -274,6 +274,8 @@ export const translations = {
     statusImportComplete: 'Imported from local storage',
     statusImportFailed: 'Import failed',
     statusStorageNearLimit: 'Storage is almost full. Sync, remove items, or reduce image sizes.',
+    statusStorageFull:
+      'Your device storage is full, so this photo could not be saved. Remove some items or free up space, then try again.',
     showingItems: 'Showing {shown} of {total} items',
     loadMore: 'Load more',
     allItemsLoaded: 'All items loaded',
@@ -807,6 +809,7 @@ export const translations = {
     statusImportComplete: '本地数据已导入',
     statusImportFailed: '导入失败，请重试。',
     statusStorageNearLimit: '存储空间接近用尽。请同步、清理藏品或缩小图片。',
+    statusStorageFull: '设备存储空间已满，无法保存此照片。请清理部分藏品或释放空间后重试。',
     showingItems: '已显示 {shown} / {total} 件',
     loadMore: '加载更多',
     allItemsLoaded: '已加载全部',

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1682,6 +1682,23 @@ const recordItemImage = async ({
   return true;
 };
 
+/**
+ * CUR-38: A full device disk surfaces an IndexedDB write as a DOMException named
+ * `QuotaExceededError` (legacy code 22) — or Firefox's `NS_ERROR_DOM_QUOTA_REACHED`
+ * (code 1014). Detect every form so callers can show an honest, actionable message
+ * ("free up space") instead of a generic "try again" that never succeeds.
+ */
+export const isQuotaExceededError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as { name?: string; code?: number };
+  return (
+    err.name === 'QuotaExceededError' ||
+    err.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    err.code === 22 ||
+    err.code === 1014
+  );
+};
+
 export const saveAsset = async (
   collectionId: string,
   id: string,

--- a/tests/integration/AppQuotaSave.test.tsx
+++ b/tests/integration/AppQuotaSave.test.tsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { CollectionItem, UserCollection } from '@/types';
+import { AppContent } from '@/App';
+import { LanguageProvider } from '@/i18n';
+import * as db from '@/services/db';
+import * as supabaseService from '@/services/supabase';
+import * as imageProcessor from '@/services/imageProcessor';
+
+// CUR-38: when the device disk is full, the IndexedDB write inside saveAsset
+// rejects with a QuotaExceededError. Adding an item with a photo must then show
+// an honest "free up space" message — not the generic "please try again", which
+// implies a transient failure that a retry would clear.
+
+vi.mock('@/components/Layout', async () => {
+  const React = await import('react');
+
+  return {
+    Layout: ({ children, onAddItem }: { children: React.ReactNode; onAddItem?: () => void }) => (
+      <div>
+        <button type="button" data-testid="mock-layout-add-item" onClick={onAddItem}>
+          Add Item
+        </button>
+        {children}
+      </div>
+    ),
+  };
+});
+
+vi.mock('@/components/AddItemModal', async () => {
+  const React = await import('react');
+  type AddItemPayload = Omit<CollectionItem, 'id' | 'createdAt' | 'updatedAt'>;
+
+  return {
+    AddItemModal: ({
+      isOpen,
+      onSave,
+    }: {
+      isOpen: boolean;
+      onSave: (collectionId: string, item: AddItemPayload) => Promise<void>;
+    }) => {
+      const [error, setError] = React.useState<string | null>(null);
+      if (!isOpen) return null;
+
+      const attemptPhotoSave = async () => {
+        try {
+          await onSave('private-col', {
+            collectionId: 'private-col',
+            photoUrl: 'data:image/jpeg;base64,AAAA',
+            title: 'A photographed piece',
+            rating: 0,
+            data: {},
+            notes: '',
+          });
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      };
+
+      return (
+        <div role="dialog" aria-label="Mock add item modal">
+          <button type="button" onClick={attemptPhotoSave}>
+            Attempt photo save
+          </button>
+          {error && <p data-testid="mock-add-error">{error}</p>}
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock('@/services/db', async () => {
+  // Faithful re-implementation of the real predicate so the App branch is
+  // exercised end to end; everything else is a stub.
+  const isQuotaExceededError = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') return false;
+    const err = error as { name?: string; code?: number };
+    return (
+      err.name === 'QuotaExceededError' ||
+      err.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      err.code === 22 ||
+      err.code === 1014
+    );
+  };
+  return {
+    getLocalCollections: vi.fn(),
+    fetchCloudCollections: vi.fn(),
+    getPendingAssetUploadSummary: vi.fn(),
+    getPendingDeletes: vi.fn(),
+    getPendingSyncIds: vi.fn(),
+    hasLocalOnlyData: vi.fn(),
+    importLocalCollectionsToCloud: vi.fn(),
+    mergeCollections: vi.fn((local, cloud) => (cloud.length ? cloud : local)),
+    saveCollection: vi.fn(),
+    saveAllCollections: vi.fn(),
+    saveAsset: vi.fn(),
+    isQuotaExceededError,
+    clearEnhancedReference: vi.fn(),
+    deleteAsset: vi.fn(),
+    deleteCloudItem: vi.fn(),
+    deleteCollection: vi.fn(),
+    requestPersistence: vi.fn(),
+    getSeedVersion: vi.fn(),
+    setSeedVersion: vi.fn(),
+    initDB: vi.fn(),
+    setAssetSyncStatusCallback: vi.fn(),
+    setSyncStatusCallback: vi.fn(),
+    syncPendingChanges: vi.fn(),
+    syncPendingAssetUploads: vi.fn(),
+    syncPendingDeletes: vi.fn(),
+    extractCurioAssetPath: vi.fn(),
+    compareTimestamps: vi.fn((a?: string, b?: string) => {
+      if (!a && !b) return 0;
+      if (!a) return -1;
+      if (!b) return 1;
+      return new Date(a).getTime() - new Date(b).getTime();
+    }),
+  };
+});
+
+vi.mock('@/services/imageProcessor', () => ({
+  processImage: vi.fn(),
+}));
+
+vi.mock('@/services/analytics', () => ({
+  trackEvent: vi.fn(),
+  storyLengthBucket: vi.fn(() => 'none'),
+}));
+
+vi.mock('@/services/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: { user: { id: 'user1', email: 'collector@example.com' } } },
+      }),
+      onAuthStateChange: vi
+        .fn()
+        .mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: { is_admin: false }, error: null }),
+        })),
+      })),
+    })),
+  },
+  isSupabaseConfigured: vi.fn().mockReturnValue(true),
+  signOutUser: vi.fn(),
+}));
+
+vi.mock('@/services/geminiService', () => ({
+  refreshAiImageEditEnabled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@vercel/speed-insights/react', () => ({
+  SpeedInsights: () => null,
+}));
+
+vi.mock('@vercel/analytics/react', () => ({
+  Analytics: () => null,
+}));
+
+vi.mock('@/theme', async () => {
+  const React = await import('react');
+  const actual = await vi.importActual<typeof import('@/theme')>('@/theme');
+
+  const ThemeContext = React.createContext({
+    theme: 'gallery',
+    setTheme: () => {},
+  });
+
+  const ThemeProvider = ({ children }: { children: React.ReactNode }) => (
+    <ThemeContext.Provider value={{ theme: 'gallery', setTheme: () => {} }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+
+  return {
+    ...actual,
+    ThemeProvider,
+    useTheme: () => React.useContext(ThemeContext),
+  };
+});
+
+describe('App quota-exhaustion save handling', () => {
+  const editableCollection: UserCollection = {
+    id: 'private-col',
+    name: 'Editable Collection',
+    templateId: 'custom',
+    icon: 'E',
+    customFields: [],
+    items: [],
+    isPublic: false,
+    updatedAt: new Date('2026-06-01T00:00:00.000Z').toISOString(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(supabaseService.isSupabaseConfigured).mockReturnValue(true);
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: { user: { id: 'user1', email: 'collector@example.com' } } },
+    } as never);
+    vi.mocked(db.getLocalCollections).mockResolvedValue([editableCollection]);
+    vi.mocked(db.fetchCloudCollections).mockResolvedValue([]);
+    vi.mocked(db.mergeCollections).mockImplementation((local, cloud) =>
+      cloud.length ? cloud : local,
+    );
+    vi.mocked(db.getPendingSyncIds).mockResolvedValue([]);
+    vi.mocked(db.getPendingDeletes).mockResolvedValue([]);
+    vi.mocked(db.hasLocalOnlyData).mockReturnValue(false);
+    vi.mocked(db.getPendingAssetUploadSummary).mockResolvedValue({ total: 0, stalled: 0 });
+    vi.mocked(db.syncPendingChanges).mockResolvedValue(0);
+    vi.mocked(db.syncPendingAssetUploads).mockResolvedValue(0);
+    vi.mocked(db.syncPendingDeletes).mockResolvedValue(0);
+    vi.mocked(db.requestPersistence).mockResolvedValue(true);
+    vi.mocked(db.saveAllCollections).mockResolvedValue(undefined);
+    vi.mocked(db.saveCollection).mockResolvedValue(undefined);
+    vi.mocked(db.initDB).mockResolvedValue({} as never);
+    vi.mocked(imageProcessor.processImage).mockResolvedValue({
+      original: new Blob(['orig'], { type: 'image/jpeg' }),
+      display: new Blob(['disp'], { type: 'image/jpeg' }),
+    } as never);
+    // The device disk is full: the IndexedDB blob write rejects.
+    vi.mocked(db.saveAsset).mockRejectedValue(new DOMException('full', 'QuotaExceededError'));
+  });
+
+  it('surfaces an honest storage-full message when saving a photo hits the quota', async () => {
+    const user = userEvent.setup();
+    const { ThemeProvider } = await import('@/theme');
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('heading', { name: 'Editable Collection' });
+
+    await user.click(screen.getByTestId('mock-layout-add-item'));
+    await user.click(await screen.findByRole('button', { name: 'Attempt photo save' }));
+
+    const storageFullMessage =
+      'Your device storage is full, so this photo could not be saved. Remove some items or free up space, then try again.';
+
+    expect(await screen.findByTestId('mock-add-error')).toHaveTextContent(storageFullMessage);
+    expect(await screen.findByTestId('status-toast-message')).toHaveTextContent(storageFullMessage);
+    // The generic, retry-implying copy must not be what the user sees.
+    expect(screen.queryByText('Could not save image. Please try again.')).toBeNull();
+  });
+});

--- a/tests/unit/services/db.pure.test.ts
+++ b/tests/unit/services/db.pure.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { compareTimestamps, normalizePhotoPaths, getSyncBackoffMs } from '@/services/db';
+import {
+  compareTimestamps,
+  normalizePhotoPaths,
+  getSyncBackoffMs,
+  isQuotaExceededError,
+} from '@/services/db';
 
 describe('db.ts - Pure Functions', () => {
   describe('compareTimestamps', () => {
@@ -512,6 +517,33 @@ describe('db.ts - Pure Functions', () => {
 
     it('caps backoff at max delay', () => {
       expect(getSyncBackoffMs(10)).toBe(600000);
+    });
+  });
+
+  describe('isQuotaExceededError', () => {
+    it('detects a DOMException named QuotaExceededError', () => {
+      expect(isQuotaExceededError(new DOMException('full', 'QuotaExceededError'))).toBe(true);
+    });
+
+    it('detects the legacy numeric code 22', () => {
+      expect(isQuotaExceededError({ name: 'SomethingElse', code: 22 })).toBe(true);
+    });
+
+    it("detects Firefox's NS_ERROR_DOM_QUOTA_REACHED (name and code 1014)", () => {
+      expect(isQuotaExceededError({ name: 'NS_ERROR_DOM_QUOTA_REACHED' })).toBe(true);
+      expect(isQuotaExceededError({ code: 1014 })).toBe(true);
+    });
+
+    it('does not misclassify unrelated errors', () => {
+      expect(isQuotaExceededError(new Error('network down'))).toBe(false);
+      expect(isQuotaExceededError(new DOMException('aborted', 'AbortError'))).toBe(false);
+      expect(isQuotaExceededError({ name: 'TypeError', code: 5 })).toBe(false);
+    });
+
+    it('is safe on null / non-object inputs', () => {
+      expect(isQuotaExceededError(null)).toBe(false);
+      expect(isQuotaExceededError(undefined)).toBe(false);
+      expect(isQuotaExceededError('QuotaExceededError')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

When a user's device disk is full, the IndexedDB blob write inside `saveAsset` rejects with a `QuotaExceededError`. The add-item photo path caught **every** failure the same way and showed **"Could not save image. Please try again."** For a full disk that copy is a small betrayal of trust: retrying never succeeds, and it gives no hint at the real cause or the fix. This protects **Trust before growth** — surface the real failure with actionable guidance instead of fake, transient-sounding certainty.

CUR-38's proactive near-limit warning (AC1/AC2) already shipped via `checkStorageQuota`. This PR closes the remaining acceptance criterion: **handle `QuotaExceededError` gracefully — don't crash, show a real error.**

## Approach

- Add an exported `isQuotaExceededError(error)` predicate in `services/db.ts` that recognizes the `QuotaExceededError` name, the legacy DOMException code `22`, and Firefox's `NS_ERROR_DOM_QUOTA_REACHED` / code `1014`.
- In `handleAddItem`'s image-save `catch`, branch to a distinct, honest message (`statusStorageFull`, EN + ZH) when storage is full — "Your device storage is full… Remove some items or free up space, then try again." — instead of the generic retry prompt. Non-quota failures keep the existing `saveImageFailed` copy.
- Realign `docs/TECHNICAL_DESIGN.md`, which still claimed storage quota warnings were unimplemented (they aren't) and listed them as a production gap.

## Why this approach

It reuses the existing save-path error handling and toast pattern rather than adding new UI, so the change is a message branch plus one small predicate. Detecting the error in a shared, tested helper keeps App.tsx thin and makes the browser-specific variants verifiable in isolation. No data, sync, merge, auth, or AI paths change — a full disk simply reports itself accurately.

## Risks

Low–moderate (Yellow because it touches the item-save path). The change is additive error-message branching only: what gets written to IndexedDB/Supabase and how items merge are untouched. The non-quota branch keeps its exact prior copy, so existing behavior is preserved; the `AppReadOnlySave` integration test still passes unchanged.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-p9uhcd-qs-projects-72b20d9d.vercel.app

Steps (manual, storage-full path):
1. Open a **private** collection → **Add Item**, attach a photo, complete/skip AI.
2. Simulate a full disk (e.g. DevTools → Application → Storage, or throttle quota) so the IndexedDB write throws `QuotaExceededError`.
3. Click **Save** → the toast reads "Your device storage is full…", not "Could not save image. Please try again."
4. Confirm a normal save (with space available) still works and non-quota image failures still show the generic message.

Checks:
- [x] npm run format:check
- [x] npm test (992 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not captured in this headless run — the storage-full state requires forcing an IndexedDB quota failure behind the authenticated Add Item flow. The user-visible delta is the toast/inline copy: `Could not save image. Please try again.` → `Your device storage is full, so this photo could not be saved. Remove some items or free up space, then try again.` Behavior is covered by `tests/integration/AppQuotaSave.test.tsx`.

## Tests

- `tests/unit/services/db.pure.test.ts` — new `isQuotaExceededError` cases (name, code 22, Firefox variant, non-quota errors, null/non-object inputs).
- `tests/integration/AppQuotaSave.test.tsx` (new) — mocks `saveAsset` to reject with a `QuotaExceededError` and asserts the storage-full toast + inline error appear and the generic retry copy does **not**. Both would fail before this change.

## Linear

Closes CUR-38

## Rollback plan

Single commit on this branch. Revert with `git revert e5c993b` (pre-hook SHA; use the merged SHA if different). No migrations, RLS, storage, feature-flag, env-var, or data changes are involved — the revert fully restores the prior generic-message behavior.