### PR TITLE
[CUR-30] Make Home museum stats jump to the collections grid

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { AlertCircle, Sparkles, Calendar, Search, Plus, Loader2, X } from 'lucide-react';
 import { useTranslation } from '../i18n';
@@ -74,6 +74,30 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const primaryHistoryItem = historyItems[0];
   const [historyExpanded, setHistoryExpanded] = useState(false);
   const visibleHistoryItems = historyExpanded ? historyItems : historyPreview;
+
+  // CUR-30: the museum stat line ("N collections · M pieces") jumps to the
+  // collections grid — a meaningful, honest drilldown to your archives without
+  // adding a separate all-items view (identity before inventory). Most useful on
+  // mobile, where the grid sits well below the search and On This Day sections.
+  const collectionsRef = useRef<HTMLDivElement>(null);
+  const scrollToCollections = () => {
+    const node = collectionsRef.current;
+    if (!node) return;
+    const reduceMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    node.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+    // Move focus so keyboard users continue from the grid, not the page top.
+    node.focus({ preventScroll: true });
+  };
+  const statsSummary = t('homeMuseumSubtitle', {
+    collections: t(stats.totalCollections === 1 ? 'collectionCount' : 'collectionsCount', {
+      n: stats.totalCollections,
+    }),
+    items: t(stats.totalItems === 1 ? 'artifactCataloged' : 'artifactsCataloged', {
+      n: stats.totalItems,
+    }),
+  });
 
   if (isLoading)
     return (
@@ -201,18 +225,21 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           {t('homeWelcome')}
         </p>
         <h1 className={`${typographyClasses.titleHero} leading-tight`}>{t('homeMuseumTitle')}</h1>
-        <p
-          className={`max-w-2xl font-serif text-sm italic sm:text-base ${theme === 'vault' ? 'text-stone-300' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-600'}`}
+        <button
+          type="button"
+          onClick={scrollToCollections}
+          aria-controls="collections-grid"
+          aria-label={t('homeStatsJumpAria', { stats: statsSummary })}
+          className={`group -mx-1 inline-flex max-w-2xl items-center rounded-md px-1 font-serif text-sm italic underline decoration-dotted decoration-1 underline-offset-4 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-amber-500/40 sm:text-base ${
+            theme === 'vault'
+              ? 'text-stone-300 decoration-white/25 hover:text-[#D4A574] hover:decoration-[#D4A574]/60'
+              : theme === 'atelier'
+                ? 'text-[#6F6257] decoration-[#8C7B6B]/40 hover:text-[#A86F3C] hover:decoration-[#A86F3C]/60'
+                : 'text-stone-600 decoration-stone-300 hover:text-amber-700 hover:decoration-amber-500/60'
+          }`}
         >
-          {t('homeMuseumSubtitle', {
-            collections: t(stats.totalCollections === 1 ? 'collectionCount' : 'collectionsCount', {
-              n: stats.totalCollections,
-            }),
-            items: t(stats.totalItems === 1 ? 'artifactCataloged' : 'artifactsCataloged', {
-              n: stats.totalItems,
-            }),
-          })}
-        </p>
+          {statsSummary}
+        </button>
       </header>
 
       <div className="relative max-w-xl mx-auto px-4">
@@ -329,7 +356,13 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
         </section>
       )}
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8" data-testid="collections-grid">
+      <div
+        ref={collectionsRef}
+        id="collections-grid"
+        tabIndex={-1}
+        className="grid grid-cols-1 md:grid-cols-2 gap-8 scroll-mt-24 outline-none"
+        data-testid="collections-grid"
+      >
         {filteredCollections.map((col) => {
           const matchesName = hasSearch && col.name.toLowerCase().includes(normalizedSearch);
           const matchesItems =

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -360,7 +360,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
         ref={collectionsRef}
         id="collections-grid"
         tabIndex={-1}
-        className="grid grid-cols-1 md:grid-cols-2 gap-8 scroll-mt-24 outline-none"
+        className="grid grid-cols-1 md:grid-cols-2 gap-8 scroll-mt-24 rounded-[2rem] outline-none focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
         data-testid="collections-grid"
       >
         {filteredCollections.map((col) => {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -49,6 +49,8 @@ export const translations = {
     homeMuseumTitle: 'Your museum',
     // Params arrive pre-pluralized via the collectionCount / artifactCataloged key pairs.
     homeMuseumSubtitle: '{collections} · {items}',
+    // Accessible name for the tappable stat line; {stats} is the visible subtitle.
+    homeStatsJumpAria: '{stats} — jump to your collections',
     collectionCount: '{n} collection',
     collectionsCount: '{n} collections',
     catalogFirst: 'Add first piece',
@@ -609,6 +611,7 @@ export const translations = {
     homeWelcome: '欢迎回来',
     homeMuseumTitle: '你的博物馆',
     homeMuseumSubtitle: '{collections} · {items}',
+    homeStatsJumpAria: '{stats} — 跳转到你的收藏集',
     collectionCount: '{n} 个收藏集',
     collectionsCount: '{n} 个收藏集',
     catalogFirst: '添加首件藏品',

--- a/tests/components/HomeScreen.test.tsx
+++ b/tests/components/HomeScreen.test.tsx
@@ -130,6 +130,29 @@ describe('HomeScreen', () => {
     expect(screen.getByText('1 collection · 2 pieces')).toBeInTheDocument();
   });
 
+  it('jumps to the collections grid when the museum stats are activated (CUR-30)', () => {
+    const scrollSpy = vi.fn();
+    const original = (HTMLElement.prototype as any).scrollIntoView;
+    (HTMLElement.prototype as any).scrollIntoView = scrollSpy;
+    try {
+      renderWithProviders(<HomeScreen {...defaultProps} />);
+
+      const grid = screen.getByTestId('collections-grid');
+      const focusMock = vi.spyOn(grid, 'focus');
+
+      const statsButton = screen.getByRole('button', { name: /jump to your collections/i });
+      // The visible label is still the plain stat line, so it stays legible.
+      expect(statsButton).toHaveTextContent('2 collections · 1 piece');
+
+      fireEvent.click(statsButton);
+
+      expect(scrollSpy).toHaveBeenCalledTimes(1);
+      expect(focusMock).toHaveBeenCalledTimes(1);
+    } finally {
+      (HTMLElement.prototype as any).scrollIntoView = original;
+    }
+  });
+
   it('filters collections by search term', async () => {
     renderWithProviders(<HomeScreen {...defaultProps} />);
 

--- a/tests/components/HomeScreen.test.tsx
+++ b/tests/components/HomeScreen.test.tsx
@@ -138,6 +138,9 @@ describe('HomeScreen', () => {
       renderWithProviders(<HomeScreen {...defaultProps} />);
 
       const grid = screen.getByTestId('collections-grid');
+      // Keyboard users are focused into the grid, so it must keep a visible
+      // focus-visible indicator rather than only suppressing the outline.
+      expect(grid.className).toMatch(/focus-visible:ring/);
       const focusMock = vi.spyOn(grid, 'focus');
 
       const statsButton = screen.getByRole('button', { name: /jump to your collections/i });


### PR DESCRIPTION
## Problem

On the populated Home screen, the museum stat line — `N collections · M pieces` — was static prose. Tapping it did nothing. CUR-30 asks for it to become a discoverable affordance that navigates to a meaningful view. Protects trust/clarity ("explicit outcomes") and improves mobile wayfinding, where the collections grid sits well below the search and On This Day sections.

## Approach

Turn the stat line into an accessible `<button>` that scrolls to — and focuses — the existing collections grid (`#collections-grid`), the honest "meaningful view" of your archives.

- A quiet **dotted underline** signals interactivity on touch (no hover needed) while staying restrained and theme-aware across gallery/vault/atelier (accent-on-hover, no blue per `DESIGN.md`).
- Respects `prefers-reduced-motion` (instant vs. smooth scroll).
- Moves focus to the grid (`tabIndex={-1}`, `scroll-mt-24`) so keyboard users continue from the collections, not the page top.
- `aria-controls="collections-grid"` plus an `aria-label` that keeps the visible counts and appends the action for screen readers.
- New regression test asserts the scroll + focus behaviour and that the visible counts stay legible.

## Why this approach

It's the smallest complete improvement: it reuses the grid that already exists instead of building a separate all-items view or route, which would add inventory surface that fights the "identity before inventory / beauty before bureaucracy" thesis. A dedicated all-items or stats-breakdown view would be a larger Phase-1 scope if ever wanted; this ships value now without that cost.

## Risks

Low. Presentational + an in-page scroll on the populated Home only (not first-run). No data flow, routing, sync, or permission changes. The subtitle text content is unchanged, so existing pluralization/copy tests still hold.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-ilzht7-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview and add/have at least one collection (populated Home).
2. On mobile, tap the `N collections · M pieces` line under "Your museum" → the view scrolls down to your collections grid.
3. Tab to the stat line and press Enter/Space → same jump, and focus lands on the grid.
4. Switch gallery/vault/atelier → the dotted underline + hover accent stay theme-appropriate.

Checks:
- [x] npm run format:check
- [x] npm test (1005 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

_Visual affordance: the stat line now carries a faint dotted underline and, on hover/focus, shifts to the theme accent. Behaviour is a smooth in-page scroll to the collections grid. See the Vercel preview above._

## Linear

Closes CUR-30

## Rollback plan

`git revert c17b056` (single commit). No migrations, flags, or data changes involved.