### PR TITLE
Show friendly localized copy for auth failures instead of raw errors

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -35,7 +35,11 @@ type Translate = (
 // authFailed message for anything unexpected. Exported for unit testing.
 export const mapAuthErrorMessage = (raw: string, t: Translate): string => {
   const message = (raw || '').trim();
-  if (/failed to fetch|networkerror|network error|load failed|fetch failed/i.test(message)) {
+  if (
+    /failed to fetch|networkerror|network (error|request failed)|load failed|fetch failed/i.test(
+      message,
+    )
+  ) {
     return t('authNetworkError');
   }
   if (/invalid login credentials|invalid.*(email|password)|incorrect.*password/i.test(message)) {

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -20,8 +20,29 @@ import {
   resetPasswordForEmail,
   updateUserPassword,
 } from '../services/supabase';
-import { useTranslation } from '../i18n';
+import { useTranslation, TranslationKey } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
+
+type Translate = (
+  key: TranslationKey | (string & {}),
+  params?: Record<string, string | number>,
+) => string;
+
+// Auth calls surface raw provider/browser strings on failure — a network drop
+// yields the literal "Failed to fetch" and bad credentials yield Supabase's
+// untranslated "Invalid login credentials". Neither is friendly or localized,
+// so map the ones we recognize to translated copy and fall back to the generic
+// authFailed message for anything unexpected. Exported for unit testing.
+export const mapAuthErrorMessage = (raw: string, t: Translate): string => {
+  const message = (raw || '').trim();
+  if (/failed to fetch|networkerror|network error|load failed|fetch failed/i.test(message)) {
+    return t('authNetworkError');
+  }
+  if (/invalid login credentials|invalid.*(email|password)|incorrect.*password/i.test(message)) {
+    return t('authInvalidCredentials');
+  }
+  return message || t('authFailed');
+};
 
 export type AuthModalMode =
   | 'signin'
@@ -285,7 +306,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
       if (mode === 'signup' && /password.*(short|characters)/i.test(raw)) {
         setError(t('passwordTooShort'));
       } else {
-        setError(raw || t('authFailed'));
+        setError(mapAuthErrorMessage(raw, t));
       }
     } finally {
       setLoading(false);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -492,6 +492,9 @@ export const translations = {
     authFastTitle: 'Fast',
     authFastDesc: 'Optimized for speed & offline.',
     authFailed: 'Authentication failed',
+    authNetworkError: "Can't reach the server. Check your connection and try again.",
+    authInvalidCredentials:
+      "That email or password doesn't match. Try again or reset your password.",
     forgotPassword: 'Forgot password?',
     resetPasswordTitle: 'Reset your password',
     resetPasswordDesc: 'Enter the email you signed up with. We will send you a reset link.',
@@ -1052,6 +1055,8 @@ export const translations = {
     authFastTitle: '快速',
     authFastDesc: '为速度和离线体验优化。',
     authFailed: '身份验证失败',
+    authNetworkError: '无法连接服务器，请检查网络后重试。',
+    authInvalidCredentials: '邮箱或密码不正确，请重试或重置密码。',
     forgotPassword: '忘记密码？',
     resetPasswordTitle: '重置密码',
     resetPasswordDesc: '请输入注册时使用的邮箱，我们将向您发送重置链接。',

--- a/tests/components/authError.test.ts
+++ b/tests/components/authError.test.ts
@@ -19,11 +19,19 @@ describe('mapAuthErrorMessage', () => {
     );
   });
 
-  it('maps other network phrasings (Load failed / NetworkError) to the network message', () => {
+  it('maps other network phrasings (Load failed / NetworkError / Network request failed) to the network message', () => {
     expect(mapAuthErrorMessage('Load failed', makeT('en'))).toBe(translations.en.authNetworkError);
     expect(
       mapAuthErrorMessage('NetworkError when attempting to fetch resource.', makeT('en')),
     ).toBe(translations.en.authNetworkError);
+    // Supabase transport failures throw an Error("Network request failed")
+    // (see tests/unit/services/supabase.test.ts), common on mobile clients.
+    expect(mapAuthErrorMessage('Network request failed', makeT('en'))).toBe(
+      translations.en.authNetworkError,
+    );
+    expect(mapAuthErrorMessage('Network request failed', makeT('zh'))).toBe(
+      translations.zh.authNetworkError,
+    );
   });
 
   it('maps Supabase "Invalid login credentials" to friendly localized copy', () => {

--- a/tests/components/authError.test.ts
+++ b/tests/components/authError.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { mapAuthErrorMessage } from '@/components/AuthModal';
+import { translations, TranslationKey } from '@/i18n';
+
+// Build a minimal translate function backed by the real string tables so the
+// test asserts against the copy users actually see, in both locales.
+const makeT =
+  (lang: 'en' | 'zh') =>
+  (key: TranslationKey | (string & {})): string =>
+    (translations[lang] as Record<string, string>)[key as string] ?? (key as string);
+
+describe('mapAuthErrorMessage', () => {
+  it('maps a raw "Failed to fetch" network error to friendly localized copy', () => {
+    expect(mapAuthErrorMessage('Failed to fetch', makeT('en'))).toBe(
+      translations.en.authNetworkError,
+    );
+    expect(mapAuthErrorMessage('Failed to fetch', makeT('zh'))).toBe(
+      translations.zh.authNetworkError,
+    );
+  });
+
+  it('maps other network phrasings (Load failed / NetworkError) to the network message', () => {
+    expect(mapAuthErrorMessage('Load failed', makeT('en'))).toBe(translations.en.authNetworkError);
+    expect(
+      mapAuthErrorMessage('NetworkError when attempting to fetch resource.', makeT('en')),
+    ).toBe(translations.en.authNetworkError);
+  });
+
+  it('maps Supabase "Invalid login credentials" to friendly localized copy', () => {
+    expect(mapAuthErrorMessage('Invalid login credentials', makeT('en'))).toBe(
+      translations.en.authInvalidCredentials,
+    );
+    expect(mapAuthErrorMessage('Invalid login credentials', makeT('zh'))).toBe(
+      translations.zh.authInvalidCredentials,
+    );
+  });
+
+  it('falls back to the raw message for unrecognized non-empty errors', () => {
+    expect(mapAuthErrorMessage('Email rate limit exceeded', makeT('en'))).toBe(
+      'Email rate limit exceeded',
+    );
+  });
+
+  it('falls back to the generic authFailed copy for an empty error', () => {
+    expect(mapAuthErrorMessage('', makeT('en'))).toBe(translations.en.authFailed);
+  });
+});


### PR DESCRIPTION
## Summary

Found during the recurring **live UI/UX review** (Mode A, 2026-07-27, real Chromium against https://curio.qiuyue.dev). When sign-in fails, `AuthModal` rendered the **raw** error string straight into the error box:

- A network / server-unreachable failure showed the literal browser string **"Failed to fetch"**.
- Wrong email or password showed Supabase's untranslated English **"Invalid login credentials"** — even when the UI language is 中文.

Only the sign-up "password too short" case was mapped to friendly copy; every other failure leaked the raw message on the trust-critical auth screen.

## Changes

- Add `mapAuthErrorMessage(raw, t)` in `src/components/AuthModal.tsx` — a small pure, exported helper that maps recognized errors to translated copy:
  - network phrasings (`Failed to fetch` / `Load failed` / `NetworkError` / …) → `authNetworkError`
  - invalid-credential phrasings (`Invalid login credentials` / …) → `authInvalidCredentials`
  - unrecognized non-empty errors fall back to the raw string; empty errors fall back to `authFailed`.
- Add `authNetworkError` and `authInvalidCredentials` keys to both the `en` and `zh` tables in `src/i18n.ts`.
- Wire the sign-in/sign-up catch block to use the helper (the existing `passwordTooShort` mapping is preserved).
- Add `tests/components/authError.test.ts` covering both locales and the fallback paths.

## User impact

Users hitting a network blip or a password typo now see a clear, localized, actionable message ("Can't reach the server. Check your connection and try again." / "That email or password doesn't match…") instead of developer jargon — reinforcing the "Trust before growth" principle.

## Testing

- `npm run format:check` ✓
- `npm test` — 1010 passed ✓ (adds 5 new assertions)
- `npm run build` ✓
- `npm run test:e2e` — 44 passed, 8 skipped ✓

## Scope

Copy/error-mapping only in the auth failure path — no behavioural change to successful auth, sign-up email confirmation, or password reset flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s8E2KmEF1Hfd2WbWEiGkX

---
_Generated by [Claude Code](https://claude.ai/code/session_011s8E2KmEF1Hfd2WbWEiGkX)_