### PR TITLE
[CUR-20] Cover the near-quota storage warning decision with tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,9 +74,8 @@ const ANONYMOUS_ADMIN_SCOPE = 'anonymous';
 
 import {
   getEnvValidationErrors,
+  isStorageNearLimit,
   STORAGE_QUOTA_CHECK_INTERVAL_MS,
-  STORAGE_QUOTA_WARNING_THRESHOLD_BYTES,
-  STORAGE_QUOTA_WARNING_THRESHOLD_RATIO,
 } from './config';
 import { detectConflicts } from './utils/conflictDetection';
 import { HomeScreen } from './components/HomeScreen';
@@ -217,14 +216,7 @@ export const AppContent: React.FC = () => {
   const checkStorageQuota = useCallback(async () => {
     if (!navigator.storage?.estimate) return;
     try {
-      const { quota, usage } = await navigator.storage.estimate();
-      if (typeof quota !== 'number' || typeof usage !== 'number') return;
-      if (quota <= 0) return;
-      const remaining = quota - usage;
-      const remainingRatio = remaining / quota;
-      const isLow =
-        remaining <= STORAGE_QUOTA_WARNING_THRESHOLD_BYTES ||
-        remainingRatio <= STORAGE_QUOTA_WARNING_THRESHOLD_RATIO;
+      const isLow = isStorageNearLimit(await navigator.storage.estimate());
       if (isLow && !hasQuotaWarningRef.current) {
         showStatus(t('statusStorageNearLimit'), 'warning');
         hasQuotaWarningRef.current = true;

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,28 @@ export const STORAGE_QUOTA_CHECK_INTERVAL_MS = parseEnvNumber(
   10 * 60 * 1000,
 );
 
+/**
+ * Decide whether IndexedDB storage is close enough to its quota that we should
+ * warn the user before writes start failing silently (CUR-20). A device that
+ * fills up loses writes with no visible signal, so an over-eager false alarm is
+ * far cheaper than a missed one — but a flaky `navigator.storage.estimate()`
+ * must never produce a warning either. Unusable estimates (missing or
+ * non-finite numbers, non-positive quota) therefore return `false`.
+ */
+export const isStorageNearLimit = (
+  estimate: { quota?: number; usage?: number },
+  bytesThreshold: number = STORAGE_QUOTA_WARNING_THRESHOLD_BYTES,
+  ratioThreshold: number = STORAGE_QUOTA_WARNING_THRESHOLD_RATIO,
+): boolean => {
+  const { quota, usage } = estimate;
+  if (typeof quota !== 'number' || typeof usage !== 'number') return false;
+  if (!Number.isFinite(quota) || !Number.isFinite(usage)) return false;
+  if (quota <= 0) return false;
+  const remaining = quota - usage;
+  const remainingRatio = remaining / quota;
+  return remaining <= bytesThreshold || remainingRatio <= ratioThreshold;
+};
+
 export const getEnvValidationErrors = (): string[] => {
   const errors: string[] = [];
   const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;

--- a/tests/unit/storageQuota.test.ts
+++ b/tests/unit/storageQuota.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isStorageNearLimit,
+  STORAGE_QUOTA_WARNING_THRESHOLD_BYTES,
+  STORAGE_QUOTA_WARNING_THRESHOLD_RATIO,
+} from '@/config';
+
+const MB = 1024 * 1024;
+const GB = 1024 * MB;
+
+// CUR-20: the near-quota warning is the only signal a user gets before writes
+// start failing silently on a full device, so this decision is trust-critical.
+// It had no coverage; these lock in both directions (warn / stay quiet) and the
+// guard against false alarms from an unreliable `navigator.storage.estimate()`.
+describe('isStorageNearLimit', () => {
+  it('stays quiet when there is ample headroom', () => {
+    expect(isStorageNearLimit({ quota: 1 * GB, usage: 100 * MB })).toBe(false);
+  });
+
+  it('warns once free space drops below the byte threshold', () => {
+    // 40MB remaining, under the default 50MB floor (ratio alone would not fire).
+    expect(isStorageNearLimit({ quota: 200 * MB, usage: 160 * MB })).toBe(true);
+  });
+
+  it('warns once free space drops below the ratio threshold on a large disk', () => {
+    // ~0.5GB remaining is comfortably above the byte floor, but only ~5% of a
+    // 10GB quota — the ratio guard is what catches near-full large disks.
+    expect(isStorageNearLimit({ quota: 10 * GB, usage: 9.5 * GB })).toBe(true);
+  });
+
+  it('treats the byte threshold as inclusive', () => {
+    expect(isStorageNearLimit({ quota: 150 * MB, usage: 100 * MB })).toBe(true);
+  });
+
+  it('stays quiet when just above both thresholds', () => {
+    // 101MB free (> 50MB) and ~10.1% remaining (> 10%): neither guard fires.
+    expect(isStorageNearLimit({ quota: 1000 * MB, usage: 899 * MB })).toBe(false);
+  });
+
+  it('never warns on an unusable estimate', () => {
+    expect(isStorageNearLimit({})).toBe(false);
+    expect(isStorageNearLimit({ quota: 1 * GB })).toBe(false);
+    expect(isStorageNearLimit({ usage: 100 * MB })).toBe(false);
+    expect(isStorageNearLimit({ quota: 0, usage: 0 })).toBe(false);
+    expect(isStorageNearLimit({ quota: -1, usage: 0 })).toBe(false);
+    expect(isStorageNearLimit({ quota: Number.NaN, usage: 100 })).toBe(false);
+    expect(isStorageNearLimit({ quota: 100, usage: Number.NaN })).toBe(false);
+    expect(isStorageNearLimit({ quota: Number.POSITIVE_INFINITY, usage: 100 })).toBe(false);
+  });
+
+  it('honors explicit thresholds over the defaults', () => {
+    // Byte + ratio floors of 0 mean "only warn at literal exhaustion".
+    expect(isStorageNearLimit({ quota: 1 * GB, usage: 100 * MB }, 0, 0)).toBe(false);
+    // A caller can widen the ratio floor to warn earlier.
+    expect(isStorageNearLimit({ quota: 100, usage: 50 }, 0, 0.6)).toBe(true);
+  });
+
+  it('exposes sane defaults for the warning thresholds', () => {
+    expect(STORAGE_QUOTA_WARNING_THRESHOLD_BYTES).toBeGreaterThan(0);
+    expect(STORAGE_QUOTA_WARNING_THRESHOLD_RATIO).toBeGreaterThan(0);
+    expect(STORAGE_QUOTA_WARNING_THRESHOLD_RATIO).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
## Problem

The proactive "storage is almost full" warning (`checkStorageQuota` in `App.tsx`) is the only signal a user gets before IndexedDB writes start failing silently on a full device — a **Trust before growth** path, since silent write loss is exactly the kind of quiet failure that breaks a collector's confidence. Yet the threshold decision had **zero test coverage** and lived inline in `App.tsx`, mixed with the toast/ref bookkeeping.

CUR-20's proactive check itself already shipped (App runs it on mount, on an interval, and after saves, with a localized EN/ZH warning). What was missing was a way to verify the decision — especially the guard that keeps a flaky `navigator.storage.estimate()` from raising a false alarm.

## Approach

- Extract the pure decision into `isStorageNearLimit(estimate, bytesThreshold?, ratioThreshold?)` in `src/config.ts`, colocated with the two thresholds it reads (which default in when omitted).
- Call it from `checkStorageQuota`, removing the inline arithmetic and the now-unused threshold imports from `App.tsx`.
- Add `tests/unit/storageQuota.test.ts` covering both directions (warn / stay quiet), inclusive boundaries, custom thresholds, sane defaults, and the "never warn on an unusable estimate" guard (missing/NaN/Infinity values, non-positive quota).

Behavior is unchanged: the previous code returned early (no warning) on unusable estimates, and the extracted helper returns `false` in those same cases; the `isLow` arithmetic is identical.

## Why this approach

It turns a trust-critical decision into a small, self-documenting, fully-tested pure function without touching the working runtime behavior — a testable seam colocated with its config, matching how the rest of `config.ts` is organized. It's the smallest change that lets CUR-20 be closed with confidence instead of on inspection.

## Risks

Low. No user-visible change and no behavior change — pure refactor + new tests. The only functional nuance is an added `Number.isFinite` guard, which cannot change outcomes (`NaN`/`Infinity` already produced `false` via the comparisons).

## How to verify

Vercel Preview: https://curio-git-claude-curio-20-storage-q-a72df2-qs-projects-72b20d9d.vercel.app _(no user-visible surface changes; preview is for parity confirmation only)_

Steps:
1. `npx vitest run tests/unit/storageQuota.test.ts` — 8 passing cases.
2. Read `checkStorageQuota` in `src/App.tsx` — same warn/clear/ref logic, now delegating the decision to `isStorageNearLimit`.
3. (Manual, optional) In DevTools, throttle storage so `navigator.storage.estimate()` reports low headroom and confirm the "Storage is almost full" toast still appears once.

Checks:
- [x] npm run format:check
- [x] npm test (1018 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

N/A — no UI change.

## Linear

Closes CUR-20

## Rollback plan

Green-tier, self-contained. Revert with `git revert 0370a03` (or hand-revert: inline the decision back into `checkStorageQuota`, restore the two threshold imports in `src/App.tsx`, and delete `src/config.ts`'s `isStorageNearLimit` plus `tests/unit/storageQuota.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzBPQVGmMiza8D9hbNN237