### PR TITLE
[CUR-51] Make exhibition jump-to reach every item in large collections

### DIFF
--- a/src/components/ExhibitionView.tsx
+++ b/src/components/ExhibitionView.tsx
@@ -11,6 +11,11 @@ import { useModalA11y } from '../hooks/useModalA11y';
 const AUTOPLAY_INTERVALS_MS = [5000, 10000, 30000] as const;
 const DEFAULT_AUTOPLAY_INTERVAL_MS = 10000;
 
+// CUR-51: the pagination rail shows at most this many jump-to dots at once. For
+// larger collections it windows around the current exhibit so every item stays
+// reachable, instead of stranding everything past the tenth behind a dead count.
+const MAX_PAGINATION_DOTS = 10;
+
 interface ExhibitionViewProps {
   collection: UserCollection;
   initialIndex?: number;
@@ -97,10 +102,17 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowRight') next();
       else if (e.key === 'ArrowLeft') prev();
+      else if (e.key === 'Home') {
+        e.preventDefault();
+        jumpTo(0);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        jumpTo(collection.items.length - 1);
+      }
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [isOpen, next, prev]);
+  }, [isOpen, next, prev, jumpTo, collection.items.length]);
 
   if (!isOpen || collection.items.length === 0) return null;
 
@@ -171,6 +183,48 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
             })}
           </div>
         )}
+      </div>
+    );
+  };
+
+  // CUR-51: jump-to pagination shared by both breakpoints. Small collections
+  // render one dot per exhibit (unchanged); larger ones window the rail around
+  // the current exhibit and flag how many items sit before / after the window,
+  // so every item is reachable by tapping rather than only the first ten.
+  const renderPaginationDots = (variant: 'mobile' | 'desktop') => {
+    const total = collection.items.length;
+    const height = variant === 'desktop' ? 'h-1.5' : 'h-1';
+    const activeWidth = variant === 'desktop' ? 'w-10' : 'w-6';
+    const inactiveWidth = variant === 'desktop' ? 'w-3' : 'w-1.5';
+    const gap = variant === 'desktop' ? 'gap-2' : 'gap-1.5';
+    const start =
+      total <= MAX_PAGINATION_DOTS
+        ? 0
+        : Math.min(
+            Math.max(index - Math.floor(MAX_PAGINATION_DOTS / 2), 0),
+            total - MAX_PAGINATION_DOTS,
+          );
+    const end = Math.min(start + MAX_PAGINATION_DOTS, total);
+    return (
+      <div className={`flex justify-center items-center ${gap}`}>
+        {start > 0 && <span className="text-[10px] opacity-40 mr-1">{start}+</span>}
+        {collection.items.slice(start, end).map((_, i) => {
+          const target = start + i;
+          return (
+            <button
+              key={target}
+              onClick={() => jumpTo(target)}
+              aria-label={t('exhibitionJumpTo', { n: target + 1 })}
+              aria-current={target === index ? 'true' : undefined}
+              className={`${height} rounded-full transition-all ${
+                target === index
+                  ? `${activeWidth} bg-amber-500`
+                  : `${inactiveWidth} bg-white/20 hover:bg-white/30`
+              }`}
+            />
+          );
+        })}
+        {end < total && <span className="text-[10px] opacity-40 ml-1">+{total - end}</span>}
       </div>
     );
   };
@@ -300,22 +354,7 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
         {/* Auto-play + pagination dots */}
         <div className="flex flex-col items-center gap-2 py-2.5">
           {renderAutoplayControls('mobile')}
-          <div className="flex justify-center items-center gap-1.5">
-            {collection.items.slice(0, 10).map((_, i) => (
-              <button
-                key={i}
-                onClick={() => jumpTo(i)}
-                aria-label={t('exhibitionJumpTo', { n: i + 1 })}
-                aria-current={i === index ? 'true' : undefined}
-                className={`h-1 rounded-full transition-all ${
-                  i === index ? 'w-6 bg-amber-500' : 'w-1.5 bg-white/20 hover:bg-white/30'
-                }`}
-              />
-            ))}
-            {collection.items.length > 10 && (
-              <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
-            )}
-          </div>
+          {renderPaginationDots('mobile')}
         </div>
       </div>
 
@@ -419,22 +458,7 @@ export const ExhibitionView: React.FC<ExhibitionViewProps> = ({
         {/* Footer: auto-play + pagination */}
         <footer className="py-6 px-8 flex flex-col items-center gap-3">
           {renderAutoplayControls('desktop')}
-          <div className="flex gap-2 items-center">
-            {collection.items.slice(0, 10).map((_, i) => (
-              <button
-                key={i}
-                onClick={() => jumpTo(i)}
-                aria-label={t('exhibitionJumpTo', { n: i + 1 })}
-                aria-current={i === index ? 'true' : undefined}
-                className={`h-1.5 rounded-full transition-all ${
-                  i === index ? 'w-10 bg-amber-500' : 'w-3 bg-white/20 hover:bg-white/30'
-                }`}
-              />
-            ))}
-            {collection.items.length > 10 && (
-              <span className="text-[10px] opacity-40 ml-1">+{collection.items.length - 10}</span>
-            )}
-          </div>
+          {renderPaginationDots('desktop')}
         </footer>
       </div>
     </div>

--- a/tests/components/ExhibitionView.test.tsx
+++ b/tests/components/ExhibitionView.test.tsx
@@ -46,6 +46,20 @@ const collection: UserCollection = {
   ],
 };
 
+const buildCollection = (count: number): UserCollection => ({
+  ...collection,
+  items: Array.from({ length: count }, (_, i) => ({
+    id: `item-${i + 1}`,
+    collectionId: 'col-1',
+    photoUrl: 'asset',
+    title: `Exhibit ${i + 1}`,
+    rating: 0,
+    data: {},
+    notes: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+  })),
+});
+
 describe('ExhibitionView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -154,6 +168,48 @@ describe('ExhibitionView', () => {
         expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*2/);
       });
       expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('large-collection navigation (CUR-51)', () => {
+    it('jumps to the last and first exhibit with End / Home keys', async () => {
+      renderWithProviders(
+        <ExhibitionView collection={buildCollection(3)} isOpen={true} onClose={vi.fn()} />,
+      );
+      expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*3/);
+
+      fireEvent.keyDown(window, { key: 'End' });
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toHaveAccessibleName(/3.*3/);
+      });
+
+      fireEvent.keyDown(window, { key: 'Home' });
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toHaveAccessibleName(/1.*3/);
+      });
+    });
+
+    it('windows the jump-to dots around the current exhibit so every item stays reachable', async () => {
+      renderWithProviders(
+        <ExhibitionView collection={buildCollection(15)} isOpen={true} onClose={vi.fn()} />,
+      );
+
+      // Windowed to the first ten exhibits on open: the last is out of range,
+      // where the old rail stranded everything past the tenth behind a count.
+      expect(screen.queryAllByRole('button', { name: 'Jump to exhibit 15' })).toHaveLength(0);
+      expect(screen.getAllByRole('button', { name: 'Jump to exhibit 1' })).toHaveLength(2);
+
+      fireEvent.keyDown(window, { key: 'End' });
+
+      await waitFor(() => {
+        const lastDots = screen.getAllByRole('button', { name: 'Jump to exhibit 15' });
+        expect(lastDots).toHaveLength(2);
+        for (const dot of lastDots) {
+          expect(dot).toHaveAttribute('aria-current', 'true');
+        }
+      });
+      // The window has slid forward, so the first exhibit's dot is gone.
+      expect(screen.queryAllByRole('button', { name: 'Jump to exhibit 1' })).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Problem

In Exhibition mode the pagination rail only rendered dots for the first **ten** items (`collection.items.slice(0, 10)`) and stranded the rest behind an inert `+N` count. A viewer walking a 50-item collection could not jump past the tenth exhibit — only step through with next/prev/swipe. Keyboard navigation had arrows but no way to jump to the ends. This is the gap called out in CUR-51 (jump-to / index / progress for large collections); the progress indicator (`12 / 47`) and arrow keys already shipped, so this closes the remainder. Protects **beauty before bureaucracy** — it keeps the cinematic dot rail rather than bolting on a heavy thumbnail strip.

## Approach

- Extracted a shared `renderPaginationDots(variant)` helper (mirroring the existing `renderAutoplayControls(variant)` pattern) used by both the mobile and desktop layouts, replacing the two duplicated inline rails.
- For collections larger than ten items the rail now **windows** around the current exhibit (keeps the active item roughly centered) and shows a leading `N+` / trailing `+N` count of the items outside the window, so every item is reachable by tapping a dot as you move.
- Added `Home` / `End` keyboard shortcuts to jump to the first / last exhibit.
- Small collections (≤10 items) render exactly as before — one dot per exhibit.

## Why this approach

It reuses the component's own render-helper idiom and touches only presentation, so risk stays local and the aesthetic is unchanged for the common small-collection case. Windowing a lightweight dot rail keeps the exhibition cinematic rather than introducing a cluttered thumbnail strip. No new i18n keys, data, sync, or AI paths are involved.

## Risks

Low. Presentational change to a single component (`ExhibitionView`), no data/sync/AI/auth/RLS surface. The only behavioral change is which dots the rail renders for collections >10 items; small collections are byte-for-byte identical. Covered by new + existing tests (12 passing in this file).

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-gnhpfm-qs-projects-72b20d9d.vercel.app

Steps:
1. Open a collection with **more than 10 items** and enter Exhibition mode.
2. Note the dot rail now windows around the current exhibit with `N+` / `+N` counts, and tapping any visible dot jumps to that exhibit.
3. Press `End` → jumps to the last exhibit (rail slides to show it); press `Home` → back to the first. `←` / `→` still step.
4. Open a collection with ≤10 items — the rail looks and behaves exactly as before.

Checks:
- [x] npm run format:check
- [x] npm test (1020 passed, 2 skipped)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not captured — this run is headless (no interactive browser to record). The change is visible only inside Exhibition mode for collections with >10 items; use the Vercel preview above with the steps to see it live.

## Linear

Closes CUR-51

## Rollback plan

Revert the single commit: `git revert f1de02d`. No migrations, flags, or data changes involved.