### PR TITLE
Fix rating-filter dropdown chevron swallowing taps in FilterModal

### DIFF
--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -129,7 +129,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({
               </select>
               <ChevronDown
                 size={16}
-                className={`absolute right-3 top-1/2 -translate-y-1/2 ${theme === 'vault' ? 'text-white/50' : 'text-stone-400'}`}
+                className={`absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none ${theme === 'vault' ? 'text-white/50' : 'text-stone-400'}`}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary

In the collection Filter modal, the custom `ChevronDown` overlaid on the **rating** `<select>` was missing `pointer-events-none`. Tapping the visible arrow — the most natural place to open a dropdown, especially on mobile — landed on the icon instead of the `<select>`, so nothing happened.

The identical chevron rendered over the custom-field selects already sets `pointer-events-none` (`src/components/FilterModal.tsx:171`); this one-line change mirrors that so the whole rating control opens the dropdown on tap.

## Why

Filter controls that appear tappable but don't respond on the arrow read as broken and erode trust in filtering. This aligns the two chevrons that are otherwise styled identically.

## Change

- `src/components/FilterModal.tsx` — add `pointer-events-none` to the rating `<select>` chevron.

## Testing

- `npm run format:check` ✅
- `npm test` ✅ (1018 passed)
- `npm run build` ✅
- `npm run test:e2e` ✅ (44 passed, 8 skipped)

## Context

Found during the July 2026 code-assisted UI/UX review. The live app is up but could not be browser-driven from the review environment (egress proxy resets Chromium's TLS handshake), so this is a code-evident fix; **the tap behaviour still merits a quick browser confirmation** on a mobile viewport. Remaining review findings are documented as a Linear comment (Linear issue creation is currently blocked by the workspace's free-tier issue limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P4bRk9CXcvfNPhj79b6TX

---
_Generated by [Claude Code](https://claude.ai/code/session_013P4bRk9CXcvfNPhj79b6TX)_