### PR TITLE
[CUR-16] Cap concurrent Supabase Storage downloads in getAsset

### DIFF
--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1953,7 +1953,12 @@ export const getEnhancedAsset = async (
       const enhancedPath = normalizedEnhancedPath || fallbackPath;
       if (!enhancedPath) return null;
 
-      const { data, error } = await supabase.storage.from('curio-assets').download(enhancedPath);
+      // Share the same download budget as getAsset (CUR-16): a grid of enhanced
+      // items renders ItemImage with type="enhanced", so without this the
+      // enhanced downloads would bypass the cap entirely.
+      const { data, error } = await withAssetDownloadSlot(() =>
+        supabase.storage.from('curio-assets').download(enhancedPath),
+      );
 
       if (data && !error) {
         // Cache back to local for performance next time

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1731,6 +1731,39 @@ export const saveAsset = async (
   }
 };
 
+// Cap concurrent Supabase Storage downloads (CUR-16). A collection grid mounts
+// one ItemImage per item, and every uncached one calls getAsset(), which then
+// hits the network. Without a limit, a 50-item collection fires 50 parallel
+// downloads on first open after a cache clear — they contend for bandwidth and
+// each individual thumbnail can stall for 10+ seconds. Serving three at a time
+// lets the top (visible) rows arrive quickly while the rest queue behind them.
+// Local IndexedDB hits never enter this queue: getAsset returns before reaching
+// it whenever the blob is already cached.
+const MAX_CONCURRENT_ASSET_DOWNLOADS = 3;
+let activeAssetDownloads = 0;
+const assetDownloadQueue: Array<() => void> = [];
+
+const withAssetDownloadSlot = async <T>(run: () => Promise<T>): Promise<T> => {
+  if (activeAssetDownloads >= MAX_CONCURRENT_ASSET_DOWNLOADS) {
+    await new Promise<void>((resolve) => assetDownloadQueue.push(resolve));
+  } else {
+    activeAssetDownloads++;
+  }
+  try {
+    return await run();
+  } finally {
+    // Hand the slot straight to the next waiter so the active count stays put;
+    // only decrement when nobody is waiting. `finally` guarantees the slot is
+    // released even if the download throws, so the queue can never deadlock.
+    const next = assetDownloadQueue.shift();
+    if (next) {
+      next();
+    } else {
+      activeAssetDownloads--;
+    }
+  }
+};
+
 export const getAsset = async (
   id: string,
   type: 'original' | 'display' = 'display',
@@ -1773,7 +1806,9 @@ export const getAsset = async (
 
       const path = normalizedRemotePath || fallbackPath;
       if (!path) return null;
-      const { data, error } = await supabase.storage.from('curio-assets').download(path);
+      const { data, error } = await withAssetDownloadSlot(() =>
+        supabase.storage.from('curio-assets').download(path),
+      );
 
       if (data && !error) {
         // Cache back to local for performance next time

--- a/tests/services/db.getAssetConcurrency.test.ts
+++ b/tests/services/db.getAssetConcurrency.test.ts
@@ -1,0 +1,131 @@
+/**
+ * CUR-16: getAsset() cloud downloads are capped so a grid of uncached items
+ * doesn't fire dozens of parallel Supabase Storage requests at once.
+ *
+ * These tests exercise the real getAsset() path (local cache miss → cloud
+ * download) with a controllable storage mock that records how many downloads
+ * are in flight simultaneously.
+ *
+ * IMPORTANT: TDD only — do not modify production implementations in these tests.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from 'vitest';
+
+// services/db.ts uses a fixed database name; map it to a per-file unique name so
+// this suite's IndexedDB never collides with the other db.* suites.
+const BASE_DB_NAME = 'CurioDatabase';
+const TEST_DB_NAME = `${BASE_DB_NAME}__vitest_${Math.random().toString(16).slice(2)}`;
+const originalOpen = indexedDB.open.bind(indexedDB);
+const originalDeleteDatabase = indexedDB.deleteDatabase.bind(indexedDB);
+
+Object.defineProperty(indexedDB, 'open', {
+  configurable: true,
+  value: ((name: string, version?: number) =>
+    originalOpen(name === BASE_DB_NAME ? TEST_DB_NAME : name, version)) as any,
+});
+Object.defineProperty(indexedDB, 'deleteDatabase', {
+  configurable: true,
+  value: ((name: string) =>
+    originalDeleteDatabase(name === BASE_DB_NAME ? TEST_DB_NAME : name)) as any,
+});
+
+afterAll(() => {
+  Object.defineProperty(indexedDB, 'open', { configurable: true, value: originalOpen as any });
+  Object.defineProperty(indexedDB, 'deleteDatabase', {
+    configurable: true,
+    value: originalDeleteDatabase as any,
+  });
+});
+
+function createStorageMock(
+  download: (path: string) => Promise<{ data: Blob | null; error: unknown }>,
+) {
+  const downloadFn = vi.fn(download);
+  return {
+    supabase: {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'test-user-id' } }, error: null }),
+      },
+      from: vi.fn(() => ({
+        upsert: vi.fn().mockResolvedValue({ error: null }),
+        select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn() })) })),
+      })),
+      storage: {
+        from: vi.fn(() => ({ download: downloadFn })),
+      },
+    },
+    downloadFn,
+  };
+}
+
+async function importDbFresh(supabaseMock: any) {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+  vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+  vi.stubEnv('VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY', 'test-key');
+  vi.doMock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(() => supabaseMock),
+  }));
+  return await import('@/services/db');
+}
+
+describe('CUR-16 — getAsset cloud download concurrency', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('never runs more than 3 cloud downloads at once for a burst of uncached items', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const { supabase, downloadFn } = createStorageMock(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return { data: new Blob(['x'], { type: 'image/jpeg' }), error: null };
+    });
+
+    const dbMod = await importDbFresh(supabase);
+
+    // 12 distinct ids, all missing locally (fresh DB) → all hit the cloud path.
+    const results = await Promise.all(
+      Array.from({ length: 12 }, (_, i) =>
+        dbMod.getAsset(`item-${i}`, 'display', undefined, 'col-1'),
+      ),
+    );
+
+    expect(downloadFn).toHaveBeenCalledTimes(12);
+    // Downloads did run in parallel (the limiter throttles, it does not serialize)...
+    expect(peak).toBeGreaterThan(1);
+    // ...but never exceeded the cap.
+    expect(peak).toBeLessThanOrEqual(3);
+    // Every request still resolved to its blob.
+    expect(results.every((b) => b instanceof Blob)).toBe(true);
+  });
+
+  it('releases the slot when a download throws, so the queue never deadlocks', async () => {
+    // Every download rejects. If the limiter leaked slots on failure, the 4th+
+    // getAsset call would wait forever and this test would time out.
+    const { supabase, downloadFn } = createStorageMock(async () => {
+      throw new Error('network down');
+    });
+
+    const dbMod = await importDbFresh(supabase);
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        dbMod.getAsset(`err-${i}`, 'display', undefined, 'col-1'),
+      ),
+    );
+
+    expect(downloadFn).toHaveBeenCalledTimes(10);
+    // getAsset swallows download failures and resolves to null rather than
+    // throwing; the point of the test is that all 10 settle at all.
+    expect(results.every((b) => b === null)).toBe(true);
+  });
+});

--- a/tests/services/db.getAssetConcurrency.test.ts
+++ b/tests/services/db.getAssetConcurrency.test.ts
@@ -108,6 +108,41 @@ describe('CUR-16 — getAsset cloud download concurrency', () => {
     expect(results.every((b) => b instanceof Blob)).toBe(true);
   });
 
+  it('shares one budget across getAsset and getEnhancedAsset (enhanced grid path)', async () => {
+    // ItemCard renders ItemImage with type="enhanced", which routes through
+    // getEnhancedAsset first. Both it and getAsset hit the same storage, so they
+    // must draw from the same 3-slot budget rather than each getting their own.
+    let inFlight = 0;
+    let peak = 0;
+    const { supabase, downloadFn } = createStorageMock(async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return { data: new Blob(['x'], { type: 'image/jpeg' }), error: null };
+    });
+
+    const dbMod = await importDbFresh(supabase);
+
+    const calls = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        dbMod.getAsset(`plain-${i}`, 'display', undefined, 'col-1'),
+      ),
+      ...Array.from({ length: 6 }, (_, i) =>
+        dbMod.getEnhancedAsset(`enh-${i}`, {
+          enhancedPath: `test-user-id/collections/col-1/enh-${i}/enhanced/v1.jpg`,
+          collectionId: 'col-1',
+        }),
+      ),
+    ];
+    const results = await Promise.all(calls);
+
+    expect(downloadFn).toHaveBeenCalledTimes(12);
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(results.every((b) => b instanceof Blob)).toBe(true);
+  });
+
   it('releases the slot when a download throws, so the queue never deadlocks', async () => {
     // Every download rejects. If the limiter leaked slots on failure, the 4th+
     // getAsset call would wait forever and this test would time out.


### PR DESCRIPTION
## Problem

When a collection grid opens after a cache clear (or on a fresh device), every
`ItemImage` whose blob isn't in IndexedDB calls `getAsset()` (or `getEnhancedAsset()`
for the enhanced grid path), which falls back to `supabase.storage.download()`.
There is no ceiling on how many run at once, so a 50-item collection fires ~50
parallel Storage downloads simultaneously. They contend for bandwidth and each
individual thumbnail can stall for 10+ seconds — the exact symptom reported in
CUR-16. This erodes the "beauty before bureaucracy" feel (slow, janky first
paint) and the trust that images will actually load.

## Approach

Gate the cloud-download calls behind a small in-module queue
(`withAssetDownloadSlot`) that lets at most **three** downloads run at a time; the
rest wait and are served as slots free up. Grid order ≈ top-to-bottom, so the
visible rows get served first while off-screen rows queue behind them.

- Applied to **both** `getAsset()` (display/original) and `getEnhancedAsset()`
  (the enhanced path `ItemCard` uses via `type="enhanced"`), so they share one
  3-slot budget rather than the enhanced path bypassing the cap.
- Local IndexedDB hits are **untouched** — both functions return before reaching
  the queue whenever the blob is already cached, so cached grids stay instant.
- The slot is released in a `finally` block, so a failed/throwing download can
  never leak a permit and deadlock the queue.

The other three CUR-16 acceptance criteria were already satisfied in the codebase:
the loading skeleton (`ItemImage`), lazy `<img loading="lazy">`, and
cache-back-to-IndexedDB (both functions write the downloaded blob back). This PR
adds the missing **concurrency cap**.

## Why this approach

It's the smallest change that fixes the reported thundering-herd behavior: a
read-side throttle that preserves every existing result and only affects *timing*
under a cache-miss burst. No merge/sync-write logic, RLS, storage boundaries, or
public/private behavior are touched.

## Risks

Yellow (touches `services/db.ts` / the shared asset read path).
- A limiter bug could stall image loads app-wide. Mitigated by the `finally`
  release and a dedicated regression test that fails if a throwing download leaks
  its slot.
- Behavior change is timing-only: identical blobs returned, just at most 3
  in-flight. Cached (local-hit) reads are entirely unaffected.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-40e33e-qs-projects-72b20d9d.vercel.app

Manual (IndexedDB + Supabase):
1. Sign in and open a private collection with 10+ photo items so blobs exist in
   Supabase Storage.
2. DevTools → Application → IndexedDB → `CurioDatabase` → clear the `assets` /
   `display` / `enhanced` stores (simulates a fresh device / cache clear).
3. DevTools → Network, throttle to "Slow 3G", reload the collection.
4. Confirm no more than **3** `curio-assets` download requests are in flight at
   any moment (they arrive in waves), the top/visible thumbnails resolve first,
   and every image eventually loads.
5. Reload again with the cache now warm → images load instantly from IndexedDB
   (the queue is never entered).

Checks:
- [x] npm run format:check
- [x] npm test (1021 passed, 2 skipped)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No visual change — this affects request scheduling only. Verify via the Network
panel steps above.

## Linear

Closes CUR-16

## Rollback plan

Revert the two commits: `git revert 8bee6a3 241b3c9`. No migrations, feature
flags, schema, or data changes are involved.