### PR TITLE
[CUR-62] Associate modal form labels with their inputs for accessibility

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1495,11 +1495,13 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
 
       <div>
         <label
+          htmlFor="add-item-title"
           className={`block text-[11px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-0.5 sm:mb-1`}
         >
           {t('title')}
         </label>
         <input
+          id="add-item-title"
           type="text"
           ref={titleInputRef}
           className={`w-full text-lg sm:text-xl font-bold bg-transparent border-b ${titleError ? 'border-red-400 focus:border-red-500' : borderClass} focus:border-amber-500 outline-none pb-1 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : 'text-stone-900'}`}

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -533,6 +533,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
               {(mode === 'signin' || mode === 'signup' || mode === 'reset-request') && (
                 <div>
                   <label
+                    htmlFor="auth-email"
                     className={`block text-[11px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-1.5`}
                   >
                     {t('email')}
@@ -543,6 +544,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                       size={16}
                     />
                     <input
+                      id="auth-email"
                       type="email"
                       required
                       disabled={loading}
@@ -561,6 +563,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                 <div>
                   <div className="flex items-baseline justify-between mb-1.5">
                     <label
+                      htmlFor="auth-password"
                       className={`block text-[11px] font-semibold uppercase tracking-[0.12em] ${mutedText}`}
                     >
                       {t('password')}
@@ -584,6 +587,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                       size={16}
                     />
                     <input
+                      id="auth-password"
                       type={showPassword ? 'text' : 'password'}
                       required
                       disabled={loading}

--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -406,11 +406,13 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
     <div className="space-y-6">
       <div>
         <label
+          htmlFor="create-collection-description"
           className={`block text-[12px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-2`}
         >
           {t('collectionPrompt')}
         </label>
         <input
+          id="create-collection-description"
           ref={descriptionInputRef}
           type="text"
           value={description}
@@ -658,11 +660,15 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
         </div>
 
         <div>
-          <p className={`text-[12px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-2`}>
+          <label
+            htmlFor="create-collection-custom-field"
+            className={`block text-[12px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-2`}
+          >
             {t('addYourOwn')}
-          </p>
+          </label>
           <div className="flex gap-2">
             <input
+              id="create-collection-custom-field"
               type="text"
               value={customFieldInput}
               onChange={(e) => setCustomFieldInput(e.target.value)}
@@ -826,11 +832,13 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
 
       <div>
         <label
+          htmlFor="create-collection-name"
           className={`block text-[12px] font-semibold uppercase tracking-[0.12em] ${mutedText} mb-2`}
         >
           {t('collectionName')}
         </label>
         <input
+          id="create-collection-name"
           type="text"
           value={collectionName}
           onChange={(e) => {

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -1403,4 +1403,24 @@ describe('AddItemModal', () => {
       expect(infoCard).toHaveClass('border-amber-100');
     });
   });
+
+  describe('Accessibility - label associations (CUR-62)', () => {
+    it('associates the manual Title input with its label', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <AddItemModal
+          isOpen
+          onClose={mockOnClose}
+          collections={[createMockCollection()]}
+          onSave={mockOnSave}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Skip and add manually' }));
+
+      // Resolves only when the Title <label> is associated with its input.
+      const titleInput = await screen.findByLabelText('Title');
+      expect(titleInput).toHaveAttribute('id', 'add-item-title');
+    });
+  });
 });

--- a/tests/components/AuthModal.test.tsx
+++ b/tests/components/AuthModal.test.tsx
@@ -891,4 +891,19 @@ describe('AuthModal', () => {
       expect(screen.getByPlaceholderText(/••••••••/)).toHaveAttribute('type', 'password');
     });
   });
+
+  describe('Accessibility - label associations (CUR-62)', () => {
+    it('associates the sign-in email and password inputs with their labels', () => {
+      renderWithProviders(<AuthModal {...defaultProps} />);
+
+      // getByLabelText only resolves when the <label> is programmatically
+      // associated with its input (htmlFor/id). Before CUR-62 these labels
+      // sat above unassociated inputs, so this query would have thrown.
+      const email = screen.getByLabelText('Email Address', { selector: 'input' });
+      expect(email).toHaveAttribute('id', 'auth-email');
+
+      const password = screen.getByLabelText('Password', { selector: 'input' });
+      expect(password).toHaveAttribute('id', 'auth-password');
+    });
+  });
 });

--- a/tests/components/CreateCollectionModal.test.tsx
+++ b/tests/components/CreateCollectionModal.test.tsx
@@ -193,4 +193,29 @@ describe('CreateCollectionModal', () => {
       expect(defaultProps.onAddFirstItem).toHaveBeenCalledWith('new-collection-id');
     });
   });
+
+  describe('Accessibility - label associations (CUR-62)', () => {
+    it('associates the prompt, custom-field, and name inputs with their labels', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<CreateCollectionModal {...defaultProps} />);
+
+      // Entry step: the collector prompt input. getByLabelText resolves only
+      // when the label is htmlFor/id-associated with its input.
+      expect(screen.getByLabelText('What do you collect?')).toBe(
+        screen.getByTestId('collection-description-input'),
+      );
+
+      await user.click(screen.getByTestId('collection-preset-vinyl'));
+      await user.click(screen.getByTestId('collection-continue-btn'));
+
+      // Fields step: the "add your own" custom-field input.
+      expect(screen.getByLabelText('Add your own')).toBe(screen.getByTestId('custom-field-input'));
+
+      await user.click(screen.getByTestId('suggested-field-3'));
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      // Preview step: the collection name input.
+      expect(screen.getByLabelText('Name')).toHaveAttribute('id', 'create-collection-name');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Form labels in the auth, add-item, and create-collection flows render as `<label>` (or `<p>`) elements sitting above their inputs, but with no `htmlFor`/`id` association. Screen readers can't link them: focusing an input announces nothing, and clicking a label doesn't focus its control (WCAG 1.3.1 / 4.1.2). This is the accessibility gap tracked in **CUR-62** — a "trust before growth" issue for anyone using assistive tech on the core sign-in → create → add flow.

## Approach

Add mechanical `htmlFor`/`id` pairs to the form controls that use real `<label>` elements:

- **AuthModal** — sign-in/sign-up email (`auth-email`) and password (`auth-password`) inputs.
- **AddItemModal** — the Title input (`add-item-title`). Story and custom fields were already associated in prior work.
- **CreateCollectionModal** — the collector-prompt (`create-collection-description`), custom-field (`create-collection-custom-field`), and name (`create-collection-name`) inputs. The custom-field label was a `<p>`; it becomes a real `<label>` with `block` added so the layout is byte-identical.

Each form gets a `getByLabelText` regression test that only resolves once the label is programmatically associated — i.e. it fails without the source change.

## Why this approach

This is the issue's recommended fix (stable `id` + matching `htmlFor`), applied only to controls that already use real `<label>` elements, so it's one uniform low-risk technique with no behavior, styling, or data-flow change. FilterModal was already associated in #330. ItemDetail's dynamic fields use `<dt>` labels (inside a `<dl>`) and need `aria-labelledby` rather than `htmlFor` on a sensitive inline-edit surface, so that slice is deliberately left as a focused follow-up rather than mixing techniques here.

## Risks

Low. Additive `id`/`htmlFor` attributes plus one semantically-correct `<p>`→`<label>` swap (with `block` preserving layout). No visual change, no logic touched, no auth/sync/RLS/AI surface involved. Full gate is green.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-wb81y8-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the sign-in modal with a screen reader (or run axe/VoiceOver): focusing the Email/Password fields now announces the label; clicking a label focuses its input.
2. Start "Add your first item" → skip to manual entry: the Title field is label-associated.
3. Create a collection: the "What do you collect?", "Add your own", and "Name" inputs are each label-associated across the entry/fields/preview steps.

Checks:
- [x] npm run format:check
- [x] npm test (1026 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No visual change — the associations are non-visual (screen-reader announcement + label-click focus). Behavior is locked by the new `getByLabelText` tests.

## Linear

Advances CUR-62 (first step). Not auto-closing: FilterModal was already done in #330; the remaining ItemDetail dynamic-field (`<dt>` + `aria-labelledby`) slice is tracked in a follow-up comment on the issue.

## Rollback plan

Green-tier. `git revert 457a383` restores the previous markup and removes the three tests. No data, schema, storage, or config involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7eDo8RyFYdnpL2buHSDGq