### PR TITLE
[CUR-159] Raise first-run promise copy to AA-compliant Gallery muted token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1540,7 +1540,7 @@ export const AppContent: React.FC = () => {
           ) : null}
         </div>
         <p
-          className={`text-[12px] mt-5 leading-relaxed ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+          className={`text-[12px] mt-5 leading-relaxed ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
         >
           {t('ctaPromise')}
         </p>

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -495,6 +495,13 @@ describe('App Integration Tests', () => {
     // Both first-run CTAs remain available
     expect(screen.getByTestId('cta-primary-add-first')).toBeInTheDocument();
     expect(screen.getByTestId('cta-secondary-explore-sample')).toBeInTheDocument();
+
+    // The reassurance promise line must use the AA-compliant Gallery muted
+    // token (stone-500, per DESIGN.md), not the too-faint stone-400 that
+    // failed WCAG AA at 2.5:1 on the light surface (CUR-159).
+    const promise = await screen.findByText(/Guided capture in under 5 minutes/i);
+    expect(promise.className).toContain('text-stone-500');
+    expect(promise.className).not.toContain('text-stone-400');
   });
 
   it('opens the auth modal in sign-up mode from the first-run "Add your first item" CTA (CUR-152)', async () => {


### PR DESCRIPTION
## Problem

On the first screen (access gate / welcome), the reassurance line **"Guided capture in under 5 minutes. Keep progress even if AI is slow."** (`t('ctaPromise')`) renders in `text-stone-400` on the light Gallery surface — measured contrast ≈ **2.5:1**, well below the WCAG AA minimum of 4.5:1 for normal text. This is the trust/reassurance microcopy on the very first screen a new visitor reads, so it protects Curio's **trust before growth** principle. `stone-400` is also the *Vault* muted token; DESIGN.md's canonical Gallery "Text Muted" is `stone-500` (`#78716C`, ≈ 4.8:1), so the current value is both inaccessible and off-system.

## Approach

Switch the Gallery branch of the `ctaPromise` line in `renderAccessGate()` from `text-stone-400` to `text-stone-500`. The Vault (`text-stone-500`) and Atelier (`#8C7B6B`) branches are unchanged — both already clear AA on their surfaces. Adds a regression test that asserts the promise line uses the AA-compliant token in the default Gallery theme (it would fail against the old `stone-400`).

## Why this approach

It is the smallest possible fix: one token swap on the single flagged line, aligning the code with DESIGN.md's own Gallery muted-text token rather than inventing a new one. No copy, layout, behavior, or data-flow change. `ctaPromise` is rendered exactly once (this is the only welcome/promise line), so the fix fully covers the issue.

## Risks

Low. A single Tailwind class change on one paragraph plus one test. No visual layout shift (same size/spacing), no logic, no auth/sync/AI/RLS surface. The line simply becomes a slightly darker, readable grey.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-4uifa4-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the app signed out in the default Gallery (light) theme.
2. Read the small grey line beneath the "Add your first item" / "Explore sample" buttons.
3. It now renders in `stone-500` (≈ 4.8:1), legible on the light card, instead of the too-faint `stone-400` (≈ 2.5:1). Vault and Atelier are visually unchanged.

Checks:
- [x] npm run format:check
- [x] npm test (1023 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No screenshot from this headless run. The change is a single muted-text token (`stone-400` → `stone-500`) on the first-run promise line — the copy renders in a slightly darker, AA-legible grey with identical size, weight, and spacing. The token is locked by the new `getByText` regression assertion.

## Linear

Closes CUR-159

## Rollback plan

Green-tier. `git revert <this commit>` restores `text-stone-400` on the Gallery branch and removes the test. No data, schema, storage, or config involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL3zXKGWkws3ManY8LBwgy