### PR TITLE
[CUR-158] Anchor header status badge to the account icon

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -403,9 +403,34 @@ export const Layout: React.FC<LayoutProps> = ({
                 title={showSignInAffordance ? t('login') : statusLabel}
                 aria-haspopup="menu"
                 aria-expanded={profileSource === 'header'}
-                className={`${showSignInAffordance ? 'pl-3 pr-4 py-2 rounded-full flex items-center gap-2' : 'p-2 rounded-full'} transition-colors ${navGhost} ${statusColor} relative`}
+                className={`${showSignInAffordance ? 'pl-3 pr-4 py-2 rounded-full flex items-center gap-2' : 'p-2 rounded-full'} transition-colors ${navGhost} ${statusColor}`}
               >
-                <User size={20} />
+                {/* CUR-158 / CUR-153: anchor the status badge to the account
+                    icon itself, not the button box. Positioning it on the box
+                    (bottom-0 right-0) kept it beside the glyph in the compact
+                    icon-only button, but once CUR-49 widened the signed-out
+                    control into a labelled "Sign In" pill, that same corner
+                    landed outside the pill's rounded edge and read as a stray
+                    orange glyph. Wrapping the icon in a positioning context
+                    keeps the badge on the glyph in both layouts. Screen
+                    readers flatten a button's descendants, so the status
+                    reaches them via the button's aria-describedby -> this
+                    badge's aria-label; the title covers hover. Both reuse the
+                    profile menu's status vocabulary so every surface uses one
+                    consistent term. */}
+                <span className="relative flex items-center justify-center">
+                  <User size={20} />
+                  <span
+                    id="header-status-badge"
+                    data-testid="header-status-badge"
+                    role="img"
+                    aria-label={statusLabel}
+                    title={statusLabel}
+                    className={`absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full border flex items-center justify-center ${statusBadgeSurface}`}
+                  >
+                    <span className={statusColor}>{statusBadgeIcon}</span>
+                  </span>
+                </span>
                 {showSignInAffordance && (
                   <span
                     data-testid="header-sign-in-label"
@@ -414,23 +439,6 @@ export const Layout: React.FC<LayoutProps> = ({
                     {t('login')}
                   </span>
                 )}
-                {/* CUR-153: the badge must stay inside the button bounds (it
-                    used to hang at -bottom-1/-right-1, poking below the header
-                    edge and reading as a stray glyph). Screen readers flatten
-                    a button's descendants, so the status reaches them via the
-                    button's aria-describedby -> this badge's aria-label; the
-                    title covers hover. Both reuse the profile menu's status
-                    vocabulary so every surface uses one consistent term. */}
-                <span
-                  id="header-status-badge"
-                  data-testid="header-status-badge"
-                  role="img"
-                  aria-label={statusLabel}
-                  title={statusLabel}
-                  className={`absolute bottom-0 right-0 w-4 h-4 rounded-full border flex items-center justify-center ${statusBadgeSurface}`}
-                >
-                  <span className={statusColor}>{statusBadgeIcon}</span>
-                </span>
               </button>
 
               {profileSource === 'header' && (

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -1142,19 +1142,33 @@ describe('Layout Component', () => {
       expect(accountButton).toHaveAccessibleDescription(label);
     });
 
+    // CUR-158: once CUR-49 widened the signed-out control into a labelled
+    // "Sign In" pill, a badge anchored to the button box floated off its
+    // rounded bottom-right corner and read as a stray glyph. The badge is now
+    // anchored to the account icon, so it hugs the glyph in both the icon-only
+    // and pill layouts, in every auth state.
     it.each([
       { state: 'signed out', props: { user: null } },
       { state: 'signed in', props: { user: authenticatedUser } },
       { state: 'unconfigured', props: { user: null, isSupabaseConfigured: false } },
-    ])('stays inside the account button bounds when $state', ({ props }) => {
-      renderWithProviders(<Layout {...defaultProps} {...props} />);
+    ])(
+      'anchors the status badge to the account icon, not the button box, when $state',
+      ({ props }) => {
+        renderWithProviders(<Layout {...defaultProps} {...props} />);
 
-      const badge = screen.getByTestId('header-status-badge');
-      expect(badge.className).toContain('bottom-0');
-      expect(badge.className).toContain('right-0');
-      expect(badge.className).not.toContain('-bottom-1');
-      expect(badge.className).not.toContain('-right-1');
-    });
+        const badge = screen.getByTestId('header-status-badge');
+        const accountButton = screen.getByRole('button', { name: /account/i });
+
+        // Anchored to the icon wrapper, not directly to the button box.
+        expect(badge.parentElement).not.toBe(accountButton);
+        expect(badge.parentElement).toHaveClass('relative');
+        // Its positioning ancestor wraps the account glyph (the User icon svg).
+        expect(badge.parentElement?.querySelector('svg')).toBeInTheDocument();
+        // Hugs the icon's corner rather than the far corner of the wide pill.
+        expect(badge.className).toContain('-bottom-0.5');
+        expect(badge.className).toContain('-right-0.5');
+      },
+    );
   });
 
   describe('Accessibility', () => {


### PR DESCRIPTION
## Problem

In the desktop header sign-in **pill** (the labelled "SIGN IN" state shown to signed-out visitors), the small "Signed Out" status badge — an orange `CloudOff` glyph — floated at the pill's bottom-right corner, outside the pill's rounded outline. It read as a stray orange mark / rendering glitch rather than an intentional status indicator, on the very first screen a new visitor sees. This undermines the badge's whole purpose and works against Curio's **trust before growth** principle ("explicit, trustworthy status").

Root cause: the badge was positioned `absolute bottom-0 right-0` against the account **button box**. That kept it beside the glyph in the compact icon-only button (CUR-153), but once CUR-49 widened the signed-out control into a wide `rounded-full` pill, the same corner landed far from the icon and outside the visible rounded shape.

## Approach

Anchor the badge to the account **icon** rather than the button box: wrap the `<User />` icon in a `relative` positioning context and position the badge on that wrapper (`-bottom-0.5 -right-0.5`). It now hugs the glyph in both the icon-only and pill layouts. The `id` / `aria-describedby` / `aria-label` / `title` status wiring is untouched, so the screen-reader description and hover tooltip are preserved in every auth state. Removed the now-unused `relative` from the button class (the badge was its only absolutely-positioned child).

Updated the CUR-153 regression test to lock the new anchoring: it asserts the badge is no longer a direct child of the account button, that its positioning ancestor wraps the account glyph, and that it hugs the icon corner. This test fails against the old `bottom-0 right-0`-on-the-button markup.

## Why this approach

It's the issue's recommended fix and the smallest one: reposition a single existing badge relative to the icon, no new tokens, colours, copy, or behaviour. The badge surface/colour classes and all a11y attributes are unchanged, so it also fixes the icon-only and cloud-unconfigured layouts uniformly.

## Risks

Low. Presentational-only change to one 16×16 status badge in the desktop header; the glyph, its colours, and its accessibility wiring are identical. No auth, sync, AI, storage, or RLS surface touched. Full gate is green.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-ouhwig-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the app signed out on a desktop-width screen (Gallery theme).
2. Look at the top-right "SIGN IN" pill: the small orange cloud-with-slash badge now sits on the account icon, inside the pill outline, instead of floating past its rounded corner.
3. Sign in (or run with Supabase unconfigured): the badge (`Cloud` / `CloudOff`) still sits neatly on the icon in the compact icon-only button.
4. With a screen reader, focus the account control: the "Signed Out / Signed In / Cloud Required" status is still announced (via `aria-describedby`), and the hover tooltip is unchanged.

Checks:
- [x] npm run format:check
- [x] npm test (1023 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No screenshot from this headless run. The change moves an existing badge from the button's bottom-right corner onto the account glyph — same size, colour, and icon; it simply stops protruding past the pill's rounded edge. Verify visually at the Vercel Preview above; the DOM anchoring is locked by the updated `header-status-badge` regression test.

## Linear

Closes CUR-158

## Rollback plan

Green-tier presentational change. `git revert 45c93d3` restores the previous badge position and the prior test. No data, schema, storage, or config involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xCwXqXHVED7XBKKQX4UQr