### PR TITLE
[CUR-157] Remove redundant duplicate Sign In control in the desktop header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1595,16 +1595,10 @@ export const AppContent: React.FC = () => {
                 </Button>
               </Link>
             )}
-            {!isAuthenticated && isSupabaseReady && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => openAuthModal('signin')}
-                className="hidden sm:inline-flex motion-fade"
-              >
-                {t('login')}
-              </Button>
-            )}
+            {/* CUR-157: the signed-out sign-in entry point lives on the header
+                account pill (label + status badge + dropdown). A second ghost
+                "Sign In" button here read as a duplicate CTA and worked against
+                the single-path first-run principle, so it was removed. */}
             <LanguageToggle />
           </div>
         }

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -530,7 +530,7 @@ describe('App Integration Tests', () => {
     expect(within(modal).getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
   });
 
-  it('keeps the header Sign In entry point in sign-in mode (CUR-152)', async () => {
+  it('shows one desktop sign-in control that opens sign-in mode (CUR-157, CUR-152)', async () => {
     const { ThemeProvider } = await import('@/theme');
     vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
       data: { session: null },
@@ -550,8 +550,16 @@ describe('App Integration Tests', () => {
       expect(screen.getByTestId('access-gate')).toBeInTheDocument();
     });
 
+    // CUR-157: the header no longer carries a standalone ghost "Sign In" button
+    // beside the account pill — the pill (aria-label "Account") is the single
+    // desktop sign-in entry point.
     const header = screen.getByRole('banner');
-    fireEvent.click(within(header).getByRole('button', { name: 'Sign In' }));
+    expect(within(header).queryByRole('button', { name: 'Sign In' })).not.toBeInTheDocument();
+
+    // CUR-152: that single control opens the auth modal in sign-in mode.
+    fireEvent.click(within(header).getByRole('button', { name: 'Account' }));
+    const dropdown = await screen.findByTestId('profile-dropdown');
+    fireEvent.click(within(dropdown).getByRole('button', { name: 'Sign In' }));
 
     const modal = await screen.findByTestId('auth-modal');
     expect(within(modal).getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();


### PR DESCRIPTION
## Problem

On desktop, a signed-out visitor saw **two** sign-in controls side by side in the top-right header: a ghost text button labelled **"Sign In"** (in `App.tsx` `headerExtras`) and, immediately to its right, the account **pill** which — since CUR-49 added a visible label — also reads **"SIGN IN"**. Both open the same sign-in modal. Two identical CTAs next to each other read as ambiguous clutter ("are these different? which one do I use?") and work against Curio's **single-path first-run** principle, where each surface should present one clear action.

## Approach

Remove the ghost `<Button variant="ghost">{t('login')}</Button>` from `App.tsx` `headerExtras`. The account pill in `Layout.tsx` already carries the sign-in label, the signed-out status badge, and the account dropdown, so it becomes the single desktop sign-in entry point. Its dropdown sign-in action is wired to `onOpenAuth={() => openAuthModal('signin')}`, so the modal still opens in **sign-in** mode (preserving CUR-152).

The removed ghost button was gated on `!isAuthenticated && isSupabaseReady` — byte-identical to the pill label's `showSignInAffordance = isSupabaseConfigured && !isAuthenticated` (App passes `isSupabaseConfigured={isSupabaseReady}`). So the surviving control appears in exactly the same states; no gap is introduced. Both were `hidden`/`sm:`-only, so the mobile bottom-nav sign-in is untouched.

Updated the CUR-152 integration test to exercise the surviving control (account pill → dropdown → Sign In) and to assert the header no longer carries a standalone "Sign In" button beside the pill — it fails against the old two-control markup.

## Why this approach

It's the issue's recommended fix and the smallest one: delete a single duplicate control, keeping the pill that already owns the label, status, and dropdown. No new tokens, colours, copy, or behaviour, and the sign-in-mode guarantee is preserved through the existing dropdown wiring.

## Risks

Low. Removes one redundant desktop-only button; the surviving pill's states, a11y wiring, and the mobile nav are unchanged. No auth logic, sync, AI, storage, or RLS surface touched. Full gate is green.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-421p5e-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the app signed out on a desktop-width screen (≥ 640px), Gallery theme.
2. Top-right header now shows a single "SIGN IN" account pill (plus language/theme toggles) — the separate ghost "Sign In" button is gone.
3. Click the pill → the account dropdown opens → click **Sign In** → the auth modal opens on **"Welcome back"** (sign-in), not sign-up.
4. Resize to mobile: the bottom-nav Profile/Sign In entry is unchanged.
5. Sign in (or run with Supabase unconfigured): header states are unchanged (no ghost button existed in those states before).

Checks:
- [x] npm run format:check
- [x] npm test (1023 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No screenshot from this headless run. The change removes one duplicate header button; the remaining account pill is visually unchanged. The single-control state is locked by the updated `AppNavigation` integration test. Verify visually at the Vercel Preview above.

## Linear

Closes CUR-157

## Rollback plan

Green-tier change. `git revert 3f4dba3` restores the ghost "Sign In" button and the prior test. No data, schema, storage, or config involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)