### PR TITLE
[CUR-163] Fall back to "Untitled" in delete confirmation when item has no title

### DIFF
--- a/src/components/DeleteItemModal.tsx
+++ b/src/components/DeleteItemModal.tsx
@@ -68,7 +68,7 @@ export const DeleteItemModal: React.FC<DeleteItemModalProps> = ({
             className={`p-4 rounded-xl ${theme === 'vault' ? 'bg-red-500/10 border border-red-500/20' : 'bg-red-50 border border-red-100'}`}
           >
             <p className={`text-sm ${theme === 'vault' ? 'text-red-200' : 'text-red-700'}`}>
-              {t('deleteItemWarning').replace('{title}', item.title)}
+              {t('deleteItemWarning').replace('{title}', item.title?.trim() || t('untitled'))}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The item delete confirmation interpolated the raw `item.title` into its copy with no fallback. For an item with an empty title, the destructive dialog read:

> This will permanently delete **""**. This action cannot be undone.

— so the user could not tell which piece they were about to permanently remove. Every other surface in the app already guards this (`item.title || 'Untitled'` / `|| t('...')`); the delete modal was the inconsistent outlier.

This uses the existing `untitled` i18n string (EN "Untitled", ZH "未命名") as the fallback, matching the pattern used at `src/App.tsx` and `src/components/AddItemModal.tsx`.

Found during a live UX review against production. The empty-title state is user-reachable because the "Title is required" validation on the item detail screen is non-blocking (clearing a title still autosaves an empty title), after which the delete dialog shows `""`.

## Change

`src/components/DeleteItemModal.tsx`:
```diff
- {t('deleteItemWarning').replace('{title}', item.title)}
+ {t('deleteItemWarning').replace('{title}', item.title?.trim() || t('untitled'))}
```

## Testing

- `npm run format:check` — pass
- `npm test` — 1026 passed (2 skipped, 1 todo)
- `npm run build` — pass
- `npm run test:e2e` — 44 passed, 8 skipped

## Linear

Fixes CUR-163. Related review issues filed separately: CUR-160, CUR-161, CUR-162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxQmUA4zLjaHQjZ8eV38S7)_