### PR TITLE
[CUR-160] Compact the mobile collection action bar so items surface sooner

### DIFF
--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -98,6 +98,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
   const isReadOnly = Boolean(collection?.isPublic) && !isAdmin;
   const isSample = Boolean(collection?.isPublic) || Boolean(collection?.id?.startsWith('sample'));
   const canAddItems = Boolean(collection) && !isReadOnly;
+  const hasItems = (collection?.items.length ?? 0) > 0;
   const [filterInput, setFilterInput] = useState('');
   const [viewMode, setViewMode] = useState<'grid' | 'waterfall'>('waterfall');
   const [sortBy, setSortBy] = useState<ItemSort>('newest');
@@ -278,7 +279,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
   }
 
   return (
-    <div className="space-y-10 animate-in slide-in-from-bottom-4 duration-500">
+    <div className="space-y-6 sm:space-y-10 animate-in slide-in-from-bottom-4 duration-500">
       {isReadOnly && (
         <div
           data-testid="read-only-banner"
@@ -298,7 +299,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
         </div>
       )}
 
-      <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-8">
+      <div className="flex flex-col lg:flex-row lg:items-end justify-between gap-5 sm:gap-8">
         <div className="flex items-center gap-4 sm:gap-6">
           <Link
             to="/"
@@ -330,120 +331,140 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
           </div>
         </div>
         <div className="flex flex-col gap-3 w-full lg:w-auto">
-          <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 w-full">
+          {/* CUR-160: keep the primary actions on one row on mobile so item
+              cards surface sooner. Add Item stays the emphasized primary;
+              Enter Exhibition collapses to a compact icon beside it, and only
+              takes the full labelled treatment when it is the sole action
+              (e.g. a read-only sample collection with no Add Item button). */}
+          <div className="flex flex-row items-center gap-3 sm:gap-4 w-full">
             {canAddItems && (
               <Button
                 variant="primary"
                 onClick={() => openAddItemModal(collection.id)}
                 icon={<Plus size={16} />}
-                className="shadow-md w-full sm:w-auto"
+                className="shadow-md flex-1 sm:flex-none sm:w-auto"
               >
                 {t('addItem')}
               </Button>
             )}
-            <Button
-              variant="primary"
-              onClick={() => setIsExhibitionOpen(true)}
-              disabled={collection.items.length === 0}
-              icon={<Play size={16} />}
-              className="shadow-md w-full sm:w-auto"
-            >
-              {t('enterExhibition')}
-            </Button>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
-            {!isReadOnly && (
-              <button
-                onClick={() => setIsDeleteCollectionModalOpen(true)}
-                aria-label={t('deleteCollection')}
-                className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center rounded-xl transition-colors ${
-                  theme === 'vault'
-                    ? 'bg-stone-900 border border-white/10 text-stone-400 hover:text-red-400 hover:border-red-400/30'
-                    : 'bg-white border border-stone-200 text-stone-400 hover:text-red-500 hover:border-red-200'
-                }`}
-                title={t('deleteCollection')}
-              >
-                <Trash2 size={18} />
-              </button>
-            )}
-            {!isReadOnly && (
+            {hasItems && (
               <Button
-                variant={isSelectionMode ? 'primary' : 'outline'}
-                onClick={handleToggleSelectionMode}
-                className={`${theme === 'vault' ? 'bg-stone-900 text-white border-white/10' : 'bg-white'} h-11`}
-                icon={<CheckSquare size={16} />}
+                variant="primary"
+                onClick={() => setIsExhibitionOpen(true)}
+                icon={<Play size={16} />}
+                aria-label={t('enterExhibition')}
+                title={t('enterExhibition')}
+                className={`shadow-md ${canAddItems ? 'w-11 !px-0 sm:w-auto sm:!px-6' : 'flex-1 sm:flex-none sm:w-auto'}`}
               >
-                {isSelectionMode ? t('done') : t('selectItems')}
+                <span className={canAddItems ? 'hidden sm:inline' : undefined}>
+                  {t('enterExhibition')}
+                </span>
               </Button>
             )}
-            <div
-              className={`flex rounded-xl p-1 ${theme === 'vault' ? 'bg-white/5' : theme === 'atelier' ? 'bg-[#D4C9B8]/30' : 'bg-stone-200/50'}`}
-            >
-              <button
-                onClick={() => setViewMode('grid')}
-                aria-label={t('viewGrid')}
-                title={t('viewGrid')}
-                className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
-              >
-                <LayoutGrid size={18} />
-              </button>
-              <button
-                onClick={() => setViewMode('waterfall')}
-                aria-label={t('viewWaterfall')}
-                title={t('viewWaterfall')}
-                className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
-              >
-                <LayoutTemplate size={18} className="rotate-180" />
-              </button>
-            </div>
-            <div className="flex items-center gap-2">
-              <ListOrdered size={16} className="text-stone-400" />
-              <select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as ItemSort)}
-                className={`h-11 px-3 rounded-xl border text-sm font-semibold ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-700'}`}
-                aria-label={t('sortLabel')}
-              >
-                <option value="newest">{t('sortNewest')}</option>
-                <option value="oldest">{t('sortOldest')}</option>
-                <option value="title">{t('sortTitle')}</option>
-                <option value="rating">{t('sortRating')}</option>
-              </select>
-            </div>
-            <div className="flex gap-2 flex-1 min-w-[12rem]">
-              <div className="relative flex-1">
-                <input
-                  type="text"
-                  placeholder={t('collectionSearchPlaceholder')}
-                  aria-label={t('collectionSearchPlaceholder')}
-                  value={filterInput}
-                  onChange={(e) => setFilterInput(e.target.value)}
-                  className={`pl-4 pr-11 py-2 rounded-xl border focus:ring-4 focus:ring-amber-500/5 outline-none text-sm w-full transition-all shadow-sm font-serif italic ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
-                />
-                {filterInput.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => setFilterInput('')}
-                    aria-label={t('clearSearch')}
-                    title={t('clearSearch')}
-                    data-testid="collection-search-clear"
-                    className={`absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 w-11 h-11 sm:w-9 sm:h-9 rounded-full flex items-center justify-center transition-colors ${theme === 'vault' ? 'text-stone-300 hover:bg-white/10' : 'text-stone-400 hover:bg-stone-100 hover:text-stone-600'}`}
+          </div>
+          {/* CUR-160: item-oriented controls only make sense once a collection
+              has items — hide Exhibition/Select/Sort/Search/Filter on an empty
+              collection so it shows just its empty-state CTA. Delete Collection
+              stays available so an empty collection can still be removed. */}
+          {(!isReadOnly || hasItems) && (
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3 w-full">
+              {!isReadOnly && (
+                <button
+                  onClick={() => setIsDeleteCollectionModalOpen(true)}
+                  aria-label={t('deleteCollection')}
+                  className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center rounded-xl transition-colors ${
+                    theme === 'vault'
+                      ? 'bg-stone-900 border border-white/10 text-stone-400 hover:text-red-400 hover:border-red-400/30'
+                      : 'bg-white border border-stone-200 text-stone-400 hover:text-red-500 hover:border-red-200'
+                  }`}
+                  title={t('deleteCollection')}
+                >
+                  <Trash2 size={18} />
+                </button>
+              )}
+              {!isReadOnly && hasItems && (
+                <Button
+                  variant={isSelectionMode ? 'primary' : 'outline'}
+                  onClick={handleToggleSelectionMode}
+                  className={`${theme === 'vault' ? 'bg-stone-900 text-white border-white/10' : 'bg-white'} h-11`}
+                  icon={<CheckSquare size={16} />}
+                >
+                  {isSelectionMode ? t('done') : t('selectItems')}
+                </Button>
+              )}
+              {hasItems && (
+                <>
+                  <div
+                    className={`flex rounded-xl p-1 ${theme === 'vault' ? 'bg-white/5' : theme === 'atelier' ? 'bg-[#D4C9B8]/30' : 'bg-stone-200/50'}`}
                   >
-                    <X size={16} />
-                  </button>
-                )}
-              </div>
-              <Button
-                variant={activeFilterCount > 0 ? 'primary' : 'outline'}
-                className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center !p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}
-                onClick={() => setIsFilterModalOpen(true)}
-                aria-label={t('filterCollection')}
-                title={t('filterCollection')}
-              >
-                <SlidersHorizontal size={18} />
-              </Button>
+                    <button
+                      onClick={() => setViewMode('grid')}
+                      aria-label={t('viewGrid')}
+                      title={t('viewGrid')}
+                      className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
+                    >
+                      <LayoutGrid size={18} />
+                    </button>
+                    <button
+                      onClick={() => setViewMode('waterfall')}
+                      aria-label={t('viewWaterfall')}
+                      title={t('viewWaterfall')}
+                      className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
+                    >
+                      <LayoutTemplate size={18} className="rotate-180" />
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <ListOrdered size={16} className="text-stone-400" />
+                    <select
+                      value={sortBy}
+                      onChange={(e) => setSortBy(e.target.value as ItemSort)}
+                      className={`h-11 px-3 rounded-xl border text-sm font-semibold ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-700'}`}
+                      aria-label={t('sortLabel')}
+                    >
+                      <option value="newest">{t('sortNewest')}</option>
+                      <option value="oldest">{t('sortOldest')}</option>
+                      <option value="title">{t('sortTitle')}</option>
+                      <option value="rating">{t('sortRating')}</option>
+                    </select>
+                  </div>
+                  <div className="flex gap-2 flex-1 min-w-[12rem]">
+                    <div className="relative flex-1">
+                      <input
+                        type="text"
+                        placeholder={t('collectionSearchPlaceholder')}
+                        aria-label={t('collectionSearchPlaceholder')}
+                        value={filterInput}
+                        onChange={(e) => setFilterInput(e.target.value)}
+                        className={`pl-4 pr-11 py-2 rounded-xl border focus:ring-4 focus:ring-amber-500/5 outline-none text-sm w-full transition-all shadow-sm font-serif italic ${theme === 'vault' ? 'bg-stone-900 border-white/10 text-white' : 'bg-white border-stone-200 text-stone-900'}`}
+                      />
+                      {filterInput.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => setFilterInput('')}
+                          aria-label={t('clearSearch')}
+                          title={t('clearSearch')}
+                          data-testid="collection-search-clear"
+                          className={`absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 w-11 h-11 sm:w-9 sm:h-9 rounded-full flex items-center justify-center transition-colors ${theme === 'vault' ? 'text-stone-300 hover:bg-white/10' : 'text-stone-400 hover:bg-stone-100 hover:text-stone-600'}`}
+                        >
+                          <X size={16} />
+                        </button>
+                      )}
+                    </div>
+                    <Button
+                      variant={activeFilterCount > 0 ? 'primary' : 'outline'}
+                      className={`w-11 h-11 sm:w-10 sm:h-10 flex items-center justify-center !p-0 rounded-xl ${theme === 'vault' ? 'bg-stone-900 border-white/10' : activeFilterCount > 0 ? '' : 'bg-white'}`}
+                      onClick={() => setIsFilterModalOpen(true)}
+                      aria-label={t('filterCollection')}
+                      title={t('filterCollection')}
+                    >
+                      <SlidersHorizontal size={18} />
+                    </Button>
+                  </div>
+                </>
+              )}
             </div>
-          </div>
+          )}
         </div>
       </div>
 

--- a/tests/components/CollectionScreen.test.tsx
+++ b/tests/components/CollectionScreen.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { LanguageProvider } from '@/i18n';
+import { ThemeProvider } from '@/theme';
+import { CollectionScreen } from '@/components/CollectionScreen';
+import { UserCollection } from '@/types';
+
+// Mock the debounce so search state settles synchronously in tests.
+vi.mock('@/hooks/useDebouncedValue', () => ({
+  useDebouncedValue: (value: unknown) => value,
+}));
+
+function makeCollection(overrides: Partial<UserCollection> = {}): UserCollection {
+  return {
+    id: 'col1',
+    name: 'Supplements',
+    items: [],
+    templateId: 'general',
+    icon: '💊',
+    customFields: [],
+    isPublic: false,
+    ownerId: 'user1',
+    updatedAt: '',
+    createdAt: '',
+    ...overrides,
+  };
+}
+
+function makeItem(id: string) {
+  return {
+    id,
+    title: `Item ${id}`,
+    data: {},
+    rating: 0,
+    notes: '',
+    photoUrl: '',
+    createdAt: '',
+    updatedAt: '',
+    collectionId: 'col1',
+    userId: 'user1',
+  };
+}
+
+function renderScreen(collection: UserCollection) {
+  const props = {
+    collections: [collection],
+    isAdmin: false,
+    isLoading: false,
+    isAuthenticated: true,
+    isSupabaseReady: true,
+    sampleCollectionId: undefined,
+    openAuthModal: vi.fn(),
+    openAddItemModal: vi.fn(),
+    deleteItem: vi.fn(() => true),
+    removeCollection: vi.fn(async () => {}),
+    showStatus: vi.fn(),
+  };
+  return render(
+    <MemoryRouter initialEntries={[`/collection/${collection.id}`]}>
+      <LanguageProvider>
+        <ThemeProvider>
+          <Routes>
+            <Route path="/collection/:id" element={<CollectionScreen {...props} />} />
+            <Route path="/" element={<div>home</div>} />
+          </Routes>
+        </ThemeProvider>
+      </LanguageProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('CollectionScreen action bar (CUR-160)', () => {
+  it('hides Exhibition/Select/Sort/Search/Filter on an empty collection', () => {
+    renderScreen(makeCollection({ items: [] }));
+
+    // Add Item stays — it is the empty collection's single primary action.
+    expect(screen.getByRole('button', { name: /add item/i })).toBeInTheDocument();
+    // Delete Collection stays so an empty collection can still be removed.
+    expect(screen.getByRole('button', { name: /delete collection/i })).toBeInTheDocument();
+
+    // Item-oriented controls have nothing to act on and are not rendered.
+    expect(screen.queryByRole('button', { name: /enter exhibition/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^select$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox', { name: /sort items/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /filter collection/i })).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/search this collection/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps every control available once the collection has items', () => {
+    renderScreen(makeCollection({ items: [makeItem('a'), makeItem('b')] }));
+
+    expect(screen.getByRole('button', { name: /add item/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /enter exhibition/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^select$/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /sort items/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /filter collection/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/search this collection/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete collection/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

On a phone-width viewport the collection screen stacked the whole action bar above the item grid: the collection title + count, a full-width **Add Item** button, a full-width **Enter Exhibition** button, then the Select / view-toggle row, then the Sort / Search / Filter row. On a 390×780 screen this filled the first viewport, so **no item card was visible above the fold** — a collector opening their collection saw a wall of controls instead of their objects. That works against Curio's *identity before inventory* and *beauty before bureaucracy* principles. The same bar also rendered in full for empty (0-item) collections, where Exhibition / Select / Sort have nothing to act on.

## Approach

Compact the mobile action bar without removing any capability:

- **One primary row on mobile.** Add Item stays the emphasized primary; **Enter Exhibition** collapses to a compact icon beside it (it isn't the primary intent when opening a collection). Exhibition keeps its full labelled treatment only when it is the *sole* action — e.g. a read-only sample collection with no Add Item button — so that surface keeps its inviting CTA.
- **Empty collections hide item-oriented controls.** Exhibition / Select / Sort / Search / Filter render only once the collection has items, so an empty collection shows just its empty-state CTA. Delete Collection stays available so an empty collection can still be removed.
- **Trim mobile-only vertical rhythm** (root `space-y` and the header title↔actions gap). The sm/lg tablet + desktop layout is untouched via responsive prefixes.

## Why this approach

It implements the issue's recommended fix as the smallest taste-aligned change: a per-viewport reflow of one existing action bar, no new tokens/colours/components and no change to data, routing, AI, or sync. Every control is relocated/compacted rather than removed, and desktop is preserved by keeping every change behind `sm:`/`lg:` prefixes.

## Risks

Low. Presentational/markup-only change to one component's action bar. No auth, sync, AI, storage, or RLS surface touched. Edge case: a read-only sample with items now shows a full-width labelled Exhibition CTA on mobile and the item-controls, exactly as before. The full gate is green.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-niucsr-qs-projects-72b20d9d.vercel.app

Steps:
1. Open a non-empty collection on a 390 / 375 / 360px viewport. Add Item + a compact Exhibition icon sit on one row; item cards now begin above the fold instead of below a stack of full-width buttons.
2. Resize to desktop (≥1024px): the action bar is identical to before — Add Item and a full labelled **Enter Exhibition** side by side, then the controls row.
3. Open an **empty** collection: only Add Item (+ the empty-state "Add first piece" CTA and Delete Collection) show; no Exhibition/Select/Sort/Search/Filter.
4. On a read-only **sample** collection: still read-only, still labelled, Exhibition + Sort/Search/Filter all present.

Measured on the read-only sample at 390×780 (built app, Chromium): the first item card's top moved from **y=742 → y=682**. The private-collection case in the issue benefits more, since its two stacked full-width buttons (Add Item + Exhibition) collapse into a single row — a saving the sample doesn't exercise because it has no Add Item.

Checks:
- [x] npm run format:check
- [x] npm test — 1028 passed, 2 skipped, 1 todo
- [x] npm run build
- [x] npm run test:e2e — 44 passed, 8 skipped

## Screenshot / GIF

No screenshot from this headless run. The DOM/behaviour is locked by the new `CollectionScreen` tests (empty collection hides the item-oriented controls — fails before this change; non-empty keeps them all) and the above-the-fold measurement is quoted above. Verify visually at the Vercel Preview.

## Linear

Closes CUR-160

## Rollback plan

Presentational change. `git revert 9fb57e8` restores the previous stacked action bar and removes the new test. No data, schema, storage, or config involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M81Uu8Y9mB1Epq8saXvfgE)_