### PR TITLE
Address post-merge review findings on #355, #378 and #395

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1134,8 +1134,15 @@ export const AppContent: React.FC = () => {
     setCollections((prev) => {
       const target = prev.find((c) => c.id === collectionId);
       if (target) {
+        // Removing an item mutates the collection, so its `updatedAt` has to
+        // move with it — `updateItem` and `updateCollection` already do this.
+        // Leaving it untouched makes a deletion invisible to every timestamp
+        // comparison downstream (cache-snapshot recency, cloud merge), so a
+        // snapshot taken moments earlier looks equally fresh and can put the
+        // deleted item back.
         const newC = {
           ...target,
+          updatedAt: new Date().toISOString(),
           items: target.items.filter((i) => i.id !== itemId),
         };
         saveCollection(newC).catch((e) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -336,7 +336,12 @@ export const AppContent: React.FC = () => {
   useEffect(() => {
     const handleOnline = () => {
       setIsOffline(false);
-      void syncPendingDeletes();
+      // Fire-and-forget: a failed tombstone read now rejects rather than
+      // reporting "nothing pending", so swallow it here. The deletes stay
+      // queued and the next sync attempt retries them.
+      void syncPendingDeletes().catch((e) =>
+        console.warn('Pending delete sync on reconnect failed:', e),
+      );
     };
     const handleOffline = () => setIsOffline(true);
     window.addEventListener('online', handleOnline);

--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -698,6 +698,10 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
       // (e.g. HEIC photos that browsers can't decode), so we never lose the
       // original payload here.
       const base64Data = await compressImageForAi(image);
+      // Compression is an await gap (image decode + canvas.toBlob) that can
+      // outlast the modal. Without a recheck here, closing mid-compression
+      // still spends an AI/network request on a photo nobody is waiting for.
+      if (analysisRunId.current !== runId) return analyzed;
       if (!base64Data) {
         setError(t('analysisFallback'));
         hadError = true;
@@ -888,6 +892,9 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
       // compressImageForAi falls back to the raw base64 on any failure so
       // we never silently lose the original payload here.
       const base64Data = await compressImageForAi(base64);
+      // Same await gap as the batch loop: the modal can close while the photo
+      // is still being compressed, so recheck before spending the request.
+      if (analysisRunId.current !== runId) return;
       if (!base64Data) {
         setError(t('analysisFallback'));
         setAnalysisError(true);

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1193,9 +1193,25 @@ export const getPendingDeletes = async (): Promise<PendingDelete[]> => {
   return pending;
 };
 
+// Reading the tombstone queue serves two opposite needs. A sync guard needs a
+// list it can trust and must abort when it cannot be read, so `getPendingDeletes`
+// rejects. The append path needs the opposite: by the time it runs the item is
+// already gone locally and its caller swallows failures, so refusing to record
+// the tombstone loses the deletion outright — no queue entry, no cloud delete,
+// and the item returns on the next refresh. Degrade to a best-effort base there
+// instead, so the new tombstone is still journaled durably.
+const readPendingDeletesForAppend = async (): Promise<PendingDelete[]> => {
+  try {
+    return await getPendingDeletes();
+  } catch (error) {
+    console.warn('Pending delete read failed; journaling new tombstone on a partial base:', error);
+    return readPendingDeleteJournal() ?? [];
+  }
+};
+
 export const addToPendingDeletes = async (entry: PendingDelete): Promise<void> => {
   const db = await initDB();
-  const pending = await getPendingDeletes();
+  const pending = await readPendingDeletesForAppend();
   // Avoid duplicates
   if (entry.type === 'item') {
     if (

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1156,11 +1156,16 @@ const getLocalStorage = (): Storage | null => {
 };
 
 const readPendingDeletesFromIndexedDb = async (db: IDBDatabase): Promise<PendingDelete[]> =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     const tx = db.transaction(SETTINGS_STORE, 'readonly');
     const req = tx.objectStore(SETTINGS_STORE).get(PENDING_DELETE_KEY);
     req.onsuccess = () => resolve(normalizePendingDeletes(req.result));
-    req.onerror = () => resolve([]);
+    // Resolving `[]` on failure is indistinguishable from "nothing is pending
+    // deletion", which defeats every tombstone guard downstream: the cloud sync
+    // would happily re-upsert an item the user just deleted. Propagate instead
+    // so callers can abort and leave the collection queued for a later retry.
+    req.onerror = () => reject(req.error ?? new Error('Pending delete read failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('Pending delete read aborted'));
   });
 
 const writePendingDeletesToIndexedDb = async (
@@ -2416,6 +2421,8 @@ export const saveAllCollections = async (collections: UserCollection[]): Promise
     const persistSnapshot = () => {
       if (!existingCollectionsLoaded || !pendingSyncLoaded) return;
 
+      const existingById = new Map(existingCollections.map((c) => [c.id, c]));
+
       // Delete stale entries unless they are queued for cloud sync. A background
       // full-cache save can lag behind a just-created local collection; deleting
       // pending rows here would silently drop the only retryable copy.
@@ -2430,8 +2437,30 @@ export const saveAllCollections = async (collections: UserCollection[]): Promise
         store.delete(collection.id);
       });
 
-      // Upsert all new collections (put instead of add)
-      collections.forEach((col) => store.put(col));
+      // Upsert the snapshot (put instead of add) — but not over a queued local
+      // edit that is newer than the snapshot. A background full-cache save can
+      // be built from state read before the user's latest edit; writing it back
+      // would drop the only copy of that edit. Recency is the discriminator,
+      // not the pending flag alone: a full-cache save also legitimately carries
+      // *newer* state for a still-pending collection (e.g. an item deleted
+      // while an older cloud save is in flight), and that must still win.
+      // Skipping the put is not enough on its own either: the asset whitelist
+      // has to track the local version too, or blobs belonging to items added
+      // in the pending edit get purged as orphans.
+      collections.forEach((col) => {
+        const existing = pendingSyncIds.has(col.id) ? existingById.get(col.id) : undefined;
+        const pendingLocal =
+          existing && compareTimestamps(existing.updatedAt, col.updatedAt) > 0
+            ? existing
+            : undefined;
+        if (pendingLocal) {
+          const idx = collectionsToKeepForAssets.findIndex((c) => c.id === col.id);
+          if (idx >= 0) collectionsToKeepForAssets[idx] = pendingLocal;
+          else collectionsToKeepForAssets.push(pendingLocal);
+          return;
+        }
+        store.put(col);
+      });
     };
 
     // Get existing collections to find stale entries and preserve queued local writes.

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -2447,10 +2447,16 @@ export const saveAllCollections = async (collections: UserCollection[]): Promise
       // Skipping the put is not enough on its own either: the asset whitelist
       // has to track the local version too, or blobs belonging to items added
       // in the pending edit get purged as orphans.
+      //
+      // Ties go to the queued local row. Equal timestamps mean the two versions
+      // are indistinguishable by recency, and the local one is the copy flagged
+      // as holding unsynced work: preferring it can at worst re-apply a cloud
+      // change that is still safely in the cloud, while preferring the snapshot
+      // can destroy a local edit that exists nowhere else.
       collections.forEach((col) => {
         const existing = pendingSyncIds.has(col.id) ? existingById.get(col.id) : undefined;
         const pendingLocal =
-          existing && compareTimestamps(existing.updatedAt, col.updatedAt) > 0
+          existing && compareTimestamps(existing.updatedAt, col.updatedAt) >= 0
             ? existing
             : undefined;
         if (pendingLocal) {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -19,6 +19,7 @@ const PENDING_SYNC_KEY = 'pending_sync_ids';
 const PENDING_ASSET_UPLOADS_KEY = 'pending_asset_uploads';
 const PENDING_IMAGE_RECORDS_KEY = 'pending_image_records';
 const PENDING_DELETE_KEY = 'pending_deletes';
+const PENDING_DELETE_RECOVERY_PREFIX = 'pending_delete_recovery:';
 const PENDING_DELETE_JOURNAL_KEY = 'curio_pending_delete_journal';
 
 const SYNC_RETRY_BACKOFF_BASE_MS = 30_000;
@@ -1180,58 +1181,121 @@ const writePendingDeletesToIndexedDb = async (
     tx.onabort = () => reject(tx.error);
   });
 
+const samePendingDelete = (a: PendingDelete, b: PendingDelete) =>
+  a.type === b.type &&
+  a.collectionId === b.collectionId &&
+  (a.type === 'collection' || b.type === 'collection' || a.itemId === b.itemId);
+
+const mergePendingDeletes = (base: PendingDelete[], extra: PendingDelete[]): PendingDelete[] => {
+  const merged = [...base];
+  extra.forEach((entry) => {
+    if (!merged.some((existing) => samePendingDelete(existing, entry))) merged.push(entry);
+  });
+  return merged;
+};
+
+// Recovery records: tombstones written while the canonical queue was unreadable.
+// The queue lives under a single key, so appending to it normally means
+// read-modify-write — and if the read fails, writing back erases whatever was
+// there. These are stored one-per-key instead, so the write is blind and
+// additive and cannot destroy a queue it could not read. The key is derived
+// from the entry's identity, so re-deleting the same thing overwrites its own
+// record rather than accumulating duplicates. `getPendingDeletes` folds them
+// back into the queue and clears them once reads recover.
+const recoveryKeyFor = (entry: PendingDelete) =>
+  `${PENDING_DELETE_RECOVERY_PREFIX}${entry.type}:${entry.collectionId}:${
+    entry.type === 'item' ? entry.itemId : ''
+  }`;
+
+const recoveryKeyRange = () =>
+  IDBKeyRange.bound(PENDING_DELETE_RECOVERY_PREFIX, `${PENDING_DELETE_RECOVERY_PREFIX}￿`);
+
+const appendPendingDeleteRecovery = async (db: IDBDatabase, entry: PendingDelete): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction(SETTINGS_STORE, 'readwrite');
+    tx.objectStore(SETTINGS_STORE).put(entry, recoveryKeyFor(entry));
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+
+const readPendingDeleteRecovery = async (
+  db: IDBDatabase,
+): Promise<{ entries: PendingDelete[]; keys: IDBValidKey[] }> =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction(SETTINGS_STORE, 'readonly');
+    const store = tx.objectStore(SETTINGS_STORE);
+    const valuesReq = store.getAll(recoveryKeyRange());
+    const keysReq = store.getAllKeys(recoveryKeyRange());
+    tx.oncomplete = () =>
+      resolve({
+        entries: normalizePendingDeletes(valuesReq.result || []),
+        keys: (keysReq.result || []) as IDBValidKey[],
+      });
+    tx.onerror = () => reject(tx.error ?? new Error('Pending delete recovery read failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('Pending delete recovery read aborted'));
+  });
+
+const clearPendingDeleteRecovery = async (db: IDBDatabase, keys: IDBValidKey[]): Promise<void> => {
+  if (keys.length === 0) return;
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(SETTINGS_STORE, 'readwrite');
+    const store = tx.objectStore(SETTINGS_STORE);
+    keys.forEach((key) => store.delete(key));
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+};
+
 export const getPendingDeletes = async (): Promise<PendingDelete[]> => {
   const db = await initDB();
+  const recovery = await readPendingDeleteRecovery(db);
   const journal = readPendingDeleteJournal();
+  const base = journal !== null ? journal : await readPendingDeletesFromIndexedDb(db);
+
+  // Reads are working again, so fold any recovered tombstones back into the
+  // canonical queue and drop their standalone records.
+  if (recovery.entries.length > 0) {
+    const merged = mergePendingDeletes(base, recovery.entries);
+    writePendingDeleteJournal(merged);
+    await writePendingDeletesToIndexedDb(db, merged);
+    await clearPendingDeleteRecovery(db, recovery.keys);
+    return merged;
+  }
+
   if (journal !== null) {
     await writePendingDeletesToIndexedDb(db, journal);
     return journal;
   }
-
-  const pending = await readPendingDeletesFromIndexedDb(db);
-  writePendingDeleteJournal(pending);
-  return pending;
-};
-
-// Reading the tombstone queue serves two opposite needs. A sync guard needs a
-// list it can trust and must abort when it cannot be read, so `getPendingDeletes`
-// rejects. The append path needs the opposite: by the time it runs the item is
-// already gone locally and its caller swallows failures, so refusing to record
-// the tombstone loses the deletion outright — no queue entry, no cloud delete,
-// and the item returns on the next refresh. Degrade to a best-effort base there
-// instead, so the new tombstone is still journaled durably.
-const readPendingDeletesForAppend = async (): Promise<PendingDelete[]> => {
-  try {
-    return await getPendingDeletes();
-  } catch (error) {
-    console.warn('Pending delete read failed; journaling new tombstone on a partial base:', error);
-    return readPendingDeleteJournal() ?? [];
-  }
+  writePendingDeleteJournal(base);
+  return base;
 };
 
 export const addToPendingDeletes = async (entry: PendingDelete): Promise<void> => {
   const db = await initDB();
-  const pending = await readPendingDeletesForAppend();
-  // Avoid duplicates
-  if (entry.type === 'item') {
-    if (
-      pending.some(
-        (d) =>
-          d.type === 'item' && d.collectionId === entry.collectionId && d.itemId === entry.itemId,
-      )
-    ) {
-      return;
-    }
+  const entryToAdd = { ...entry, createdAt: entry.createdAt ?? new Date().toISOString() };
+
+  let pending: PendingDelete[];
+  try {
+    pending = await getPendingDeletes();
+  } catch (error) {
+    // A sync guard must abort on an unreadable queue, but this path must not:
+    // the item is already gone locally and the caller swallows failures, so
+    // refusing here loses the deletion outright — no tombstone, no cloud
+    // delete, item back on the next refresh. Rewriting the queue from a
+    // guessed base is equally unsafe, since it would erase the very entries
+    // that could not be read. Record additively instead: no read, nothing to
+    // clobber, folded back in once reads recover.
+    console.warn('Pending delete read failed; recording tombstone additively:', error);
+    await appendPendingDeleteRecovery(db, entryToAdd);
+    return;
   }
-  if (entry.type === 'collection') {
-    if (pending.some((d) => d.type === 'collection' && d.collectionId === entry.collectionId)) {
-      return;
-    }
+
+  if (pending.some((existing) => samePendingDelete(existing, entryToAdd))) {
+    return;
   }
-  const updated = [
-    ...pending,
-    { ...entry, createdAt: entry.createdAt ?? new Date().toISOString() },
-  ];
+  const updated = [...pending, entryToAdd];
   writePendingDeleteJournal(updated);
   await writePendingDeletesToIndexedDb(db, updated);
 };

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -55,8 +55,10 @@ vi.mock('@capacitor/camera', () => ({
 
 import { analyzeImage, refreshAiEnabled } from '@/services/geminiService';
 import { trackEvent } from '@/services/analytics';
+import { compressImageForAi } from '@/services/imageProcessor';
 import { Camera, CameraSource } from '@capacitor/camera';
 
+const mockCompressImageForAi = compressImageForAi as ReturnType<typeof vi.fn>;
 const mockAnalyzeImage = analyzeImage as ReturnType<typeof vi.fn>;
 const mockRefreshAiEnabled = refreshAiEnabled as ReturnType<typeof vi.fn>;
 const mockTrackEvent = trackEvent as ReturnType<typeof vi.fn>;
@@ -948,6 +950,55 @@ describe('AddItemModal', () => {
     });
 
     expect(mockAnalyzeImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops a closed batch while the first photo is still compressing', async () => {
+    // Compression is an await gap before any request is sent. The run-id check
+    // sat above it, so closing mid-compression still spent an AI call on a
+    // photo the user had already dismissed.
+    const user = userEvent.setup();
+    mockRefreshAiEnabled.mockResolvedValue(true);
+    let releaseCompression: () => void = () => {};
+    mockCompressImageForAi.mockImplementationOnce(
+      (dataUrl: string) =>
+        new Promise((resolve) => {
+          releaseCompression = () => {
+            const idx = dataUrl.indexOf(',');
+            resolve(idx >= 0 ? dataUrl.slice(idx + 1) : dataUrl);
+          };
+        }),
+    );
+
+    const collection = createMockCollection({ name: 'Artifacts', customFields: [] });
+    const { rerender } = renderWithProviders(
+      <AddItemModal isOpen onClose={mockOnClose} collections={[collection]} onSave={mockOnSave} />,
+    );
+
+    const files = [
+      new File(['a'], 'a.png', { type: 'image/png' }),
+      new File(['b'], 'b.png', { type: 'image/png' }),
+    ];
+    const input = screen.getByTestId('add-item-batch-input') as HTMLInputElement;
+    await user.upload(input, files);
+    await screen.findByRole('heading', { name: 'Analyzing photo...' });
+    await waitFor(() => expect(mockCompressImageForAi).toHaveBeenCalled());
+    expect(mockAnalyzeImage).not.toHaveBeenCalled();
+
+    rerender(
+      <AddItemModal
+        isOpen={false}
+        onClose={mockOnClose}
+        collections={[collection]}
+        onSave={mockOnSave}
+      />,
+    );
+
+    releaseCompression();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockAnalyzeImage).not.toHaveBeenCalled();
   });
 
   it('fades the verify-step scroll edge while fields remain below the fold (CUR-45)', async () => {

--- a/tests/services/db.loadCollections.test.ts
+++ b/tests/services/db.loadCollections.test.ts
@@ -162,6 +162,29 @@ function failReadonlyTransactionsFor(storeName: string, failures = Number.POSITI
   } as IDBDatabase['transaction']);
 }
 
+// The transaction opens fine here; it is the `get()` request that fails
+// asynchronously via `onerror`. That is the realistic IndexedDB failure mode
+// (corrupt record, quota eviction mid-read) and it bypasses any guard that only
+// catches a synchronous `transaction()` throw.
+function failAsyncGetFor(storeName: string, key: string) {
+  const originalGet = IDBObjectStore.prototype.get;
+  return vi.spyOn(IDBObjectStore.prototype, 'get').mockImplementation(function (
+    this: IDBObjectStore,
+    query: any,
+  ) {
+    if (this.name === storeName && query === key) {
+      const request: any = {
+        onsuccess: null,
+        onerror: null,
+        error: new DOMException(`IndexedDB ${storeName} read failed`, 'UnknownError'),
+      };
+      setTimeout(() => request.onerror?.(new Event('error')), 0);
+      return request as IDBRequest;
+    }
+    return originalGet.call(this, query);
+  } as IDBObjectStore['get']);
+}
+
 describe('Phase 2.1 — services/db.ts loadCollections merge behavior', () => {
   beforeEach(async () => {
     if (openDb) {
@@ -497,6 +520,42 @@ describe('Phase 2.1 — services/db.ts loadCollections merge behavior', () => {
       );
     } finally {
       transactionSpy.mockRestore();
+    }
+
+    expect(itemsUpsert).not.toHaveBeenCalled();
+    await expect(dbMod.getPendingSyncIds()).resolves.toContain('col-1');
+  });
+
+  it('does not upsert stale items when the pending-delete read fails asynchronously', async () => {
+    // Regression for the async half of the tombstone guard: the settings
+    // transaction opens successfully and only the `get()` request errors. That
+    // used to resolve to an empty tombstone list — indistinguishable from
+    // "nothing is pending deletion" — letting a just-deleted item be upserted
+    // straight back into the cloud.
+    window.localStorage.removeItem('curio_pending_delete_journal');
+    const itemsUpsert = vi.fn(async () => ({ error: null }));
+    const { supabase } = createSupabaseMock({
+      collections: [],
+      items: [],
+      itemsUpsert,
+    });
+    const dbMod = await importDbModuleFresh(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const getSpy = failAsyncGetFor('settings', 'pending_deletes');
+    try {
+      await dbMod.saveCollection(
+        baseCollection({
+          id: 'col-1',
+          ownerId: 'user-123',
+          items: [baseItem({ id: 'item-hidden-by-unreadable-delete-journal' })],
+        }),
+      );
+    } finally {
+      getSpy.mockRestore();
     }
 
     expect(itemsUpsert).not.toHaveBeenCalled();

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -430,6 +430,66 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     consoleError.mockRestore();
   });
 
+  it('saveAllCollections: does not resurrect a queued deletion on an equal timestamp', async () => {
+    // Two versions that are indistinguishable by recency: a snapshot captured
+    // moments before a local item deletion carries the same collection
+    // `updatedAt`. Ties must fall to the queued local row, or the deleted item
+    // is written back and reappears on the next cache-backed startup.
+    const { supabase, collectionsUpsert } = createSupabaseMock();
+    collectionsUpsert.mockRejectedValue(new Error('offline'));
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'enhanced', 'settings']);
+
+    const sharedTimestamp = '2026-07-13T00:00:00.000Z';
+    const survivingItem: CollectionItem = {
+      id: 'item-kept',
+      collectionId: 'col-pending',
+      photoUrl: 'asset',
+      title: 'Kept',
+      rating: 4,
+      data: {},
+      createdAt: sharedTimestamp,
+      updatedAt: sharedTimestamp,
+      notes: '',
+    };
+
+    // Local state after the deletion: the item is gone, but `updatedAt` matches
+    // the snapshot's.
+    await dbMod.saveCollection({
+      id: 'col-pending',
+      templateId: 'vinyl',
+      name: 'Queued deletion',
+      icon: 'C',
+      customFields: [],
+      items: [survivingItem],
+      ownerId: 'test-user-id',
+      updatedAt: sharedTimestamp,
+    });
+
+    await dbMod.saveAllCollections([
+      {
+        id: 'col-pending',
+        templateId: 'vinyl',
+        name: 'Queued deletion',
+        icon: 'C',
+        customFields: [],
+        items: [survivingItem, { ...survivingItem, id: 'item-deleted', title: 'Deleted' }],
+        ownerId: 'test-user-id',
+        updatedAt: sharedTimestamp,
+      },
+    ]);
+
+    const stored = await readFromStore<UserCollection>(db, 'collections', 'col-pending');
+    expect(stored?.items.map((item) => item.id)).toEqual(['item-kept']);
+
+    consoleError.mockRestore();
+  });
+
   it('saveCollection: invalid collection object (missing id) rejects and does not attempt cloud writes', async () => {
     /**
      * Error case: IndexedDB keyPath is `id`; objects without `id` should fail local persistence,

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -484,13 +484,47 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
       getSpy.mockRestore();
     }
 
-    const journal = JSON.parse(window.localStorage.getItem('curio_pending_delete_journal') || '[]');
-    expect(journal).toEqual([
-      expect.objectContaining({ type: 'item', collectionId: 'col-1', itemId: 'item-deleted' }),
-    ]);
+    // Once reads recover the tombstone is back in the canonical queue, so the
+    // retry path can still delete it from the cloud.
     await expect(dbMod.getPendingDeletes()).resolves.toEqual([
       expect.objectContaining({ type: 'item', collectionId: 'col-1', itemId: 'item-deleted' }),
     ]);
+
+    consoleWarn.mockRestore();
+  });
+
+  it('deleteCloudItem: does not erase existing tombstones when the queue read fails', async () => {
+    // The recovery path must not rewrite the queue from a guessed base: the
+    // entries it could not read are exactly the ones a blind rewrite destroys,
+    // which would let their cloud rows survive and reappear on a later refresh.
+    const { supabase } = createSupabaseMock();
+    supabase.auth.getUser = vi.fn().mockResolvedValue({ data: { user: null }, error: null });
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'enhanced', 'settings']);
+
+    // An older tombstone is already queued, and the journal is gone — so the
+    // IndexedDB queue is the only copy of it.
+    await dbMod.addToPendingDeletes({
+      type: 'item',
+      collectionId: 'col-1',
+      itemId: 'item-older',
+      createdAt: '2026-07-13T00:00:00.000Z',
+    });
+    window.localStorage.removeItem('curio_pending_delete_journal');
+
+    const getSpy = failAsyncGetFor('settings', 'pending_deletes');
+    try {
+      await expect(dbMod.deleteCloudItem('col-1', 'item-newer')).resolves.toBeUndefined();
+    } finally {
+      getSpy.mockRestore();
+    }
+
+    const queued = await dbMod.getPendingDeletes();
+    expect(queued.map((entry: any) => entry.itemId).sort()).toEqual(['item-newer', 'item-older']);
 
     consoleWarn.mockRestore();
   });

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -360,6 +360,76 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     consoleError.mockRestore();
   });
 
+  it('saveAllCollections: does not overwrite a pending local edit present in a stale snapshot', async () => {
+    // The sibling case to the test above. There, the queued collection was
+    // absent from the snapshot; here it is present but at an older revision.
+    // The snapshot must not be written over the newer queued row, and the newly
+    // added item's blobs must survive orphan cleanup.
+    const { supabase, collectionsUpsert } = createSupabaseMock();
+    collectionsUpsert.mockRejectedValue(new Error('offline'));
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'enhanced', 'settings']);
+
+    const makeItem = (id: string, title: string): CollectionItem => ({
+      id,
+      collectionId: 'col-pending',
+      photoUrl: 'asset',
+      title,
+      rating: 4,
+      data: {},
+      createdAt: '2026-07-13T00:00:00.000Z',
+      updatedAt: '2026-07-13T00:00:00.000Z',
+      notes: '',
+    });
+
+    // The user's latest local edit: renamed, plus a second item added.
+    await dbMod.saveCollection({
+      id: 'col-pending',
+      templateId: 'vinyl',
+      name: 'Renamed locally',
+      icon: 'C',
+      customFields: [],
+      items: [makeItem('item-original', 'Original'), makeItem('item-added', 'Added while syncing')],
+      ownerId: 'test-user-id',
+      updatedAt: '2026-07-13T12:00:00.000Z',
+    });
+    for (const itemId of ['item-original', 'item-added']) {
+      await dbMod.saveAsset(
+        'col-pending',
+        itemId,
+        new Blob(['orig'], { type: 'image/jpeg' }),
+        new Blob(['display'], { type: 'image/jpeg' }),
+      );
+    }
+
+    // A background refresh finishes with a snapshot taken before that edit.
+    await dbMod.saveAllCollections([
+      {
+        id: 'col-pending',
+        templateId: 'vinyl',
+        name: 'Stale name from cloud',
+        icon: 'C',
+        customFields: [],
+        items: [makeItem('item-original', 'Original')],
+        ownerId: 'test-user-id',
+        updatedAt: '2026-07-13T00:00:00.000Z',
+      },
+    ]);
+
+    const stored = await readFromStore<UserCollection>(db, 'collections', 'col-pending');
+    expect(stored?.name).toBe('Renamed locally');
+    expect(stored?.items.map((item) => item.id)).toEqual(['item-original', 'item-added']);
+    expect(await readFromStore<Blob>(db, 'assets', 'item-added')).toBeTruthy();
+    expect(await readFromStore<Blob>(db, 'display', 'item-added')).toBeTruthy();
+
+    consoleError.mockRestore();
+  });
+
   it('saveCollection: invalid collection object (missing id) rejects and does not attempt cloud writes', async () => {
     /**
      * Error case: IndexedDB keyPath is `id`; objects without `id` should fail local persistence,

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -97,6 +97,13 @@ function createSupabaseMock() {
     return chain;
   });
 
+  const itemsDelete = vi.fn(() => {
+    const chain: any = { error: null };
+    chain.eq = vi.fn().mockReturnValue(chain);
+    chain.then = (resolve: (value: { error: null }) => unknown) => resolve({ error: null });
+    return chain;
+  });
+
   const from = vi.fn((table: string) => {
     const upsertForTable =
       table === 'collections'
@@ -107,6 +114,7 @@ function createSupabaseMock() {
     return {
       upsert: upsertForTable,
       update,
+      delete: itemsDelete,
       select: vi.fn(() => ({
         eq: vi.fn(() => ({ maybeSingle: itemsMaybeSingle })),
       })),
@@ -130,9 +138,31 @@ function createSupabaseMock() {
     itemsUpsert,
     itemImagesUpsert,
     itemsMaybeSingle,
+    itemsDelete,
     upload,
     from,
   };
+}
+
+// Opens the transaction normally and fails only the `get()` request, matching a
+// transient IndexedDB read failure (corrupt record, eviction mid-read).
+function failAsyncGetFor(storeName: string, key: string) {
+  const originalGet = IDBObjectStore.prototype.get;
+  return vi.spyOn(IDBObjectStore.prototype, 'get').mockImplementation(function (
+    this: IDBObjectStore,
+    query: any,
+  ) {
+    if (this.name === storeName && query === key) {
+      const request: any = {
+        onsuccess: null,
+        onerror: null,
+        error: new DOMException(`IndexedDB ${storeName} read failed`, 'UnknownError'),
+      };
+      setTimeout(() => request.onerror?.(new Event('error')), 0);
+      return request as IDBRequest;
+    }
+    return originalGet.call(this, query);
+  } as IDBObjectStore['get']);
 }
 
 async function importDbModuleFreshWithSupabaseMock(
@@ -428,6 +458,41 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     expect(await readFromStore<Blob>(db, 'display', 'item-added')).toBeTruthy();
 
     consoleError.mockRestore();
+  });
+
+  it('deleteCloudItem: still records the tombstone when the queue read fails', async () => {
+    // The guard path must abort on an unreadable tombstone queue, but the append
+    // path must not: the item is already gone locally by the time this runs and
+    // deleteItem swallows the failure, so refusing to queue would lose the
+    // deletion outright — no tombstone, no cloud delete, item back on refresh.
+    const { supabase } = createSupabaseMock();
+    // No session, so the cloud delete cannot complete and the tombstone has to
+    // survive for a later retry — the state Codex flagged as lost.
+    supabase.auth.getUser = vi.fn().mockResolvedValue({ data: { user: null }, error: null });
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'enhanced', 'settings']);
+    window.localStorage.removeItem('curio_pending_delete_journal');
+
+    const getSpy = failAsyncGetFor('settings', 'pending_deletes');
+    try {
+      await expect(dbMod.deleteCloudItem('col-1', 'item-deleted')).resolves.toBeUndefined();
+    } finally {
+      getSpy.mockRestore();
+    }
+
+    const journal = JSON.parse(window.localStorage.getItem('curio_pending_delete_journal') || '[]');
+    expect(journal).toEqual([
+      expect.objectContaining({ type: 'item', collectionId: 'col-1', itemId: 'item-deleted' }),
+    ]);
+    await expect(dbMod.getPendingDeletes()).resolves.toEqual([
+      expect.objectContaining({ type: 'item', collectionId: 'col-1', itemId: 'item-deleted' }),
+    ]);
+
+    consoleWarn.mockRestore();
   });
 
   it('saveAllCollections: does not resurrect a queued deletion on an equal timestamp', async () => {


### PR DESCRIPTION
## Problem

Three Codex review threads landed on #355, #378 and #395 after those PRs were merged, so the findings never got addressed. I verified each against the code rather than taking the bot at its word — all three were real. Reviewing the fixes then surfaced three more findings, each fixed in its own commit below.

Every fix has a regression test that **fails without it**, verified by reverting the source change and re-running.

## Commit 1 — the three original findings (`925f4a7`)

**#355 (P1) — a stale full-cache save could drop a local edit.** `saveAllCollections` checked the pending-sync queue only in its *delete* loop. For a collection already in the snapshot the loop hit `if (newIds.has(collection.id)) return;` and never reached the pending check, after which `store.put(col)` wrote the snapshot over the queued row. The asset whitelist tracked the snapshot version, so `cleanupOrphanedAssets` then purged blobs for items the edit had added. Fixed by gating the `put` on recency, with the whitelist following the version actually stored.

Recency, not the pending flag, is the discriminator. My first attempt preferred the local row whenever it was pending, which broke the existing `does not upsert an item removed locally while an older cloud save is in flight` test — a full-cache save also legitimately carries *newer* state for a still-pending collection. That test caught the overreach.

**#395 (P1) — the tombstone guard could not fire.** `readPendingDeletesFromIndexedDb` resolved `[]` when the settings `get()` errored, indistinguishable from "nothing pending". The guard only catches throws, so a failed read let a just-deleted item be upserted back into Supabase. Fixed by rejecting on request error and transaction abort. The test shipped with #395 covered only a *synchronous* `transaction()` throw, so this needed a new `failAsyncGetFor` helper that opens the transaction and fails just the request.

**#378 (P2) — closing mid-compression still spent an AI request.** The batch loop checked the run id at the top of each iteration but not after `await compressImageForAi(...)`. The single-photo path had the identical gap; both now recheck after the await.

## Commit 2 — equal timestamps (`473452f`)

The strict newer-than check still let an equal-timestamp snapshot overwrite a queued edit, and a local item deletion produced exactly that tie: `deleteItem` was the outlier among the mutations, rebuilding the collection without moving `updatedAt` (`updateItem` and `updateCollection` both bump it). A deletion was therefore invisible to *every* timestamp comparison downstream, cloud merge included.

Fixed at the root — `deleteItem` now bumps like its siblings — plus defence in depth: ties fall to the queued local row, since equal timestamps make the versions indistinguishable by recency and the local one is the copy flagged as holding unsynced work.

## Commit 3 — the append path (`ca160bb`)

Making the tombstone read fatal was right for the sync guard and wrong for the append path, and I had applied it to both. `deleteCloudItem` queues the tombstone *before* the network call precisely to prevent resurrection; the rejection aborted it there, and `deleteItem`'s caller swallows the error. Result: item gone locally, no tombstone, cloud delete never attempted.

The two callers want opposite things from the same read, so they were split: `getPendingDeletes` still rejects for guards, while the append path degrades.

## Commit 4 — additive recovery records (`1fd8209`)

That degraded path still rewrote the queue from a guessed base, so with the journal absent and IndexedDB unreadable it wrote a list containing only the new entry over both stores, erasing older tombstones.

Fixed properly: recovery records are written **one-per-key** under a `pending_delete_recovery:` prefix. The write is blind and additive, so it cannot destroy a queue it could not read; the key derives from the entry's identity so a repeated delete overwrites its own record; and `getPendingDeletes` folds them into the canonical queue and clears them once reads recover, keeping the guard's view complete.

## Testing

Six regression tests, each verified to fail without its fix:

```
× stops a closed batch while the first photo is still compressing
× does not upsert stale items when the pending-delete read fails asynchronously
× saveAllCollections: does not overwrite a pending local edit present in a stale snapshot
× saveAllCollections: does not resurrect a queued deletion on an equal timestamp
× deleteCloudItem: still records the tombstone when the queue read fails
× deleteCloudItem: does not erase existing tombstones when the queue read fails
```

Full gate:

- `npm run format:check` — pass
- `npm test` — 1049 passed, 2 skipped, 1 todo
- `npm run build` — pass
- `npm run test:e2e` — 44 passed, 8 skipped

## Risks

Behavioural change on the sync and deletion paths, all in the conservative direction: prefer not losing local work, abort rather than sync on unverifiable state, and never rewrite a queue that could not be read. The blast radius of the `getPendingDeletes` rejection is its four call sites; the one fire-and-forget caller (`void syncPendingDeletes()` in the reconnect handler) now has a `.catch()` so the rejection cannot surface as an unhandled rejection.

Worth a careful read despite the green gate: this touches IndexedDB and Supabase write paths where a regression is silent, and three of the six findings here came from reviewing the fixes rather than the original code.

## Rollback plan

`git revert 1fd8209 ca160bb 473452f 925f4a7` (or revert the merge commit). No data, schema, storage, or config involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2x5FF1rQUyDiKWHdUeAL5)_