### PR TITLE
[#411] Consolidate the sample collection read-only notice

### DIFF
--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -295,6 +295,11 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
               {t('readOnlyMode')}
             </p>
             <p className="text-xs text-stone-500">{t('readOnlyCollectionDesc')}</p>
+            {!isAuthenticated && (
+              <p className="text-xs font-semibold text-amber-600 mt-1">
+                {t('readOnlyCollectionEditHint')}
+              </p>
+            )}
           </div>
         </div>
       )}
@@ -497,10 +502,6 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
             {t('clearAll')}
           </button>
         </div>
-      )}
-
-      {isReadOnly && (
-        <p className="text-sm text-amber-600 font-semibold">{t('readOnlyCollectionNote')}</p>
       )}
 
       {isSelectionMode && (

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -347,7 +347,7 @@ export const translations = {
     importing: 'Importing...',
     importComplete: 'Import complete.',
     importFailed: 'Import failed. Please try again.',
-    readOnlyCollectionNote: 'Public samples are read-only. Sign in to duplicate or edit.',
+    readOnlyCollectionEditHint: 'Sign in to duplicate or edit.',
     readOnlyControls: 'Edits disabled in read-only mode.',
     account: 'Account',
     // Field Labels
@@ -904,7 +904,7 @@ export const translations = {
     importing: '正在导入...',
     importComplete: '导入完成。',
     importFailed: '导入失败，请重试。',
-    readOnlyCollectionNote: '公开示例为只读，登录或复制后可编辑。',
+    readOnlyCollectionEditHint: '登录后可复制或编辑。',
     readOnlyControls: '只读模式下不可编辑。',
     account: '账户',
     // Field Labels

--- a/tests/components/CollectionScreen.test.tsx
+++ b/tests/components/CollectionScreen.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
@@ -42,7 +43,10 @@ function makeItem(id: string) {
   };
 }
 
-function renderScreen(collection: UserCollection) {
+function renderScreen(
+  collection: UserCollection,
+  overrides: Partial<ComponentProps<typeof CollectionScreen>> = {},
+) {
   const props = {
     collections: [collection],
     isAdmin: false,
@@ -55,6 +59,7 @@ function renderScreen(collection: UserCollection) {
     deleteItem: vi.fn(() => true),
     removeCollection: vi.fn(async () => {}),
     showStatus: vi.fn(),
+    ...overrides,
   };
   return render(
     <MemoryRouter initialEntries={[`/collection/${collection.id}`]}>
@@ -97,5 +102,42 @@ describe('CollectionScreen action bar (CUR-160)', () => {
     expect(screen.getByRole('button', { name: /filter collection/i })).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/search this collection/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /delete collection/i })).toBeInTheDocument();
+  });
+});
+
+describe('CollectionScreen read-only notice consolidation (#411)', () => {
+  it('shows a single read-only notice with a sign-in next step when signed out', () => {
+    renderScreen(makeCollection({ isPublic: true, items: [makeItem('a')] }), {
+      isAuthenticated: false,
+    });
+
+    // One consolidated notice: the boxed banner, carrying both the read-only
+    // explanation and the actionable sign-in hint.
+    const banner = screen.getByTestId('read-only-banner');
+    expect(banner).toHaveTextContent(/can be viewed but not edited/i);
+    expect(banner).toHaveTextContent(/sign in to duplicate or edit/i);
+
+    // The old redundant amber line must be gone (no second notice).
+    expect(screen.queryByText(/public samples are read-only/i)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('read-only-banner')).toHaveLength(1);
+  });
+
+  it('omits the sign-in hint for an already signed-in non-admin viewer', () => {
+    renderScreen(makeCollection({ isPublic: true, items: [makeItem('a')] }), {
+      isAuthenticated: true,
+    });
+
+    const banner = screen.getByTestId('read-only-banner');
+    expect(banner).toHaveTextContent(/can be viewed but not edited/i);
+    // Telling a signed-in user to "sign in" would be inaccurate, so the hint
+    // is withheld — but the collection is still clearly labelled read-only.
+    expect(banner).not.toHaveTextContent(/sign in to duplicate or edit/i);
+  });
+
+  it('shows no read-only notice on an editable own collection', () => {
+    renderScreen(makeCollection({ isPublic: false, items: [makeItem('a')] }));
+
+    expect(screen.queryByTestId('read-only-banner')).not.toBeInTheDocument();
+    expect(screen.queryByText(/sign in to duplicate or edit/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/e2e/first-time-user.spec.ts
+++ b/tests/e2e/first-time-user.spec.ts
@@ -78,6 +78,9 @@ test.describe('First-Time User Experience', () => {
     await expect(
       page.getByTestId('read-only-banner').getByText(/Public sample collections can be viewed/i),
     ).toBeVisible();
+    // #411: the notice is consolidated into the single banner — the old
+    // redundant "Public samples are read-only…" line must not also render.
+    await expect(page.getByText(/Public samples are read-only/i)).toHaveCount(0);
     await expect(page.getByRole('button', { name: /add item/i })).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Problem

Opening the public sample collection (**The Vinyl Vault**) signed out showed **two** overlapping read-only messages within the same viewport:

1. A boxed banner at the top: **"Read-only — Public sample collections can be viewed but not edited."**
2. A redundant amber line above the item grid: **"Public samples are read-only. Sign in to duplicate or edit."**

On the strongest pre-auth conversion screen this reads as visual noise and buries the collection itself. It protects Curio's **read-only clarity** MVP constraint and the **beauty before bureaucracy** principle (one clear affordance, not two saying almost the same thing in two tones). Ref: #411.

## Approach

- `src/components/CollectionScreen.tsx`: fold the actionable next step into the single boxed banner and remove the redundant amber `readOnlyCollectionNote` line above the grid. The sign-in hint renders inside the banner only when `!isAuthenticated`.
- `src/i18n.ts`: replaced `readOnlyCollectionNote` with a concise `readOnlyCollectionEditHint` ("Sign in to duplicate or edit." / "登录后可复制或编辑。") in both EN and ZH.
- Tests: added three `CollectionScreen` cases (signed-out shows one banner + hint and no second notice; signed-in non-admin shows the banner without the sign-in hint; own editable collection shows no notice) and one E2E assertion pinning that the old redundant line no longer renders.

## Why this approach

The boxed banner is the more polished, accessible, already-tested element (icon, `data-testid="read-only-banner"`), so keeping it and dropping the plain line yields the single, clearest affordance the issue asks for. Gating the sign-in hint on `!isAuthenticated` is more accurate than the old unconditional copy — an already signed-in non-admin is no longer told to "sign in." No visual tokens, data, or permission logic change.

## Risks

Low. Presentational + copy only, gated by the existing `isReadOnly` / `isAuthenticated` flags. Read-only labelling is preserved (E2E still asserts the banner), editable own collections remain notice-free, and no data/sync/auth behaviour changes.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-uotiy5-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview signed out → **Explore** → the sample collection loads.
2. Confirm only the boxed **Read-only** banner appears (with the "Sign in to duplicate or edit." hint inside it) and the separate amber line above the grid is gone.
3. Sign in as a non-admin and open a public collection → banner still labels it read-only, without the "sign in" hint.
4. Open your own collection → no read-only notice.

Checks:
- [x] npm run format:check
- [x] npm test (1065 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed)

## Screenshot / GIF

No visual token or layout change — this removes one redundant text notice and moves the "Sign in to duplicate or edit." hint into the existing banner. Behaviour is covered by the new `CollectionScreen` tests and the updated first-time-user E2E; see the Vercel preview above for the live result.

## Linear

Closes #411

## Rollback plan

Not required for Green tier. If needed: `git revert 7dadb0c` — the change is isolated to `CollectionScreen.tsx` and the two i18n keys.