### PR TITLE
[CUR-412] Describe Rapid-Fire Mode on the Add Item upload step

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1220,13 +1220,16 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
             {t('editPhoto')}
           </Button>
         )}
-        <Button
-          variant="secondary"
-          onClick={() => batchInputRef.current?.click()}
-          icon={<Zap size={18} />}
-        >
-          {t('batchMode')}
-        </Button>
+        <div className="flex flex-col gap-1.5">
+          <Button
+            variant="secondary"
+            onClick={() => batchInputRef.current?.click()}
+            icon={<Zap size={18} />}
+          >
+            {t('batchMode')}
+          </Button>
+          <p className={`text-xs text-center ${mutedText}`}>{t('batchModeDesc')}</p>
+        </div>
         <button
           onClick={switchToManual}
           data-testid="add-item-skip-manual"

--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1225,10 +1225,13 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
             variant="secondary"
             onClick={() => batchInputRef.current?.click()}
             icon={<Zap size={18} />}
+            aria-describedby="add-item-batch-desc"
           >
             {t('batchMode')}
           </Button>
-          <p className={`text-xs text-center ${mutedText}`}>{t('batchModeDesc')}</p>
+          <p id="add-item-batch-desc" className={`text-xs text-center ${mutedText}`}>
+            {t('batchModeDesc')}
+          </p>
         </div>
         <button
           onClick={switchToManual}

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -480,6 +480,22 @@ describe('AddItemModal', () => {
     expect(screen.getByText('Sneaker Gallery')).toBeInTheDocument();
   });
 
+  it('describes what Rapid-Fire Mode does on the upload step', () => {
+    renderWithProviders(
+      <AddItemModal
+        isOpen
+        onClose={mockOnClose}
+        collections={[createMockCollection()]}
+        onSave={mockOnSave}
+      />,
+    );
+
+    // Single collection routes straight to the upload step.
+    expect(screen.getByRole('button', { name: 'Rapid-Fire Mode' })).toBeInTheDocument();
+    // The emphasized alternate mode is no longer label-only: it explains itself.
+    expect(screen.getByText('Process multiple items in a single session.')).toBeInTheDocument();
+  });
+
   it('processes a batch upload and renders the analyzed item', async () => {
     const user = userEvent.setup();
     mockRefreshAiEnabled.mockResolvedValue(true);

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -491,9 +491,13 @@ describe('AddItemModal', () => {
     );
 
     // Single collection routes straight to the upload step.
-    expect(screen.getByRole('button', { name: 'Rapid-Fire Mode' })).toBeInTheDocument();
-    // The emphasized alternate mode is no longer label-only: it explains itself.
-    expect(screen.getByText('Process multiple items in a single session.')).toBeInTheDocument();
+    const batchButton = screen.getByRole('button', { name: 'Rapid-Fire Mode' });
+    // The emphasized alternate mode is no longer label-only: it explains itself,
+    // and the description is programmatically associated for screen readers.
+    const description = screen.getByText('Process multiple items in a single session.');
+    expect(description).toBeInTheDocument();
+    expect(batchButton).toHaveAttribute('aria-describedby', description.id);
+    expect(description.id).toBeTruthy();
   });
 
   it('processes a batch upload and renders the analyzed item', async () => {


### PR DESCRIPTION
## Problem

On the Add Item modal's upload step, three actions compete: **Upload Photo** (with the subtitle "Add a photo and Gemini will suggest the details."), **Rapid-Fire Mode** (a visually emphasized amber secondary button with **no** description), and **Skip and add manually** (a self-explanatory text link). Rapid-Fire Mode was the only emphasized option besides the primary, yet a first-time user had no way to know what it does before committing to it — friction at the exact moment the product wants a fast, confident "add my first item." Protects Curio's **beauty before bureaucracy** (one clear hierarchy of affordances) and **trust** (controls should be legible about what they do). Ref: #412.

## Approach

- `src/components/AddItemModal.tsx`: wrap the Rapid-Fire button and a one-line caption in a tight `flex flex-col gap-1.5` container, rendering the existing `batchModeDesc` string ("Process multiple items in a single session.") directly beneath the button — mirroring the primary Upload Photo subtitle.
- Reuses the already-localized `batchModeDesc` key (EN + ZH), the same copy shown on the batch verify banner, so the button and the screen it opens describe the mode identically. No new strings to translate.
- Test: added an `AddItemModal` case asserting the Rapid-Fire button and its description both render on the upload step.

## Why this approach

Reusing `batchModeDesc` is the smallest taste-aligned fix: it's accurate to the mode's behaviour, already translated, and creates continuity between the button and the verify screen it leads to. Placement beneath the button restores the clear three-option hierarchy the issue asks for without touching any visual token, layout system, or data flow.

## Risks

Low. Presentational + copy-reuse only. No new i18n keys, no behaviour change, no visual-token change; the Rapid-Fire input, batch flow, and manual-skip fallback are untouched. AI remains non-blocking and the manual path is unaffected.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-femd07-qs-projects-72b20d9d.vercel.app

Steps:
1. Sign in and start Add Item (bottom-nav **Add**, or a collection's **Add Item**).
2. On the upload step, confirm **Rapid-Fire Mode** now shows the caption "Process multiple items in a single session." directly beneath it.
3. Switch language to 中文 and confirm the caption localizes ("在一次会话中处理多件藏品。").
4. Confirm the three options still read as primary upload → described alternate mode → manual skip.

Checks:
- [x] npm run format:check
- [x] npm test (1063 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed)

## Screenshot / GIF

No visual-token or layout-system change — this adds one muted caption line beneath the existing Rapid-Fire button. Behaviour is covered by the new `AddItemModal` test; see the Vercel preview for the live result.

## Linear

Closes #412

## Rollback plan

Not required for Green tier. If needed: `git revert` the single commit — the change is isolated to the Rapid-Fire block in `AddItemModal.tsx` and one test.