### PR TITLE
[CURIO-410] Add a desktop header Add-item entry point

### DIFF
--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -343,6 +343,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
                 onClick={() => openAddItemModal(collection.id)}
                 icon={<Plus size={16} />}
                 className="shadow-md flex-1 sm:flex-none sm:w-auto"
+                data-testid="collection-add-item"
               >
                 {t('addItem')}
               </Button>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from '../i18n';
+import { Button } from './ui/Button';
 import { ThemeQuickToggle } from './ThemeQuickToggle';
 import { useTheme, cardSurfaceClasses, dividerClasses } from '../theme';
 import { AppTheme } from '../types';
@@ -391,6 +392,28 @@ export const Layout: React.FC<LayoutProps> = ({
           </Link>
 
           <nav className="flex items-center gap-2 justify-end">
+            {/* CUR-410: the global Add-item affordance lived only on the mobile
+                bottom-nav Add pill (`sm:hidden`), so a signed-in desktop user on
+                the home screen had no way to add an item without first drilling
+                into a collection. This mirrors that pill on desktop widths
+                (`hidden sm:inline-flex`, so the two never overlap) using the
+                same `onAddItem` handler, which already routes through auth /
+                collection-picker gating. Gated on `isAuthenticated` to keep the
+                pre-auth first run single-path — signed-out users still land on
+                the access gate's one primary CTA. */}
+            {isAuthenticated && onAddItem && (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={onAddItem}
+                icon={<Plus size={14} strokeWidth={2.5} />}
+                className="hidden sm:inline-flex motion-fade"
+                data-testid="header-add-item"
+              >
+                {t('addItem')}
+              </Button>
+            )}
+
             {headerExtras}
 
             <ThemeQuickToggle />

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -668,6 +668,38 @@ describe('Layout Component', () => {
     });
   });
 
+  describe('CUR-410 Desktop header Add-item entry point', () => {
+    const authenticatedUser = { id: 'user-1', email: 'test@example.com' };
+
+    it('renders a desktop Add Item button for signed-in users', () => {
+      renderWithProviders(
+        <Layout {...defaultProps} user={authenticatedUser} onAddItem={vi.fn()} />,
+      );
+
+      const addButton = screen.getByTestId('header-add-item');
+      expect(addButton).toHaveTextContent('Add Item');
+      // Hidden on mobile so it never overlaps the bottom-nav Add pill.
+      expect(addButton.className).toContain('hidden');
+      expect(addButton.className).toContain('sm:inline-flex');
+    });
+
+    it('calls onAddItem when the desktop Add Item button is clicked', () => {
+      const onAddItem = vi.fn();
+      renderWithProviders(
+        <Layout {...defaultProps} user={authenticatedUser} onAddItem={onAddItem} />,
+      );
+
+      fireEvent.click(screen.getByTestId('header-add-item'));
+      expect(onAddItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the desktop Add Item button when signed out', () => {
+      renderWithProviders(<Layout {...defaultProps} user={null} onAddItem={vi.fn()} />);
+
+      expect(screen.queryByTestId('header-add-item')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Theme Support', () => {
     describe.each([
       { theme: 'gallery' as const, bgPattern: /bg-white/, description: 'light background' },

--- a/tests/e2e/authenticated-user.spec.ts
+++ b/tests/e2e/authenticated-user.spec.ts
@@ -55,8 +55,10 @@ test.describe('Authenticated User Experience', () => {
     await expect(page.getByText('E2E Collection')).toBeVisible({ timeout: 15000 });
     await page.getByText('E2E Collection').click();
 
-    // Add item (manual path — recoverable AI)
-    await page.getByRole('button', { name: /add item/i }).click();
+    // Add item (manual path — recoverable AI). Target the in-screen CTA by
+    // testid: on desktop the global header Add Item button (CUR-410) shares the
+    // same accessible name, so a name-based locator is ambiguous here.
+    await page.getByTestId('collection-add-item').click();
     await page.getByText(/skip and add manually/i).click();
 
     const title = page.getByRole('textbox').first();
@@ -88,7 +90,7 @@ test.describe('Authenticated User Experience', () => {
     await expect(page.getByText(name).first()).toBeVisible({ timeout: 15000 });
     await page.getByText(name).first().click();
 
-    await page.getByRole('button', { name: /add item/i }).click();
+    await page.getByTestId('collection-add-item').click();
     await page.getByText(/skip and add manually/i).click();
 
     await page.getByRole('textbox').first().fill('CUR-142 Item');


### PR DESCRIPTION
## Problem

On mobile, a persistent bottom-nav **Add** pill opens the Add Item flow from anywhere. On **desktop**, a signed-in user on the home ("Your museum") screen had **no** global add-item affordance — the header showed only Explore / language / theme / account controls. To add an item you first had to drill into a specific collection and use its in-screen **Add Item** button. Adding an item is the product's core action, so its entry point being inconsistent across breakpoints is friction on the primary loop ("Add your first item in under 5 minutes"). Protects **beauty before bureaucracy** (a clear, consistent primary affordance) and the sub-5-minute add-item constraint.

Ref: #410. `onAddItem` (the global Add handler) was wired only to the mobile bottom-nav Add pill in `src/components/Layout.tsx`, inside the `sm:hidden` bottom nav.

## Approach

- `src/components/Layout.tsx`: render a primary **Add Item** `Button` in the header nav, shown on desktop widths only (`hidden sm:inline-flex`, so it never overlaps the mobile bottom-nav Add pill, which is `sm:hidden`). It calls the same `onAddItem` handler and is gated on `isAuthenticated`.
- Reuses the existing `addItem` i18n key ("Add Item" / "添加藏品") and the shared `Button` component — no new strings, no new visual tokens.
- Tests: three `Layout` cases — the desktop button renders (with the correct responsive classes) for signed-in users, clicking it calls `onAddItem`, and it is absent when signed out.

## Why this approach

`onAddItem` (`handleAddAction`) already routes through the auth prompt, the "no collections yet → create one" path, and the collection picker, so mirroring the mobile pill needs no new logic — just a desktop-visible trigger. Gating on `isAuthenticated` keeps the pre-auth first run single-path (signed-out users still land on the access gate's one primary CTA) rather than adding a competing header CTA. Reusing the `Button` component and existing string keeps it visually and linguistically consistent with the rest of the header.

## Risks

Low. Presentational only — no data, sync, routing, or permission logic changes; the click handler is the exact one the mobile pill already uses. The desktop button and the mobile pill are on mutually exclusive breakpoints, so there is no duplicate affordance. Read-only, sample-gallery pre-login access, and the AI-optional manual path are all untouched.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-sgokwg-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview and sign in on a desktop-width viewport (≥640px).
2. On the home ("Your museum") screen, confirm a primary **Add Item** button now sits in the header; click it and confirm the Add Item flow opens (collection picker, or create-collection if you have none).
3. Narrow to a mobile width: the header button disappears and the bottom-nav **Add** pill takes over — no duplicate.
4. Sign out: the header **Add Item** button is not shown.

Checks:
- [x] npm run format:check
- [x] npm test (1065 passed, 2 skipped)
- [x] npm run build
- [x] npm run test:e2e (44 passed)

## Screenshot / GIF

No new visual tokens or layout system — this places the shared primary `Button` (same styling as the existing header "Explore" secondary button) into the header on desktop. The signed-in desktop state requires Supabase auth, which isn't available in this headless environment, so the live result is best seen on the Vercel preview above; rendering and responsive gating are pinned by the new `Layout` tests.

## Linear

Closes #410

## Rollback plan

Not required for Green tier. If needed: `git revert 11a39e3` — the change is isolated to the header Add-item block in `Layout.tsx` and its tests.