### PR TITLE
[CURIO-376] Ignore local .env files so secrets can't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ dist
 dist-ssr
 *.local
 
+# Local env files — never commit real secrets. Keep the tracked template
+# (.env.example) so contributors know which variables to set.
+.env
+.env.*
+!.env.example
+
 # Test coverage
 coverage
 


### PR DESCRIPTION
## Problem

`.gitignore` ignored `.env.local` (matched by the existing `*.local` rule) but **not** `.env`, `.env.production`, or `server/.env`. A contributor who creates a real `.env` (the file `CLAUDE.md` and `.env.example` tell them to create, holding `VITE_SUPABASE_*` keys, and `server/.env` holding `GEMINI_API_KEY`) could commit it by accident — secrets are committable today. This protects Curio's **Trust before growth** principle at the repository level. Ref: #376.

Verified before the fix:

| File | Before |
| --- | --- |
| `.env` | **NOT ignored** |
| `.env.production` | **NOT ignored** |
| `server/.env` | **NOT ignored** |
| `.env.local` | ignored (via `*.local`) |
| `.env.example` | tracked (correct) |

## Approach

- `.gitignore`: add a dedicated block that ignores `.env` and all `.env.*` variants at any depth, with a `!.env.example` negation so the tracked template stays visible:

  ```gitignore
  # Local env files — never commit real secrets. Keep the tracked template
  # (.env.example) so contributors know which variables to set.
  .env
  .env.*
  !.env.example
  ```

Patterns without a slash match at every directory level, so `.env` also covers `server/.env`. No `.env` file is created, modified, or removed — only the ignore rules change.

## Why this approach

It's the smallest complete fix: three ignore lines plus a negation close every uncovered `.env` variant while keeping `.env.example` tracked so onboarding still shows the required variables. No code, no runtime behavior, no product surface touched.

## Risks

Low. Config-only change to `.gitignore`. The only currently-tracked env file, `.env.example`, is explicitly re-included and remains tracked (verified it still appears in `git ls-files` and `git status`). Nothing in the app reads `.gitignore`, so build/test/e2e behavior is unchanged.

## How to verify

Vercel Preview: n/a — `.gitignore`-only change produces no user-visible or deployable difference (nothing for a preview to show).

Steps:
1. `git check-ignore .env .env.production server/.env` → all report **ignored**.
2. `git check-ignore .env.example` → **not** ignored; `git ls-files | grep '^.env'` still lists `.env.example`.
3. `printf 'GEMINI_API_KEY=x\n' > .env && git status --porcelain` → `.env` does **not** appear; `rm .env`.

Checks:
- [x] npm run format:check (passed)
- [x] npm test (1066 passed, 2 skipped)
- [x] npm run build (passed)
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

n/a — no user-visible change.

## Linear

Closes #376

## Rollback plan

Not required for Green tier. If needed: `git revert ccb12ae` — the change is isolated to the new env block in `.gitignore`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4GEezuP3pSRVg9oSEXQZP)_