### PR TITLE
[#372] Give item-detail story and metadata fields accessible names

### DIFF
--- a/src/components/ItemDetailScreen.tsx
+++ b/src/components/ItemDetailScreen.tsx
@@ -784,6 +784,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
               <div className={`flex flex-wrap items-center gap-3 ${accentColorClasses[theme]}`}>
                 <Quote size={18} fill="currentColor" className="opacity-20 sm:w-5 sm:h-5" />
                 <dt
+                  id="item-story-label"
                   className={`min-w-0 ${typographyClasses.label} ${labelColorClasses[theme]} break-words`}
                 >
                   {t('story')}
@@ -859,6 +860,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                     ) : (
                       <textarea
                         ref={detailStoryRef}
+                        aria-labelledby="item-story-label"
                         className={`w-full p-6 sm:p-8 rounded-2xl sm:rounded-[2.5rem] italic border font-serif text-xl sm:text-2xl leading-relaxed min-h-[200px] sm:min-h-[240px] focus:ring-8 focus:ring-amber-500/30 focus:border-amber-500 outline-none transition-all shadow-inner placeholder:text-stone-400 ${theme === 'vault' ? 'bg-white/5 border-white/5 text-white' : 'bg-stone-50/50 border-stone-100 text-stone-800'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`}
                         value={item.notes}
                         onChange={(e) => applyItemUpdate({ notes: e.target.value })}
@@ -962,6 +964,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                   return (
                     <div key={field.id} className="group">
                       <dt
+                        id={`item-field-label-${field.id}`}
                         className={`${typographyClasses.label} ${mutedTextClasses[theme]} mb-1 sm:mb-2 group-hover:text-amber-500 transition-colors break-words leading-tight`}
                       >
                         {label}
@@ -975,6 +978,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                           value={fieldValue}
                           placeholder="—"
                           rows={1}
+                          aria-labelledby={`item-field-label-${field.id}`}
                           aria-describedby={showHint ? `item-field-hint-${field.id}` : undefined}
                           onChange={(e) => {
                             e.currentTarget.style.height = 'auto';
@@ -988,6 +992,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                           className={fieldBaseClass}
                           value={fieldValue}
                           placeholder="—"
+                          aria-labelledby={`item-field-label-${field.id}`}
                           aria-describedby={showHint ? `item-field-hint-${field.id}` : undefined}
                           onChange={handleFieldChange}
                           disabled={isReadOnly}

--- a/tests/components/ItemDetailScreen.test.tsx
+++ b/tests/components/ItemDetailScreen.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { LanguageProvider } from '@/i18n';
+import { ItemDetailScreen } from '@/components/ItemDetailScreen';
+import { mockCollectionWithItems, mockItem } from '../utils/fixtures/collections';
+
+vi.mock('@/services/db', () => ({
+  clearEnhancedReference: vi.fn(),
+  extractCurioAssetPath: vi.fn(() => null),
+  saveAsset: vi.fn(async () => undefined),
+  getAsset: vi.fn(async () => null),
+  getEnhancedAsset: vi.fn(async () => null),
+}));
+
+vi.mock('@/services/geminiService', () => ({
+  fetchStoryPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
+  refreshAiImageEditEnabled: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@/services/analytics', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/services/analytics')>('@/services/analytics');
+  return { ...actual, trackEvent: vi.fn() };
+});
+
+// Route the real useTheme through the test-utils mock state.
+vi.mock('@/theme', async () => {
+  const { createThemeMock } = await import('../utils/test-utils');
+  return createThemeMock();
+});
+
+function renderItemDetail() {
+  const noop = vi.fn();
+  const path = `/collection/${mockCollectionWithItems.id}/item/${mockItem.id}`;
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <LanguageProvider>
+        <Routes>
+          <Route
+            path="/collection/:id/item/:itemId"
+            element={
+              <ItemDetailScreen
+                collections={[mockCollectionWithItems]}
+                isAdmin={false}
+                isLoading={false}
+                itemSaveStates={{}}
+                updateItem={noop}
+                deleteItem={vi.fn(() => true)}
+                retryItemSave={noop}
+                checkStorageQuota={vi.fn(async () => undefined)}
+                showStatus={noop}
+              />
+            }
+          />
+        </Routes>
+      </LanguageProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('ItemDetailScreen accessibility (CURIO-372)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exposes an accessible name for the story field', () => {
+    renderItemDetail();
+    expect(screen.getByRole('textbox', { name: 'Story' })).toBeInTheDocument();
+  });
+
+  it('exposes each metadata field label as its input accessible name', () => {
+    renderItemDetail();
+    // Text field → textarea; select field → input. Both should be reachable by
+    // their visible caption, not just placeholder text.
+    expect(screen.getByRole('textbox', { name: 'Artist' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Condition' })).toBeInTheDocument();
+  });
+
+  it('leaves no metadata textbox without an accessible name', () => {
+    renderItemDetail();
+    for (const box of screen.getAllByRole('textbox')) {
+      expect(box).toHaveAccessibleName();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

On the item detail screen, each field caption is rendered as a standalone `<dt>` with no programmatic association to its control. Screen-reader users focusing the **Story** textarea or any **metadata** field (e.g. 品类 / 有效期) heard placeholder text or nothing at all — only the Title field had an accessible name (`aria-label="Title"`). This is a concrete accessibility gap on the core editing surface, and it protects Curio's **trust before growth** principle (controls should be legible about what they are).

Ref: #372. The issue has two acceptance criteria for inputs; the auth-modal half (email/password accessible names) was already resolved via native `<label htmlFor>` associations in prior work (#398 / CUR-62). This PR completes the remaining item-detail half.

## Approach

- `src/components/ItemDetailScreen.tsx`: associate each existing caption with its control via `aria-labelledby`, exactly as the issue recommends (no visual change):
  - Story `<dt>` gets `id="item-story-label"`; the Story textarea references it.
  - Each custom metadata field `<dt>` gets `id="item-field-label-<fieldId>"`; both the multiline (`<textarea>`) and single-line (`<input>`) branches reference it.
- The existing `aria-describedby` hint wiring is untouched, so a field now exposes both its label (name) and its hint (description).
- `tests/components/ItemDetailScreen.test.tsx` (new): renders the screen and asserts the Story and metadata fields expose their captions as accessible names, and that no editable textbox is left without an accessible name.

## Why this approach

`aria-labelledby` reuses the captions already on screen, so nothing new needs translating and the accessible name stays in sync with the localized label automatically. It is the smallest change that satisfies the acceptance criteria and it introduces no visual or behavioural change. Native `<label>` was not used here because the captions are `<dt>` elements inside a description list; `aria-labelledby` is the correct association and is what the issue's recommended solution specifies for these rows.

## Risks

Low. Accessibility attributes only — no data, sync, routing, permission, or visual-token changes. Read-only clarity, sample-gallery pre-login access, and the AI-optional manual path are all untouched.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-fn7noo-qs-projects-72b20d9d.vercel.app (a11y-only change — there is no visual difference to inspect; verify with a screen reader or DOM inspection).

Steps:
1. Open an own item's detail page.
2. Inspect the Story textarea and each metadata `<textarea>`/`<input>` → each now exposes an accessible name matching its visible caption (`aria-labelledby`), instead of announcing placeholder text or nothing.
3. Switch language to 中文 → the accessible names localize with the captions.
4. With VoiceOver/NVDA, tab through the fields and confirm each field is announced by its label.

Checks:
- [x] npm run format:check
- [x] npm test (1080 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No visual change — this affects only the accessible names of existing item-detail controls. The behaviour is pinned by the new `ItemDetailScreen` test.

## Linear

Closes #372

## Rollback plan

Not required for Green tier. If needed: `git revert 1309d5d` — the change is isolated to the `aria-labelledby`/`id` attributes in `ItemDetailScreen.tsx` and its new test.