### PR TITLE
Preserve custom sample photos during seed upgrades

### DIFF
--- a/src/services/seedCollections.ts
+++ b/src/services/seedCollections.ts
@@ -133,6 +133,15 @@ type SeedRef = { id: string; seedKey?: string };
 const matchesSeed = (candidate: SeedRef, seed: SeedRef) =>
   candidate.id === seed.id || (Boolean(candidate.seedKey) && candidate.seedKey === seed.seedKey);
 
+const CODE_DEFINED_SEED_PHOTO_URLS = new Set<string>(
+  INITIAL_COLLECTIONS.flatMap((collection) =>
+    collection.items.flatMap((item) => (item.photoUrl ? [item.photoUrl] : [])),
+  ),
+);
+
+const isCustomSeedPhoto = (photoUrl?: string): boolean =>
+  Boolean(photoUrl && !CODE_DEFINED_SEED_PHOTO_URLS.has(photoUrl));
+
 const hasSeedDrift = (seed: UserCollection, cloud: UserCollection | undefined): boolean => {
   if (!cloud) return true;
   if (!cloud.isPublic) return true;
@@ -157,8 +166,8 @@ const hasSeedDrift = (seed: UserCollection, cloud: UserCollection | undefined): 
  * private, seed items lost or stripped of photo paths outside the app).
  * Returns the seed collections whose cloud copy must be re-upserted so the
  * admin load path can repair drift instead of only seeding an empty cloud
- * (CUR-143). Curator-added items already in the cloud copy are preserved.
- * Pass `force` to re-push healthy seeds too (seed-version content upgrades).
+ * (CUR-143). Curator-added items and explicit custom seed photos are preserved.
+ * Pass `force` to re-push healthy seed content too (seed-version upgrades).
  */
 export const buildSeedRepairs = (
   cloudCollections: UserCollection[],
@@ -168,6 +177,18 @@ export const buildSeedRepairs = (
   INITIAL_COLLECTIONS.flatMap((seed) => {
     const cloud = cloudCollections.find((collection) => matchesSeed(collection, seed));
     if (!force && !hasSeedDrift(seed, cloud)) return [];
+    const repairedSeedItems: CollectionItem[] = seed.items.map((seedItem) => {
+      const cloudItem = cloud?.items.find((item) => matchesSeed(item, seedItem));
+      // A photo outside the code-defined seed asset set came from the admin's
+      // Update Photo path. Preserve that explicit customization even during a
+      // forced content upgrade; missing photos and known seed assets still take
+      // the canonical value from the current seed (including the #373 migration
+      // away from the old shared sample-vinyl.jpg path).
+      if (cloudItem?.photoUrl && isCustomSeedPhoto(cloudItem.photoUrl)) {
+        return { ...seedItem, photoUrl: cloudItem.photoUrl };
+      }
+      return seedItem;
+    });
     const curatorItems: CollectionItem[] = (cloud?.items ?? []).filter(
       (item) => !seed.items.some((seedItem) => matchesSeed(item, seedItem)),
     );
@@ -180,7 +201,7 @@ export const buildSeedRepairs = (
         id: targetId,
         ownerId: cloud?.ownerId || ownerId,
         isPublic: true,
-        items: [...seed.items, ...curatorItems].map((item) => ({
+        items: [...repairedSeedItems, ...curatorItems].map((item) => ({
           ...item,
           collectionId: targetId,
         })),

--- a/src/services/seedCollections.ts
+++ b/src/services/seedCollections.ts
@@ -139,8 +139,17 @@ const CODE_DEFINED_SEED_PHOTO_URLS = new Set<string>(
   ),
 );
 
+// Seed art is shipped under public/assets with a `sample-*` filename. Keep this
+// convention in the classification, not just the current INITIAL_COLLECTIONS
+// values, so a forced upgrade recognizes a photo from an older seed version as
+// code-defined even after that exact URL has been replaced or removed later.
+const isCodeDefinedSeedAsset = (photoUrl: string): boolean => {
+  if (CODE_DEFINED_SEED_PHOTO_URLS.has(photoUrl)) return true;
+  return /(?:^|\/)assets\/sample-[^/?#]+\.(?:jpe?g|png|webp)(?:[?#].*)?$/i.test(photoUrl);
+};
+
 const isCustomSeedPhoto = (photoUrl?: string): boolean =>
-  Boolean(photoUrl && !CODE_DEFINED_SEED_PHOTO_URLS.has(photoUrl));
+  Boolean(photoUrl && !isCodeDefinedSeedAsset(photoUrl));
 
 const hasSeedDrift = (seed: UserCollection, cloud: UserCollection | undefined): boolean => {
   if (!cloud) return true;
@@ -179,11 +188,10 @@ export const buildSeedRepairs = (
     if (!force && !hasSeedDrift(seed, cloud)) return [];
     const repairedSeedItems: CollectionItem[] = seed.items.map((seedItem) => {
       const cloudItem = cloud?.items.find((item) => matchesSeed(item, seedItem));
-      // A photo outside the code-defined seed asset set came from the admin's
-      // Update Photo path. Preserve that explicit customization even during a
-      // forced content upgrade; missing photos and known seed assets still take
-      // the canonical value from the current seed (including the #373 migration
-      // away from the old shared sample-vinyl.jpg path).
+      // A photo outside the code-defined seed asset convention came from the
+      // admin's Update Photo path. Preserve that explicit customization even
+      // during a forced content upgrade; current and historical sample assets
+      // take the canonical value from the new seed version instead.
       if (cloudItem?.photoUrl && isCustomSeedPhoto(cloudItem.photoUrl)) {
         return { ...seedItem, photoUrl: cloudItem.photoUrl };
       }

--- a/tests/unit/services/seedCollections.test.ts
+++ b/tests/unit/services/seedCollections.test.ts
@@ -106,6 +106,20 @@ describe('seedCollections.ts — buildSeedRepairs (CUR-143)', () => {
     );
   });
 
+  it('replaces a historical code-defined sample photo during a forced upgrade', () => {
+    // A future seed version may remove an older sample asset from
+    // INITIAL_COLLECTIONS. It is still code-owned, not an admin customization.
+    const historicalSeedPhoto = '/assets/sample-vinyl-retired.jpg';
+    const items = masterSeed.items.map((item, index) => ({
+      ...item,
+      photoUrl: index === 1 ? historicalSeedPhoto : item.photoUrl,
+    }));
+
+    const repairs = buildSeedRepairs([healthyCloudSeed({ items })], ADMIN_ID, { force: true });
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].items[1].photoUrl).toBe(masterSeed.items[1].photoUrl);
+  });
+
   it('preserves curator-added items when repairing', () => {
     const curatorItem: CollectionItem = {
       id: 'curator-pick-1',

--- a/tests/unit/services/seedCollections.test.ts
+++ b/tests/unit/services/seedCollections.test.ts
@@ -91,6 +91,21 @@ describe('seedCollections.ts — buildSeedRepairs (CUR-143)', () => {
     expect(buildSeedRepairs([healthyCloudSeed({ items })], ADMIN_ID)).toEqual([]);
   });
 
+  it('preserves an admin-customized seed photo during a forced content upgrade (#373)', () => {
+    const customPhoto = 'data:image/jpeg;base64,QUJD';
+    const legacySharedPhoto = masterSeed.items[0].photoUrl;
+    const items = masterSeed.items.map((item, index) => ({
+      ...item,
+      photoUrl: index === 1 ? customPhoto : legacySharedPhoto,
+    }));
+
+    const repairs = buildSeedRepairs([healthyCloudSeed({ items })], ADMIN_ID, { force: true });
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0].items.slice(0, masterSeed.items.length).map((item) => item.photoUrl)).toEqual(
+      masterSeed.items.map((item, index) => (index === 1 ? customPhoto : item.photoUrl)),
+    );
+  });
+
   it('preserves curator-added items when repairing', () => {
     const curatorItem: CollectionItem = {
       id: 'curator-pick-1',


### PR DESCRIPTION
## Problem

Follow-up to the unresolved post-merge review on #413. The normal seed-drift path already treats an admin-updated sample photo as a valid customization, but an existing admin device with seed version 1–4 takes the `force: true` upgrade path and reconstructs every seed item from `INITIAL_COLLECTIONS`, silently overwriting that same custom photo.

## Approach

- Keep seed-version upgrades authoritative for canonical seed content.
- Preserve a matched seed item's `photoUrl` only when it is outside Curio's code-defined seed photo set, which identifies an explicit admin photo customization.
- Missing photos and code-defined seed assets still take the current canonical seed value. That means the #373 v5 migration still replaces the old shared `sample-vinyl.jpg` on items 2–5 with their distinct artwork.
- Curator-added non-seed items continue to be preserved as before.

## Regression coverage

Adds a forced-upgrade test that starts with the legacy shared photo on the seed items plus one admin-customized data-URL photo. The repair must keep the custom photo while migrating the remaining seed photos to the current canonical set.

## Validation

I could not run the local npm gate in this environment because direct GitHub cloning/network access is unavailable. The change is limited to `src/services/seedCollections.ts` and its existing unit-test file; CI should run the repository gate on this PR.

Refs #413 / #373.