### PR TITLE
[#424] Gate collection-card name tooltip on real truncation

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { UserCollection } from '../types';
 import { ChevronRight, Search } from 'lucide-react';
 import { TEMPLATES } from '../constants';
@@ -25,6 +25,21 @@ export const CollectionCard: React.FC<CollectionCardProps> = React.memo(function
 }) {
   const { t } = useTranslation();
   const { theme } = useTheme();
+  // The single-line title truncates with an ellipsis. Only reveal the full-name
+  // tooltip when the name is actually clipped — otherwise it pops a redundant
+  // duplicate over the description on every hover/focus (reads as a glitch).
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const [isNameTruncated, setIsNameTruncated] = useState(false);
+  useEffect(() => {
+    const el = titleRef.current;
+    if (!el) return;
+    const measure = () => setIsNameTruncated(el.scrollWidth > el.clientWidth + 1);
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [collection.name]);
   const template = TEMPLATES.find((t) => t.id === collection.templateId) || TEMPLATES[0];
   const itemCount = collection.items.length;
   const isSample = Boolean(collection.isPublic) || collection.id.startsWith('sample');
@@ -86,7 +101,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = React.memo(function
       }}
       data-testid="collection-card"
       data-collection-id={collection.id}
-      className={`group relative p-5 sm:p-8 rounded-[2.5rem] border ${baseSurface} ${accentBorder[template.accentColor] || accentBorder['stone']} transition-all duration-500 ease-out cursor-pointer motion-safe:active:scale-[0.98] ${tapShadow} ${tapRing} flex flex-col justify-between min-h-[11rem] sm:h-52 overflow-hidden motion-card`}
+      className={`group relative p-5 sm:p-8 rounded-[2.5rem] border ${baseSurface} ${accentBorder[template.accentColor] || accentBorder['stone']} transition-all duration-500 ease-out cursor-pointer motion-safe:active:scale-[0.98] ${tapShadow} ${tapRing} focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent flex flex-col justify-between min-h-[11rem] sm:h-52 overflow-hidden motion-card`}
     >
       <div className="absolute top-0 right-0 p-5 sm:p-8 opacity-10 text-6xl sm:text-7xl select-none group-hover:scale-110 group-hover:rotate-12 transition-transform duration-700 pointer-events-none">
         {displayIcon}
@@ -96,17 +111,20 @@ export const CollectionCard: React.FC<CollectionCardProps> = React.memo(function
         <div className="flex items-center gap-2 mb-1 flex-wrap">
           <div className="relative flex-1 min-w-0 max-w-[80%]">
             <h3
+              ref={titleRef}
               title={collection.name}
               aria-label={collection.name}
               className={`${typographyClasses.titleLarge} group-hover:${accentColorClasses[theme]} leading-tight truncate`}
             >
               {collection.name}
             </h3>
-            <span
-              className={`pointer-events-none absolute left-0 top-full mt-2 w-max max-w-[90vw] rounded-2xl px-3 py-2 text-sm leading-snug shadow-lg opacity-0 scale-95 transition duration-200 ease-out whitespace-normal break-words [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:scale-100 group-focus-visible:opacity-100 group-focus-visible:scale-100 sm:max-w-[18rem] ${theme === 'vault' ? 'bg-stone-900 text-white' : 'bg-white text-stone-900 border border-stone-200/70'}`}
-            >
-              {collection.name}
-            </span>
+            {isNameTruncated && (
+              <span
+                className={`pointer-events-none absolute left-0 top-full mt-2 w-max max-w-[90vw] rounded-2xl px-3 py-2 text-sm leading-snug shadow-lg opacity-0 scale-95 transition duration-200 ease-out whitespace-normal break-words [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-hover:scale-100 group-focus-visible:opacity-100 group-focus-visible:scale-100 sm:max-w-[18rem] ${theme === 'vault' ? 'bg-stone-900 text-white' : 'bg-white text-stone-900 border border-stone-200/70'}`}
+              >
+                {collection.name}
+              </span>
+            )}
           </div>
           {isSample && (
             <span

--- a/tests/components/CollectionCard.test.tsx
+++ b/tests/components/CollectionCard.test.tsx
@@ -5,7 +5,7 @@
  * Validates rendering, accessibility, theme support, and interaction behavior.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   renderWithProviders,
   screen,
@@ -115,8 +115,9 @@ describe('CollectionCard Component', () => {
 
       renderWithProviders(<CollectionCard collection={collection} onClick={onClick} />);
 
-      // Name renders as the heading (plus its hover tooltip), never as the description.
-      expect(screen.queryAllByText('Supplement')).toHaveLength(2);
+      // Name renders once as the heading (the reveal tooltip only mounts when the
+      // title is actually truncated), never as the description.
+      expect(screen.queryAllByText('Supplement')).toHaveLength(1);
       expect(
         screen.getByText('Track terroir, cocoa percentages, and nuanced flavor profiles.'),
       ).toBeInTheDocument();
@@ -424,30 +425,77 @@ describe('CollectionCard Component', () => {
   describe('Full-Name Tooltip Reveal', () => {
     const getTooltip = () => {
       const heading = screen.getByRole('heading', { name: 'My Vinyl Collection' });
-      return heading.nextElementSibling as HTMLElement;
+      return heading.nextElementSibling as HTMLElement | null;
     };
 
-    it('only reveals on hover for hover-capable pointers (no sticky tap tooltip)', () => {
-      const collection = createMockCollection();
+    // Force the title to report as clipped so the truncation-gated tooltip renders.
+    const mockTitleTruncation = (truncated: boolean) => {
+      Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+        configurable: true,
+        get: () => (truncated ? 500 : 100),
+      });
+      Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+        configurable: true,
+        get: () => 100,
+      });
+    };
 
-      renderWithProviders(<CollectionCard collection={collection} onClick={vi.fn()} />);
-
-      const tooltip = getTooltip();
-      expect(tooltip.className).toContain('[@media(hover:hover)]:group-hover:opacity-100');
-      // Bare group-hover / group-active reveals stick open after tap on touch devices
-      expect(tooltip.className).not.toMatch(/(^|\s)group-hover:/);
-      expect(tooltip.className).not.toContain('group-active:');
+    afterEach(() => {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>).scrollWidth;
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
     });
 
-    it('still reveals on keyboard focus via focus-visible', () => {
+    it('does not render the reveal tooltip when the title fits', () => {
+      mockTitleTruncation(false);
+      const collection = createMockCollection();
+
+      renderWithProviders(<CollectionCard collection={collection} onClick={vi.fn()} />);
+
+      // No duplicate name pill overlapping the description for untruncated titles.
+      expect(getTooltip()).toBeNull();
+      // The native affordance still exposes the full name.
+      const heading = screen.getByRole('heading', { name: 'My Vinyl Collection' });
+      expect(heading).toHaveAttribute('title', 'My Vinyl Collection');
+    });
+
+    it('reveals on hover for hover-capable pointers only when the title is truncated', () => {
+      mockTitleTruncation(true);
       const collection = createMockCollection();
 
       renderWithProviders(<CollectionCard collection={collection} onClick={vi.fn()} />);
 
       const tooltip = getTooltip();
-      expect(tooltip.className).toContain('group-focus-visible:opacity-100');
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.className).toContain('[@media(hover:hover)]:group-hover:opacity-100');
+      // Bare group-hover / group-active reveals stick open after tap on touch devices
+      expect(tooltip!.className).not.toMatch(/(^|\s)group-hover:/);
+      expect(tooltip!.className).not.toContain('group-active:');
+    });
+
+    it('still reveals on keyboard focus via focus-visible when truncated', () => {
+      mockTitleTruncation(true);
+      const collection = createMockCollection();
+
+      renderWithProviders(<CollectionCard collection={collection} onClick={vi.fn()} />);
+
+      const tooltip = getTooltip();
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.className).toContain('group-focus-visible:opacity-100');
       // Plain focus-within would also match tap-focus on the card
-      expect(tooltip.className).not.toContain('group-focus-within:');
+      expect(tooltip!.className).not.toContain('group-focus-within:');
+    });
+  });
+
+  describe('Keyboard focus affordance', () => {
+    it('exposes a clearly visible focus-visible ring on the card', () => {
+      const collection = createMockCollection();
+
+      renderWithProviders(<CollectionCard collection={collection} onClick={vi.fn()} />);
+
+      const card = screen.getByTestId('collection-card');
+      expect(card.className).toContain('focus:outline-none');
+      expect(card.className).toContain('focus-visible:ring-2');
+      expect(card.className).toContain('focus-visible:ring-amber-500/70');
     });
   });
 });


### PR DESCRIPTION
## Problem

On the Home screen, the collection card's "full name reveal" tooltip (added for the truncated-title case, cf. #100) rendered on **every** hover and keyboard focus — regardless of whether the title was actually clipped. Positioned `absolute left-0 top-full mt-2`, it popped a redundant duplicate of the title directly over the card's description/fields line, so hovering or tabbing to any card briefly covered its description and read as a rendering glitch. The card also had no `focus-visible` outline, so keyboard focus relied on that same overlapping pill (plus a ~5% black ring) as its only cue.

Protects Curio's **beauty before bureaucracy** (no glitchy duplicate over content) and **trust** (a clear, legible keyboard-focus affordance).

## Approach

`src/components/CollectionCard.tsx`:
- Measure the single-line, `truncate`d title with a `ref` + `ResizeObserver` (`scrollWidth > clientWidth`) and only mount the reveal tooltip when the name is genuinely clipped. Untruncated titles keep their always-present native `title` / `aria-label` affordance, so no information is lost.
- Add a content-safe `focus-visible` ring on the card (`focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/70 focus-visible:ring-offset-2`), reusing the existing amber focus-ring convention already used elsewhere (e.g. `AddItemModal`, `HomeScreen`) and the warm accent from `DESIGN.md` (no new tokens).

`tests/components/CollectionCard.test.tsx`:
- No tooltip renders for a fitting title (native `title` still present).
- Tooltip renders **only** when the title is truncated — asserting both the hover-capable (`[@media(hover:hover)]:group-hover`) and keyboard (`group-focus-visible`) reveal classes.
- The card exposes the visible `focus-visible` ring.
- Updated one pre-existing test that assumed the tooltip always renders.

## Why this approach

The truncation check reuses the same `ResizeObserver` + guard pattern already in the codebase, so it introduces no new dependency or visual language — it just stops the tooltip from firing when there is nothing to reveal. The focus ring uses the established amber `focus-visible` convention, keeping the fix presentational and token-free.

## Risks

Low. Presentational only — no data, sync, routing, or permission changes. The identical tooltip pattern also exists in `ItemCard`; I scoped this PR to the collection card per the issue and left `ItemCard` untouched (a candidate follow-up if you want the two kept consistent). In non-layout environments (jsdom) `scrollWidth`/`clientWidth` report `0`, so the tooltip simply stays hidden — the safe default; tests mock the measurement to exercise the truncated path.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-kkdd4x-qs-projects-72b20d9d.vercel.app

Steps:
1. Open Home (`/`) on desktop and sign in so your collections render.
2. Hover (or Tab to) a card whose title is **not** truncated (e.g. "Chocolate Haven") — no name pill appears over the description; the card shows a clear amber focus ring on keyboard focus.
3. Hover/Tab to a card with a long, truncated title — the full-name reveal still appears.
4. Confirm the native tooltip (`title=`) still shows the full name on any card.

Checks:
- [x] npm run format:check
- [x] npm test (1082 passed, 2 skipped)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

The change affects interaction states (hover tooltip suppression + keyboard `focus-visible` ring) that are best seen live on the Vercel preview above; the signed-in Home view requires Supabase auth, unavailable in this headless environment. Rendering and gating are pinned by the new `CollectionCard` tests.

## Linear

Closes #424

## Rollback plan

Green tier — single revert of this PR's commit. The change is isolated to `CollectionCard.tsx` and its test; no schema, storage, flag, or token changes.