### PR TITLE
[#425] Meet the 44px minimum touch target on mobile header and bottom nav

### DIFF
--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -12,7 +12,7 @@ export const LanguageToggle: React.FC = () => {
   return (
     <button
       onClick={() => setLanguage(targetLang)}
-      className={`p-2 rounded-full transition-colors flex items-center justify-center gap-1 sm:gap-1.5 [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px] ${
+      className={`p-2 rounded-full transition-colors flex items-center justify-center gap-1 sm:gap-1.5 [@media(any-pointer:coarse)]:min-h-[44px] [@media(any-pointer:coarse)]:min-w-[44px] ${
         theme === 'vault'
           ? 'text-white/70 hover:text-white hover:bg-white/10'
           : theme === 'atelier'

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -12,7 +12,7 @@ export const LanguageToggle: React.FC = () => {
   return (
     <button
       onClick={() => setLanguage(targetLang)}
-      className={`p-2 rounded-full transition-colors flex items-center gap-1 sm:gap-1.5 ${
+      className={`p-2 rounded-full transition-colors flex items-center justify-center gap-1 sm:gap-1.5 [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px] ${
         theme === 'vault'
           ? 'text-white/70 hover:text-white hover:bg-white/10'
           : theme === 'atelier'

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -489,7 +489,7 @@ export const Layout: React.FC<LayoutProps> = ({
             <Link
               to="/"
               aria-current={location.pathname === '/' ? 'page' : undefined}
-              className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${location.pathname === '/' ? 'text-amber-500' : bottomNavMuted}`}
+              className={`flex flex-col items-center justify-center gap-1 min-h-[44px] text-[11px] font-semibold transition-colors ${location.pathname === '/' ? 'text-amber-500' : bottomNavMuted}`}
             >
               <Home size={22} />
               {t('navHome')}
@@ -500,7 +500,7 @@ export const Layout: React.FC<LayoutProps> = ({
                 to={exploreTo}
                 onClick={onExploreSamples}
                 aria-current={isExploreActive ? 'page' : undefined}
-                className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
+                className={`flex flex-col items-center justify-center gap-1 min-h-[44px] text-[11px] font-semibold transition-colors ${isExploreActive ? 'text-amber-500' : bottomNavMuted}`}
               >
                 <Compass size={22} />
                 {t('exploreSample')}
@@ -509,7 +509,7 @@ export const Layout: React.FC<LayoutProps> = ({
 
             <button
               onClick={onAddItem}
-              className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${bottomNavMuted}`}
+              className={`flex flex-col items-center justify-center gap-1 min-h-[44px] text-[11px] font-semibold transition-colors ${bottomNavMuted}`}
             >
               <div
                 data-testid="bottom-nav-add-pill"
@@ -526,7 +526,7 @@ export const Layout: React.FC<LayoutProps> = ({
               aria-haspopup="dialog"
               aria-expanded={profileSource === 'bottomNav'}
               aria-label={showSignInAffordance ? t('login') : t('profile')}
-              className={`flex flex-col items-center gap-1 text-[11px] font-semibold transition-colors ${profileSource === 'bottomNav' ? 'text-amber-500' : bottomNavMuted}`}
+              className={`flex flex-col items-center justify-center gap-1 min-h-[44px] text-[11px] font-semibold transition-colors ${profileSource === 'bottomNav' ? 'text-amber-500' : bottomNavMuted}`}
             >
               <User size={22} />
               {showSignInAffordance ? t('login') : t('profile')}

--- a/src/components/ThemeQuickToggle.tsx
+++ b/src/components/ThemeQuickToggle.tsx
@@ -51,7 +51,7 @@ export const ThemeQuickToggle: React.FC = () => {
         aria-expanded={isOpen}
         aria-label={t('themeSelection')}
         title={t('themeSelection')}
-        className={`p-2 rounded-full transition-colors inline-flex items-center justify-center [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px] ${buttonClass}`}
+        className={`p-2 rounded-full transition-colors inline-flex items-center justify-center [@media(any-pointer:coarse)]:min-h-[44px] [@media(any-pointer:coarse)]:min-w-[44px] ${buttonClass}`}
       >
         <Paintbrush size={18} aria-hidden="true" />
       </button>

--- a/src/components/ThemeQuickToggle.tsx
+++ b/src/components/ThemeQuickToggle.tsx
@@ -51,7 +51,7 @@ export const ThemeQuickToggle: React.FC = () => {
         aria-expanded={isOpen}
         aria-label={t('themeSelection')}
         title={t('themeSelection')}
-        className={`p-2 rounded-full transition-colors ${buttonClass}`}
+        className={`p-2 rounded-full transition-colors inline-flex items-center justify-center [@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px] ${buttonClass}`}
       >
         <Paintbrush size={18} aria-hidden="true" />
       </button>

--- a/tests/components/LanguageToggle.test.tsx
+++ b/tests/components/LanguageToggle.test.tsx
@@ -43,6 +43,18 @@ describe('LanguageToggle (CUR-113)', () => {
     expect(screen.getByRole('button', { name: '切换语言为英文' })).toBeInTheDocument();
   });
 
+  it('reserves a >=44px coarse-pointer hit area without enlarging the desktop glyph', () => {
+    // Issue #425: the header toggle rendered ~34px tall, below the 44px touch
+    // minimum. The larger hit area is applied only on coarse pointers so the
+    // desktop (fine-pointer) header keeps its compact height.
+    renderWithProviders(<LanguageToggle />);
+
+    const button = screen.getByRole('button', { name: /switch language to/i });
+    expect(button.className).toContain('[@media(pointer:coarse)]:min-h-[44px]');
+    expect(button.className).toContain('[@media(pointer:coarse)]:min-w-[44px]');
+    expect(button.className).toContain('justify-center');
+  });
+
   it('hides the Globe icon and target-code text from the accessibility tree', () => {
     renderWithProviders(<LanguageToggle />);
 

--- a/tests/components/LanguageToggle.test.tsx
+++ b/tests/components/LanguageToggle.test.tsx
@@ -43,15 +43,17 @@ describe('LanguageToggle (CUR-113)', () => {
     expect(screen.getByRole('button', { name: '切换语言为英文' })).toBeInTheDocument();
   });
 
-  it('reserves a >=44px coarse-pointer hit area without enlarging the desktop glyph', () => {
+  it('reserves a >=44px hit area on any touch-capable device without enlarging the desktop glyph', () => {
     // Issue #425: the header toggle rendered ~34px tall, below the 44px touch
-    // minimum. The larger hit area is applied only on coarse pointers so the
-    // desktop (fine-pointer) header keeps its compact height.
+    // minimum. The larger hit area is applied whenever a coarse pointer is
+    // available (`any-pointer: coarse`) so it covers hybrid touchscreen laptops
+    // too, while a pure non-touch desktop (no coarse pointer at all) keeps its
+    // compact height.
     renderWithProviders(<LanguageToggle />);
 
     const button = screen.getByRole('button', { name: /switch language to/i });
-    expect(button.className).toContain('[@media(pointer:coarse)]:min-h-[44px]');
-    expect(button.className).toContain('[@media(pointer:coarse)]:min-w-[44px]');
+    expect(button.className).toContain('[@media(any-pointer:coarse)]:min-h-[44px]');
+    expect(button.className).toContain('[@media(any-pointer:coarse)]:min-w-[44px]');
     expect(button.className).toContain('justify-center');
   });
 

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -1195,6 +1195,43 @@ describe('Layout Component', () => {
     });
   });
 
+  // Issue #425: always-visible header and bottom-nav controls rendered below
+  // the 44px minimum touch target. The header toggles gain the larger hit area
+  // only on coarse pointers (no desktop regression); the mobile-only bottom nav
+  // items get a >=44px tall hit area unconditionally.
+  describe('Touch target sizing (#425)', () => {
+    const authenticatedUser = { id: 'user-1', email: 'test@example.com' };
+
+    it('gives the header theme toggle a >=44px coarse-pointer hit area', () => {
+      renderWithProviders(<Layout {...defaultProps} />);
+
+      const themeToggle = screen.getByTestId('theme-picker');
+      expect(themeToggle.className).toContain('[@media(pointer:coarse)]:min-h-[44px]');
+      expect(themeToggle.className).toContain('[@media(pointer:coarse)]:min-w-[44px]');
+      expect(themeToggle.className).toContain('justify-center');
+    });
+
+    it('gives each bottom-nav item a >=44px tall hit area', () => {
+      renderWithProviders(
+        <Layout {...defaultProps} user={authenticatedUser} sampleCollectionId="sample-vinyl-1" />,
+      );
+
+      const bottomNav = screen.getByRole('navigation', { name: /primary/i });
+      const items = [
+        within(bottomNav).getByText('Home').closest('a'),
+        within(bottomNav).getByText('Explore').closest('a'),
+        within(bottomNav).getByText('Add').closest('button'),
+        within(bottomNav).getByText('Profile').closest('button'),
+      ];
+
+      for (const item of items) {
+        expect(item).not.toBeNull();
+        expect(item!.className).toContain('min-h-[44px]');
+        expect(item!.className).toContain('justify-center');
+      }
+    });
+  });
+
   describe('Edge Cases', () => {
     it('handles null sampleCollectionId gracefully', () => {
       expect(() => {

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -1197,17 +1197,18 @@ describe('Layout Component', () => {
 
   // Issue #425: always-visible header and bottom-nav controls rendered below
   // the 44px minimum touch target. The header toggles gain the larger hit area
-  // only on coarse pointers (no desktop regression); the mobile-only bottom nav
-  // items get a >=44px tall hit area unconditionally.
+  // whenever a coarse pointer is available (`any-pointer: coarse`), so touch on
+  // hybrid laptops is covered while a pure non-touch desktop is unchanged; the
+  // mobile-only bottom nav items get a >=44px tall hit area unconditionally.
   describe('Touch target sizing (#425)', () => {
     const authenticatedUser = { id: 'user-1', email: 'test@example.com' };
 
-    it('gives the header theme toggle a >=44px coarse-pointer hit area', () => {
+    it('gives the header theme toggle a >=44px touch-capable hit area', () => {
       renderWithProviders(<Layout {...defaultProps} />);
 
       const themeToggle = screen.getByTestId('theme-picker');
-      expect(themeToggle.className).toContain('[@media(pointer:coarse)]:min-h-[44px]');
-      expect(themeToggle.className).toContain('[@media(pointer:coarse)]:min-w-[44px]');
+      expect(themeToggle.className).toContain('[@media(any-pointer:coarse)]:min-h-[44px]');
+      expect(themeToggle.className).toContain('[@media(any-pointer:coarse)]:min-w-[44px]');
       expect(themeToggle.className).toContain('justify-center');
     });
 


### PR DESCRIPTION
## Problem

Several always-visible interactive controls render below the 44×44px minimum touch target (WCAG 2.5.5 / Apple HIG / Material) at mobile widths, making them fiddly to tap on the exact device class the product targets:

- Header language toggle ("ZH"): ~34px tall
- Header theme/aesthetic toggle (paintbrush): ~34×34px
- Bottom-nav items (Home / Explore / Add / Profile): ~43px tall

Protects Curio's **trust before growth** and mobile-first stance — a control that feels unresponsive on a phone undermines the "collecting on the go" experience. Ref: #425.

## Approach

- `src/components/LanguageToggle.tsx` and `src/components/ThemeQuickToggle.tsx`: add a `[@media(any-pointer:coarse)]:min-h-[44px] [@media(any-pointer:coarse)]:min-w-[44px]` hit area and center the glyph (`justify-center`). `any-pointer: coarse` is the standard "touch input is available" query, so the enlargement applies on phones, tablets, **and** hybrid touchscreen laptops — but a pure non-touch desktop (which has no coarse pointer at all) is left unchanged. The visible icons/text are unchanged either way.
- `src/components/Layout.tsx`: give each of the four bottom-nav items `min-h-[44px] justify-center`. The bottom nav is `sm:hidden` (mobile/touch only), so no pointer guard is needed there.

Reuses the existing arbitrary-media-variant convention already in the codebase (`[@media(hover:hover)]:` in `CollectionCard`/`ItemCard`) — no new tokens, dependencies, or visual language.

## Why this approach

Sizing on `any-pointer: coarse` is the smallest change that gives a ≥44px hit area wherever a finger can actually tap while leaving a pure mouse-driven desktop untouched. Keeping the visible glyphs the same size means the fix is purely a hit-area enlargement, not a visual redesign.

> Note: the original commit guarded on `pointer: coarse`, which only matches the *primary* pointer; per Codex review it was switched to `any-pointer: coarse` so hybrid touchscreen laptops are covered too (commit `c562649`).

## Risks

Low. Presentational only — no data, sync, routing, or permission changes. Touch-capable devices get the ~8px-larger header hit area (the intended fix); a non-touch desktop is unchanged because the min-size rules never apply without a coarse pointer.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-mb3meq-qs-projects-72b20d9d.vercel.app

Steps:
1. Open the preview at a 375px-wide viewport.
2. Tap the "ZH" language toggle and the paintbrush theme toggle — each now has a ≥44×44px hit area (inspect `getBoundingClientRect`).
3. Confirm the bottom-nav Home / Explore / Add / Profile items are ≥44px tall.
4. On a non-touch desktop (mouse only, no touchscreen) the header controls keep their original compact size.

Checks:
- [x] npm run format:check
- [x] npm test (1083 passed, 2 skipped)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

The change is a hit-area enlargement (no visible-glyph change) best measured live on the Vercel preview; the signed-in states require Supabase auth, unavailable in this headless environment. The presence and gating of the touch-target classes are pinned by new `LanguageToggle` and `Layout` tests.

## Linear

Closes #425

## Rollback plan

Green tier — revert this PR's commits. The change is isolated to the className of three header/nav controls and two test files; no schema, storage, flag, or token changes.