### PR TITLE
[#423] Fix Gallery muted/label text contrast to meet WCAG AA

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from '../i18n';
 import {
   useTheme,
   typographyClasses,
-  accentColorClasses,
+  accentLabelColorClasses,
   labelColorClasses,
   matSurfaceClasses,
 } from '../theme';
@@ -268,7 +268,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const newArchiveTileClasses = {
-    gallery: 'border-stone-200 hover:border-amber-400 bg-white/50 text-stone-400',
+    gallery: 'border-stone-200 hover:border-amber-400 bg-white/50 text-stone-500',
     vault: 'border-white/10 hover:border-amber-400 bg-white/5 text-stone-500',
     atelier: 'border-[#D4C9B8] hover:border-[#A86F3C] bg-[#EDE4D3]/60 text-[#8C7B6B]',
   };
@@ -280,7 +280,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   };
 
   const newArchiveTitleClasses = {
-    gallery: 'text-stone-400',
+    gallery: 'text-stone-500',
     vault: 'text-white/60',
     atelier: 'text-[#8C7B6B]',
   };
@@ -301,7 +301,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-full bg-amber-500 text-white shadow-lg shadow-amber-500/20">
             <Sparkles size={24} />
           </div>
-          <p className={`${typographyClasses.label} ${accentColorClasses[theme]} mb-3`}>
+          <p className={`${typographyClasses.label} ${accentLabelColorClasses[theme]} mb-3`}>
             {t('firstRunEyebrow')}
           </p>
           <h1
@@ -341,7 +341,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   return (
     <div className={`space-y-10 sm:space-y-12 animate-in fade-in duration-700`}>
       <header className="space-y-2">
-        <p className={`${typographyClasses.label} ${accentColorClasses[theme]}`}>
+        <p className={`${typographyClasses.label} ${accentLabelColorClasses[theme]}`}>
           {t('homeWelcome')}
         </p>
         <h1 className={`${typographyClasses.titleHero} leading-tight`}>{t('homeMuseumTitle')}</h1>
@@ -517,7 +517,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
               >
                 {t('newArchive')}
               </span>
-              <span className={typographyClasses.labelMuted}>{t('expandSpace')}</span>
+              <span className={typographyClasses.labelSmall}>{t('expandSpace')}</span>
             </div>
           </button>
         )}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -159,10 +159,13 @@ export const typographyClasses = {
   quote: 'font-serif italic text-lg leading-relaxed',
 } as const;
 
-// Theme-aware label colors. Vault uses stone-400 (#A8A29E) to match DESIGN.md's
-// "Text Muted" token — stone-500 fails WCAG AA on stone-900 surfaces.
+// Theme-aware label colors, tuned per surface so muted labels still clear
+// WCAG AA. Gallery uses stone-500 (#78716C) — DESIGN.md's Gallery "Text Muted"
+// token — which reaches ~4.8:1 on the light surface, where stone-400 (#A8A29E)
+// only manages ~2.4:1. Vault keeps stone-400 to match DESIGN.md's dark "Text
+// Muted" token, which clears AA against the stone-900 surface.
 export const labelColorClasses: Record<AppTheme, string> = {
-  gallery: 'text-stone-400',
+  gallery: 'text-stone-500',
   vault: 'text-stone-400',
   atelier: 'text-[#8C7B6B]', // Sepia-toned labels
 };
@@ -235,6 +238,17 @@ export const accentColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-600 hover:text-amber-700',
   vault: 'text-[#D4A574] hover:text-[#E0B585]',
   atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]', // Rich amber-brown
+};
+
+// Accent color for small uppercase eyebrow/label text. The interactive accent
+// (amber-600, ~3.05:1 on white) fails WCAG AA when used as static label text,
+// so labels use the darker accent tone per theme: amber-700 (#B45309, DESIGN.md
+// "Accent Hover", ~4.6:1) on Gallery and the deeper amber-brown on Atelier.
+// Vault's brass already clears AA on the dark surface.
+export const accentLabelColorClasses: Record<AppTheme, string> = {
+  gallery: 'text-amber-700',
+  vault: 'text-[#D4A574]',
+  atelier: 'text-[#8B5A2B]',
 };
 
 // Accent background classes (for buttons, badges)

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -9,6 +9,7 @@ import {
   ratingColorClasses,
   ratingEmptyClasses,
   accentColorClasses,
+  accentLabelColorClasses,
   frameAccentClasses,
   cardHoverClasses,
   inputClasses,
@@ -94,6 +95,13 @@ describe('Theme Utilities', () => {
     // (~3.77:1); DESIGN.md sets Vault textMuted to stone-400 (#A8A29E).
     it('keeps Vault labels at or above stone-400 contrast', () => {
       expect(labelColorClasses.vault).toBe('text-stone-400');
+    });
+
+    // stone-400 (#A8A29E) only reaches ~2.4:1 on the Gallery light surface and
+    // fails WCAG AA; DESIGN.md's Gallery "Text Muted" token is stone-500
+    // (#78716C, ~4.8:1). Regression guard for #423.
+    it('uses AA-compliant stone-500 for Gallery labels', () => {
+      expect(labelColorClasses.gallery).toBe('text-stone-500');
     });
   });
 
@@ -184,6 +192,30 @@ describe('Theme Utilities', () => {
       expect(accentColorClasses.gallery).toContain('hover:');
       expect(accentColorClasses.vault).toContain('hover:');
       expect(accentColorClasses.atelier).toContain('hover:');
+    });
+  });
+
+  describe('accentLabelColorClasses', () => {
+    it('has all three themes', () => {
+      expect(accentLabelColorClasses.gallery).toBeDefined();
+      expect(accentLabelColorClasses.vault).toBeDefined();
+      expect(accentLabelColorClasses.atelier).toBeDefined();
+    });
+
+    // The interactive accent amber-600 (~3.05:1 on white) fails WCAG AA as
+    // static label text; eyebrow labels use amber-700 (#B45309, ~4.6:1), which
+    // DESIGN.md already defines as "Accent Hover". Regression guard for #423.
+    it('uses the AA-compliant darker accent for Gallery label text', () => {
+      expect(accentLabelColorClasses.gallery).toBe('text-amber-700');
+      expect(accentLabelColorClasses.gallery).not.toContain('amber-600');
+    });
+
+    // Label text is static, so no hover state is needed (unlike the
+    // interactive accentColorClasses).
+    it('does not carry a hover state', () => {
+      expect(accentLabelColorClasses.gallery).not.toContain('hover:');
+      expect(accentLabelColorClasses.vault).not.toContain('hover:');
+      expect(accentLabelColorClasses.atelier).not.toContain('hover:');
     });
   });
 


### PR DESCRIPTION
## Problem

Several small/secondary strings in the **Gallery** (light) theme rendered below the WCAG 2.1 AA minimum (4.5:1 normal, 3:1 large), per #423:

| Text | Was | Contrast | Result |
|------|-----|----------|--------|
| "Start a collection" tile title (30px) | stone-400 | 2.41:1 | ❌ |
| "Make room for something new" caption | stone-400 @ opacity-50 | <2.4:1 | ❌ |
| Collection header "N pieces" count | stone-400 | 2.41:1 | ❌ |
| "Welcome back" / first-run eyebrow labels | amber-600 | 3.05:1 | ❌ |

This hurts low-vision users, bright-sunlight readers, and anyone on a dim display — on a primary empty-state CTA and labels that recur across screens. Protects Curio's **trust** and **beauty before bureaucracy** principles (legible, legitimate affordances).

## Approach

The muted tone had **drifted from `DESIGN.md`**, which already defines the Gallery "Text Muted" token as `#78716C` (stone-500, ~4.8:1) — the same value as the sibling `mutedTextClasses.gallery`. So this is an enforcement fix, not a new design decision:

- `theme.tsx`: `labelColorClasses.gallery` stone-400 → **stone-500** (matches `DESIGN.md`). Vault keeps stone-400 to match `DESIGN.md`'s *dark* Text Muted token (which clears AA on stone-900); Atelier unchanged.
- `theme.tsx`: new **`accentLabelColorClasses`** token so static uppercase eyebrow labels use the darker accent — Gallery `amber-700` (`#B45309`, `DESIGN.md` "Accent Hover", ~4.6:1) instead of the interactive `amber-600`. Vault brass and the deeper Atelier brown already clear AA; no hover state on static labels.
- `HomeScreen.tsx`: the two amber eyebrows use `accentLabelColorClasses`; the "Start a collection" tile muted text → stone-500; the "make room" caption drops the `opacity-50` muted style so the tone renders at full strength.
- `tests/unit/theme.test.ts`: regression guards asserting `labelColorClasses.gallery === stone-500` and the new AA-safe accent-label token (both would have failed before).

## Why this approach

It corrects code that contradicted `DESIGN.md` rather than inventing a new palette, and it uses only already-approved `DESIGN.md` tones (stone-500 Text Muted, amber-700 Accent Hover — the exact tone the issue author pre-approved for meaningful labels). Fixing at the token level (not per-element overrides) satisfies AC #4 and re-checks cleanly across all three themes.

## Risks

Low. Presentational only — no data, sync, routing, AI, or permission changes. `labelColorClasses.gallery` is consumed by four muted-label sites (Home "on this day" label, collection count header, two item-detail field labels), all of which want the more-legible muted tone. Vault/Atelier are unchanged where they already pass. `accentColorClasses` (interactive/hover accents) is untouched.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-82i18r-qs-projects-72b20d9d.vercel.app

Steps:
1. Sign in and open Home (`/`) in the **Gallery** theme.
2. "Welcome back" eyebrow and the "Start a collection" tile title/caption are now clearly legible; run any contrast checker → all ≥ AA.
3. Open a collection → the "N pieces" count in the header meets AA.
4. Switch to Vault and Atelier → labels/eyebrows unchanged where they already passed.

Checks:
- [x] npm run format:check
- [x] npm test (1099 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No new layout or visual language — only muted/label text tones shift one step darker in the Gallery theme. The signed-in Home view requires Supabase auth (unavailable in this headless environment), so the tone changes are pinned by the new `theme` token unit tests; see the Vercel preview above for the live result.

## Linear

Closes #423

## Rollback plan

Green tier — single `git revert` of this PR's commit. Isolated to `theme.tsx`, `HomeScreen.tsx`, and one test file; no schema, storage, flag, or token-foundation changes beyond the two AA-alignment adjustments described above.