### PR TITLE
a11y: add semantic h1 heading to item detail view (#435)

### DIFF
--- a/src/components/ItemDetailScreen.tsx
+++ b/src/components/ItemDetailScreen.tsx
@@ -607,6 +607,10 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
           )}
           <div className="flex flex-col md:flex-row justify-between items-start gap-8 sm:gap-12">
             <div className="flex-1 w-full">
+              {/* Semantic page heading for document structure / screen readers.
+                  The visible title is an inline-editable textarea below, which
+                  cannot itself be a heading, so we mirror it here visually hidden. */}
+              <h1 className="sr-only">{item.title.trim() || t('untitled')}</h1>
               <textarea
                 ref={titleTextareaRef}
                 rows={1}


### PR DESCRIPTION
## Summary

Fixes the accessibility issue reported in #435, found during the recurring UI/UX product review.

The Item Detail screen renders the item title as an inline‑editable `<textarea>`, which cannot be a heading. As a result the page had **no `<h1>` — and no heading elements at all** (`document.querySelectorAll('h1,h2,h3,h4')` returned `[]` on a live item detail page). Screen‑reader users got no page title in the heading outline, and heading‑based navigation skipped the app's primary content view.

This adds a visually‑hidden `<h1>` that mirrors the item title (falling back to the existing `untitled` string when empty), giving the view a proper semantic heading while leaving the visible editable title — and its read‑only/disabled behaviour for public samples — completely unchanged.

## Change
- `src/components/ItemDetailScreen.tsx`: add `<h1 className="sr-only">{item.title.trim() || t('untitled')}</h1>` above the title textarea. `sr-only` and the `untitled` i18n key already exist in the codebase.

## Why this is low‑risk
- No visual change (the heading is `sr-only`).
- No behaviour change to editing or read‑only mode.
- The heading text updates live as the title is edited (it reads the same `item.title` state).

## Testing
Full mandatory gate run locally, all green:
- `npm run format:check` ✓
- `npm test` — 1099 passed / 2 skipped / 1 todo ✓
- `npm run build` ✓
- `npm run test:e2e` — 44 passed / 8 skipped ✓ (includes the accessibility spec's "proper heading hierarchy" and "landmark regions" checks)

## Related
Part of the UI/UX review that also filed #433 (AI analysis 503 in prod), #434 (Add Item failure copy/affordance), and #436 (post‑login intent mismatch). Those need product/design or backend work and are tracked as issues rather than included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLsWvCCJqvSwtFnUsr8h63

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLsWvCCJqvSwtFnUsr8h63)_