### PR TITLE
[CURIO-436] Resume "Add your first item" into Add Item for returning users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1469,15 +1469,34 @@ export const AppContent: React.FC = () => {
     }
   };
 
+  // Ready means: initial load settled, auth settled, the admin-profile lookup
+  // settled for the current session, and the last completed collections
+  // refresh served the current user/role identity. The identity key flips in
+  // the same render as an isAdmin/user change, so the marker can never show
+  // ready during the window between an admin lookup resolving and the seeding
+  // re-refresh it triggers.
+  const currentIdentityKey = `${user?.id ?? 'anon'}:${isAdmin ? 'admin' : 'member'}`;
+  const adminLookupSettled = adminCheckedFor === (user ? user.id : ANONYMOUS_ADMIN_SCOPE);
+  const appReady =
+    !isLoading &&
+    (!isSupabaseReady ||
+      (authReady && adminLookupSettled && refreshedForKey === currentIdentityKey));
+
   useEffect(() => {
     if (!isAuthenticated || !authActionQueue) return;
     if (authActionQueue === 'add-item') {
+      // A returning user's own collections load asynchronously after auth.
+      // Resolving the queued intent before that refresh settles would leave
+      // editableCollections empty, so handleAddAction would misread the user as
+      // brand-new and open "Start a collection" instead of Add Item (#436).
+      // Wait for the post-auth refresh before branching on collection count.
+      if (!appReady) return;
       handleAddAction();
     } else if (authActionQueue === 'create-collection') {
       setIsCreateCollectionOpen(true);
     }
     setAuthActionQueue(null);
-  }, [isAuthenticated, authActionQueue, handleAddAction]);
+  }, [isAuthenticated, authActionQueue, handleAddAction, appReady]);
 
   const renderAccessGate = () => (
     <div
@@ -1559,19 +1578,6 @@ export const AppContent: React.FC = () => {
       </div>
     </div>
   );
-
-  // Ready means: initial load settled, auth settled, the admin-profile lookup
-  // settled for the current session, and the last completed collections
-  // refresh served the current user/role identity. The identity key flips in
-  // the same render as an isAdmin/user change, so the marker can never show
-  // ready during the window between an admin lookup resolving and the seeding
-  // re-refresh it triggers.
-  const currentIdentityKey = `${user?.id ?? 'anon'}:${isAdmin ? 'admin' : 'member'}`;
-  const adminLookupSettled = adminCheckedFor === (user ? user.id : ANONYMOUS_ADMIN_SCOPE);
-  const appReady =
-    !isLoading &&
-    (!isSupabaseReady ||
-      (authReady && adminLookupSettled && refreshedForKey === currentIdentityKey));
 
   return (
     <div

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -60,6 +60,10 @@ vi.mock('@/services/supabase', () => ({
   },
   isSupabaseConfigured: vi.fn().mockReturnValue(true),
   signOutUser: vi.fn(),
+  signInWithEmail: vi.fn().mockResolvedValue({ session: { user: { id: 'user1' } } }),
+  signUpWithEmail: vi.fn().mockResolvedValue({ session: { user: { id: 'user1' } } }),
+  resetPasswordForEmail: vi.fn().mockResolvedValue(undefined),
+  updateUserPassword: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/services/geminiService', () => ({
@@ -568,6 +572,68 @@ describe('App Integration Tests', () => {
     // The manual escape hatch to sign-in stays available.
     fireEvent.click(within(modal).getByText(/Already have an account/i));
     expect(within(modal).getByRole('heading', { name: /welcome back/i })).toBeInTheDocument();
+  });
+
+  // #436: a returning user who taps the landing "Add your first item" CTA and
+  // signs in must resume into Add Item — not "Start a collection". Their
+  // collections load asynchronously after auth, so the queued intent must wait
+  // for that refresh before branching on collection count; resolving it too
+  // early misreads them as brand-new and opens the create-collection flow.
+  it('resumes "Add your first item" into Add Item for a returning user whose collections load after login (#436)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+    // Signed-out landing: no session yet.
+    vi.mocked(supabaseService.supabase!.auth.getSession).mockResolvedValue({
+      data: { session: null },
+    } as never);
+    // Fresh device with no local cache: the returning user's collection lives
+    // only in the cloud and arrives after auth completes — the exact window
+    // where the queued intent used to misfire into "Start a collection".
+    vi.mocked(db.getLocalCollections).mockResolvedValue([]);
+    vi.mocked(db.fetchCloudCollections).mockImplementation(async ({ userId }) =>
+      userId ? [mockCollection] : [],
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('access-gate')).toBeInTheDocument();
+    });
+
+    // Tap the landing CTA, switch to sign-in (returning user), and submit.
+    fireEvent.click(screen.getByTestId('cta-primary-add-first'));
+    const modal = await screen.findByTestId('auth-modal');
+    fireEvent.click(within(modal).getByText(/Already have an account/i));
+    fireEvent.change(within(modal).getByLabelText('Email Address'), {
+      target: { value: 'returning@example.com' },
+    });
+    fireEvent.change(within(modal).getByLabelText('Password'), {
+      target: { value: 'hunter2pw' },
+    });
+    await act(async () => {
+      fireEvent.click(within(modal).getByRole('button', { name: 'Sign In' }));
+    });
+
+    // signInWithEmail is mocked, so drive the auth-state transition Supabase
+    // would otherwise emit. This flips the app to authenticated and resumes the
+    // queued intent while the cloud collections fetch is still in flight.
+    const authCallback = vi.mocked(supabaseService.supabase!.auth.onAuthStateChange).mock
+      .calls[0][0];
+    await act(async () => {
+      authCallback('SIGNED_IN', { user: { id: 'user1' } } as never);
+    });
+
+    // Once their data settles the resume lands on Add Item, never on the
+    // create-collection modal.
+    expect(await screen.findByTestId('add-item-upload-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('create-collection-modal')).not.toBeInTheDocument();
   });
 
   it('shows one desktop sign-in control that opens sign-in mode (CUR-157, CUR-152)', async () => {


### PR DESCRIPTION
## Problem

On the signed-out landing page, the primary CTA is **"Add your first item"**. When a *returning* user (who already has collections) taps it, signs in, and lands back on their museum, the app opens the **"Start a collection"** modal on top of their populated home — not Add Item.

The root cause is a race, not a missing branch. `handleAddAction` already branches on collection count, but the queued post-auth resume ran it the instant `isAuthenticated` flipped true — *before* the returning user's collections finished loading from the cloud. In that window `editableCollections` is still empty, so the user is misread as brand-new and dropped into create-collection. This breaks intent-preservation and the trust principle: the post-login action should match the button the user pressed.

## Approach

Gate the queued **add-item** resume on `appReady`, which already tracks that the post-auth collections refresh has settled for the current identity (`refreshedForKey === currentIdentityKey`, plus auth/admin-lookup settled). The effect now waits for loaded data before branching on collection count. The **create-collection** resume path is unconditional and unchanged. Hoisted the existing `appReady` derivation a few lines up so both the effect and the app-shell readiness marker share one definition rather than duplicating the logic.

## Why this approach

`appReady` is the codebase's existing, battle-tested signal that "this identity's data is loaded" — reusing it keeps one source of truth instead of inventing a parallel readiness flag. The fix is ~1 meaningful line of behavior (`if (!appReady) return;`) plus a code move, and it preserves the correct new-user flow (0 collections → "Start a collection") because that branch only runs once real data is in hand.

## Risks

Low–moderate. Touches post-auth intent resume in `App.tsx`.
- The `add-item` resume now waits for the refresh to settle. `refreshedForKey` is set in **every** refresh branch (success and both error paths), so a failed/empty cloud fetch still lets the action fire — it can't strand the user. On cloud failure with no collections, it correctly falls back to "Start a collection" (you can't add an item without a collection).
- New-user and Explore paths are unchanged; covered by existing tests (all green).

## How to verify

Vercel Preview: https://curio-git-claude-curio-436-resume-a-9cadb0-qs-projects-72b20d9d.vercel.app

Steps:
1. Sign out. On the landing page, click **Add your first item**.
2. In the auth modal, switch to **Sign in** and log in with an account that already has ≥1 collection.
3. After login, the **Add Item** flow opens (or you land home) — **not** "Start a collection".
4. Repeat with a brand-new account that has 0 collections: **"Start a collection"** still opens (unchanged).

Checks:
- [x] npm run format:check
- [x] npm test (1117 passed)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

Automated coverage: `tests/integration/AppNavigation.test.tsx` adds a regression test that drives the sign-in resume with cloud collections arriving after auth. It **fails** without the guard (create-collection opens) and **passes** with it (Add Item opens). Verified both directions locally.

## Screenshot / GIF

Behavioral fix (modal routing after login); no visual/style change. The observable difference is which modal opens after the sign-in resume — asserted by the new integration test rather than a screenshot, since reproducing the load-timing race by hand for a clean capture is unreliable.

## Linear

Closes #436

## Rollback plan

Revert the single commit on this branch:
`git revert <commit-sha>` (or reset the branch). No migrations, flags, storage, or schema involved — the change is confined to `src/App.tsx` intent-resume logic and one test.