### PR TITLE
[#86] Document the public sample gallery admin workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,41 +153,16 @@ If you previously created tables with UUID `id` columns for collections/items, d
 
 ### Public Sample Collection
 
-Curated sample collections are stored in the same `collections`/`items` tables and marked with `is_public = true`. All users can read them, but only admin users can edit or delete them.
+Curated sample collections live in the same `collections`/`items` tables
+(`is_public = true`), defined in code at `src/services/seedCollections.ts` with
+images served from `public/assets/`. Everyone can read them; writes are limited to
+admins and the row owner.
 
-To promote an admin account:
-
-```sql
-update public.profiles set is_admin = true where id = 'YOUR_USER_UUID';
-```
-
-Notes:
-
-- Public samples should use local image assets (e.g., `public/assets/...`) rather than private storage paths.
-- The admin account can seed the public sample by signing in on a clean database and saving the sample collection.
-
-### Seed Data Structure (Sample Content)
-
-Seed data is the default sample content every new user sees. In this project it is defined in
-`src/services/seedCollections.ts` and used by `App.tsx` to populate the sample collection when the database
-is empty and the current user is an admin.
-
-Why this structure:
-
-- Keeps sample content in a single, predictable file (easier to maintain than inline data in `App.tsx`).
-- Keeps sample images local so they load without Supabase storage policies or public buckets.
-
-#### Rules for Sample Assets
-
-- Store sample images in `public/assets/`.
-- Use stable, descriptive filenames (e.g., `sample-vinyl.jpg`, `sample-camera.jpg`).
-- Prefer `.jpg` for consistent compression and load performance.
-- Reference paths as `assets/<filename>` in seed data (`photoUrl` fields).
-
-To add new sample items:
-
-1. Add the image file to `public/assets/`.
-2. Add or update the item entry in `src/services/seedCollections.ts` with `photoUrl: 'assets/<filename>'`.
+The full admin workflow — the code-defined seed and `CURRENT_SEED_VERSION`, how an
+admin publishes changes to Supabase (reconciled on every admin load, not just a
+clean database), the sample-asset rules, and how to grant admin — is the single
+source of truth in
+**[`docs/ops/PUBLIC_SAMPLE_GALLERY.md`](docs/ops/PUBLIC_SAMPLE_GALLERY.md)**.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Issue prioritization and TODO tracking live in **GitHub Issues**, not in docs. P
 
 ### Other docs (organized)
 
-- **Operations**: `docs/ops/AI_GATEWAY_MONITORING.md`, `docs/ops/INDEXEDDB_RELIABILITY.md`, `docs/ops/PWA_CACHE_STRATEGY.md`
+- **Operations**: `docs/ops/AI_GATEWAY_MONITORING.md`, `docs/ops/INDEXEDDB_RELIABILITY.md`, `docs/ops/PWA_CACHE_STRATEGY.md`, `docs/ops/PUBLIC_SAMPLE_GALLERY.md` (admin guide for the pre-login sample gallery)
 - **Product analytics**: `docs/ops/PRODUCT_ANALYTICS.md`
 - **Release**: `docs/GOOGLE_PLAY_SUBMISSION_GUIDE.md`, `docs/ANDROID_PRODUCTION_REVIEW.md`
 - **Plans**: `docs/plan/` (forward-looking design specs; deleted after shipping)

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -38,7 +38,7 @@ If a user has existing IndexedDB data from older builds, they can trigger a manu
 
 ### Public Sample Collections
 
-Curated sample collections live in the same tables and are flagged with `is_public = true`. In the current implementation, authenticated users can read them, but only admin users (profiles with `is_admin = true`) can edit or delete them. The client treats public collections as read-only for non-admins.
+Curated sample collections live in the same tables and are flagged with `is_public = true`. In the current implementation, everyone can read them (public read via RLS), while writes are limited to admins and the row's owner — the policy is `auth.uid() = user_id or (is_public and is_admin)` (`supabase/1_schema.sql`). The client treats public collections as read-only for non-admins. See `docs/ops/PUBLIC_SAMPLE_GALLERY.md` for the admin workflow and the owner-exception detail.
 
 For Phase 1, that public-collection foundation should extend into anonymous-readable public museum routes for profile, collection, item, Wrapped, and widget surfaces. Those routes must expose only content derived from explicitly public collections.
 

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -33,14 +33,33 @@ _structural_ drift, not content edits — see "Seed versioning" below.)
   no-op.
 - **Only the owner or an admin can write it.** RLS gives everyone public read on
   `is_public` collections/items, but a write requires either being an admin _or_
-  being the row's `user_id` owner — the policy is
-  `auth.uid() = user_id or (is_public and is_admin)` (`supabase/1_schema.sql`). So
-  a visitor or ordinary signed-in user can browse but not change the gallery. One
-  caveat worth knowing: the admin who first publishes a sample becomes its owner,
-  and the owner branch is independent of `is_admin`, so a former admin who is later
-  demoted keeps DB-level write access to the rows they published. Closing that gap
-  is an RLS change beyond this guide's scope — it means reviewing the owner
-  (`auth.uid() = user_id`) write branches in `supabase/1_schema.sql`, which is the
+  being the row's owner — broadly `auth.uid() = user_id or (is_public and
+is_admin)` (`supabase/1_schema.sql`). So a visitor or ordinary signed-in user can
+  browse but not change the gallery.
+
+  One caveat worth knowing: the admin who first publishes a sample becomes its
+  owner, and the owner branch does not re-check `is_admin`, so an admin who is
+  later demoted keeps DB-level write access to the rows they published — the app
+  UI is read-only for them, but Supabase (REST/SQL) is not. Exactly five policies
+  carry that bypass:
+
+  | Policy                    | Owner branch that bypasses `is_admin`                    |
+  | ------------------------- | -------------------------------------------------------- |
+  | `collections: update own` | `auth.uid() = user_id`                                   |
+  | `collections: delete own` | `auth.uid() = user_id`                                   |
+  | `items: insert own`       | `c.user_id = auth.uid()` (the parent collection's owner) |
+  | `items: update own`       | `auth.uid() = user_id`                                   |
+  | `items: delete own`       | `auth.uid() = user_id`                                   |
+
+  The other write policies are already admin-gated and need no change:
+  `collections: insert own` requires admin whenever `is_public = true`, and every
+  `item_images` write policy requires either a private parent collection or a
+  current admin.
+
+  Closing the gap is an RLS change beyond this guide's scope. If you do take it on,
+  restricting only the update/delete policies is incomplete — `items: insert own`
+  would still let a demoted owner add content to the public gallery, so its owner
+  branch has to become private-only too. `supabase/1_schema.sql` remains the
   authoritative definition of who can write.
 
 ### Seed versioning

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -38,9 +38,12 @@ _structural_ drift, not content edits — see "Seed versioning" below.)
   a visitor or ordinary signed-in user can browse but not change the gallery. One
   caveat worth knowing: the admin who first publishes a sample becomes its owner,
   and the owner branch is independent of `is_admin`, so a former admin who is later
-  demoted keeps DB-level write access to the rows they published. If edits must be
-  strictly admin-only, drop the owner branch from the public rows' update/delete
-  policies.
+  demoted keeps DB-level write access to the rows they published. Making this
+  strictly admin-only is a policy change beyond this guide's scope: the owner
+  (`auth.uid() = user_id`) branch appears in the **insert, update, and delete**
+  policies for `collections`, `items`, and `item_images` in
+  `supabase/1_schema.sql`, so all of them (not just update/delete) would need
+  revisiting together.
 
 ### Seed versioning
 
@@ -98,7 +101,11 @@ as few accounts as possible.
    them with `sampleAsset('your-file.jpg')`. For the Vinyl Vault artwork, the
    still-lifes are generated, not hand-shot — re-render them with
    `node scripts/generate-sample-vinyl.mjs` (guarded by
-   `tests/unit/publicAssets.regression.test.ts`).
+   `tests/unit/publicAssets.regression.test.ts`). Note: `public/sw.js` caches
+   `/assets/` **stale-while-revalidate**, so re-rendering an image under the _same_
+   filename shows the old art on a returning visitor's first load (it refreshes in
+   the background). If you need the change to be visible immediately, give the new
+   artwork a new filename, or verify with a hard reload / fresh browser.
 3. **Bump the version.** Increment `CURRENT_SEED_VERSION` by one whenever step 1 or
    2 changed content. (You can skip the bump only for a pure code refactor that
    leaves the rendered seed identical.)
@@ -115,8 +122,10 @@ as few accounts as possible.
    time — so the forced pass upserts your change. A **structural** addition (a new
    collection or item, a restored/broken photo) publishes from any admin load,
    including a fresh browser. If your only admin browser is fresh and the change is
-   content-only, update the affected rows directly in Supabase. Reload as a
-   signed-out visitor to confirm the gallery reflects the update.
+   content-only, update the affected rows directly in Supabase. Confirm as a
+   signed-out visitor — hard-reload (or use a fresh browser) if you changed an
+   image under an existing filename, since the service worker serves it
+   stale-while-revalidate.
 
 ## Local development vs production
 

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -38,12 +38,10 @@ _structural_ drift, not content edits — see "Seed versioning" below.)
   a visitor or ordinary signed-in user can browse but not change the gallery. One
   caveat worth knowing: the admin who first publishes a sample becomes its owner,
   and the owner branch is independent of `is_admin`, so a former admin who is later
-  demoted keeps DB-level write access to the rows they published. Making this
-  strictly admin-only is a policy change beyond this guide's scope: the owner
-  (`auth.uid() = user_id`) branch appears in the **insert, update, and delete**
-  policies for `collections`, `items`, and `item_images` in
-  `supabase/1_schema.sql`, so all of them (not just update/delete) would need
-  revisiting together.
+  demoted keeps DB-level write access to the rows they published. Closing that gap
+  is an RLS change beyond this guide's scope — it means reviewing the owner
+  (`auth.uid() = user_id`) write branches in `supabase/1_schema.sql`, which is the
+  authoritative definition of who can write.
 
 ### Seed versioning
 

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -13,10 +13,14 @@ _structural_ drift, not content edits — see "Seed versioning" below.)
 
 ## How it works
 
-- **Source of truth is code.** `INITIAL_COLLECTIONS` in
+- **Source of truth is code — for content that exists.** `INITIAL_COLLECTIONS` in
   `src/services/seedCollections.ts` defines every sample collection and item
-  (currently "The Vinyl Vault"). Supabase holds a mirror of this, not the
-  original.
+  (currently "The Vinyl Vault"); Supabase holds a mirror of this, not the
+  original. One asymmetry: **removals are not reconciled.** `buildSeedRepairs`
+  iterates only the seeds still present in code and preserves any unmatched cloud
+  row as a curator item, so deleting a collection or item from
+  `INITIAL_COLLECTIONS` leaves its cloud row live and still visible in the gallery.
+  To retire a sample, delete its row (and its images) directly in Supabase.
 - **Images are public files.** Sample photos live in `public/assets/` and are
   referenced with the `sampleAsset()` helper, so they resolve to plain public
   URLs (`<BASE_URL>assets/<file>`). The gallery never depends on private Supabase
@@ -144,8 +148,10 @@ as few accounts as possible.
    carried the previous seed version (its recorded `seed_version` is now below the
    new `CURRENT_SEED_VERSION`) — usually the admin browser you published from last
    time — so the forced pass upserts your change. A **structural** addition (a new
-   collection or item, a restored/broken photo) publishes from any admin load,
-   including a fresh browser. If your only admin browser is fresh and the change is
+   collection or item, or repairing a photo path that is null or the superseded
+   #373 shared image) publishes from any admin load, including a fresh browser;
+   swapping an existing photo to a _different_ canonical asset is a content edit,
+   not structural. If your only admin browser is fresh and the change is
    content-only, update the affected rows directly in Supabase. Confirm as a
    signed-out visitor — hard-reload (or use a fresh browser) if you changed an
    image under an existing filename, since the service worker serves it

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -1,0 +1,130 @@
+# Public Sample Gallery — Admin Guide
+
+How to add or update the pre-login **Public Sample Gallery** (the seed
+collections a visitor explores before signing in). This is admin-only internal
+tooling; normal users see the gallery read-only.
+
+If you only need the one-line version: the gallery is **code-defined** in
+`src/services/seedCollections.ts`. Edit it, bump `CURRENT_SEED_VERSION`, ship the
+code, then load the app **once while signed in as an admin** — that publishes the
+change to Supabase automatically.
+
+## How it works
+
+- **Source of truth is code.** `INITIAL_COLLECTIONS` in
+  `src/services/seedCollections.ts` defines every sample collection and item
+  (currently "The Vinyl Vault"). Supabase holds a mirror of this, not the
+  original.
+- **Images are public files.** Sample photos live in `public/assets/` and are
+  referenced with the `sampleAsset()` helper, so they resolve to plain public
+  URLs (`<BASE_URL>assets/<file>`). The gallery never depends on private Supabase
+  Storage — that is what lets a signed-out visitor see it.
+- **Admins publish by loading the app.** On every load by an admin, the app
+  reconciles the cloud copy against the code-defined seed
+  (`buildSeedRepairs` → `saveCollection`, in `src/hooks/useCollections.ts` and the
+  matching path in `src/App.tsx`). It upserts the seed rows as `is_public: true`.
+  This is self-healing: drift (a row toggled private, a missing item, a stripped
+  photo path) is repaired the next time an admin opens the app. A healthy cloud
+  copy makes the pass a no-op.
+- **Non-admins never write it.** RLS gives everyone public read on `is_public`
+  collections/items but restricts edits to admins, so a visitor or ordinary user
+  can browse the gallery but cannot change it.
+
+### Seed versioning
+
+`CURRENT_SEED_VERSION` (in `seedCollections.ts`) gates whether existing installs
+re-pull your content:
+
+- Each device records the last-applied version in IndexedDB (`seed_version`).
+- Structural drift is always repaired. But a device that already has a **healthy**
+  cloud copy only re-pushes your edited content when its recorded version is lower
+  than `CURRENT_SEED_VERSION`.
+- **So: bump `CURRENT_SEED_VERSION` whenever you change seed _content_** (titles,
+  notes, ratings, field data, canonical photos). If you skip the bump, admin
+  devices that already recorded the current version treat their healthy cloud copy
+  as fine and your edit never propagates.
+- A fresh/cleared device reports version `0`, which forces nothing on its own —
+  only a device that recorded an _older_ version forces a content re-push.
+
+### Admin-curated photos are preserved
+
+If an admin swaps a sample item's photo in-app (the **Update Photo** control on a
+public item), that custom photo is kept across seed-version upgrades
+(`isCustomSeedPhoto` in `seedCollections.ts`). A forced content upgrade updates
+everything else from the new seed but leaves an explicitly curated photo alone.
+
+## Granting admin access
+
+Admin status is the `is_admin` flag on the `public.profiles` row for a user
+(`supabase/3_profiles.sql`). The app reads it in `src/hooks/useAuthState.ts`.
+
+There is **no in-app UI to grant admin** — by design. The `profiles` RLS update
+policy explicitly forbids a user from changing their own `is_admin`. Set it
+directly in Supabase (SQL editor or Table editor) for the target account:
+
+```sql
+update public.profiles set is_admin = true where id = '<auth-user-uuid>';
+```
+
+Look up `<auth-user-uuid>` in the Supabase **Authentication → Users** list. Do
+this against the same project the environment points at (dev vs prod). Grant it to
+as few accounts as possible.
+
+## Add or update a sample collection (step by step)
+
+1. **Edit the seed.** In `src/services/seedCollections.ts`, update
+   `INITIAL_COLLECTIONS` — add/edit items, adjust titles, `data` fields, ratings,
+   and human-written `notes`. Keep each item's stable `id` and `seedKey`; they are
+   how reconciliation matches a code item to its cloud row. A new collection needs
+   its own `id`/`seedKey` and a `templateId` from `constants.ts`.
+2. **Add images (if any).** Drop the JPEG(s) into `public/assets/` and reference
+   them with `sampleAsset('your-file.jpg')`. For the Vinyl Vault artwork, the
+   still-lifes are generated, not hand-shot — re-render them with
+   `node scripts/generate-sample-vinyl.mjs` (guarded by
+   `tests/unit/publicAssets.regression.test.ts`).
+3. **Bump the version.** Increment `CURRENT_SEED_VERSION` by one whenever step 1 or
+   2 changed content. (You can skip the bump only for a pure code refactor that
+   leaves the rendered seed identical.)
+4. **Verify locally.** `npm run dev`, sign in with an admin account against your
+   dev Supabase project, and load the home screen. Confirm the gallery renders,
+   the change is present, and the read-only labelling still holds for a
+   non-admin/signed-out view. Run `npm test` (the public-assets regression test
+   covers the sample images) and `npm run build`.
+5. **Ship the code.** Merge and deploy as usual (Vercel).
+6. **Publish to production.** After the deploy, open the production app **once
+   while signed in as a prod admin**. That load runs the reconciliation and upserts
+   the new seed into the production database as public rows. Reload as a
+   signed-out visitor to confirm the gallery reflects the update.
+
+## Local development vs production
+
+The mechanism is identical in both; only the Supabase project and admin account
+differ.
+
+| Step                | Local development                                | Production                                        |
+| ------------------- | ------------------------------------------------ | ------------------------------------------------- |
+| Target database     | Your dev Supabase project (`.env`)               | The production Supabase project                   |
+| Admin account       | An account with `is_admin = true` in the dev DB  | An account with `is_admin = true` in the prod DB  |
+| Trigger the publish | Load `npm run dev` signed in as the dev admin    | Load the deployed app signed in as the prod admin |
+| Verify              | Signed-out browse + `npm test` / `npm run build` | Signed-out browse of the live gallery             |
+
+## Troubleshooting
+
+- **My edit didn't show up in the cloud.** You likely forgot to bump
+  `CURRENT_SEED_VERSION`; a device with a healthy cloud copy and the current
+  version won't re-push content. Bump it, redeploy, and reload as an admin.
+- **The gallery went blank / rows disappeared.** An admin load self-heals
+  structural drift — sign in as an admin and reload. If it persists, confirm the
+  rows are still `is_public = true` and the account's `is_admin` flag is set.
+- **A sample image 404s.** Confirm the file exists in `public/assets/` and the
+  `sampleAsset('…')` filename matches exactly (the build serves it from
+  `<BASE_URL>assets/`).
+
+## Related
+
+- Code: `src/services/seedCollections.ts`, `src/hooks/useCollections.ts`,
+  `src/App.tsx`, `src/hooks/useAuthState.ts`
+- Schema/RLS: `supabase/1_schema.sql` (public read + admin edit),
+  `supabase/3_profiles.sql` (`is_admin`)
+- Adding a new template that a sample uses: see "Adding a New Collection Template"
+  in `CLAUDE.md`

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -6,8 +6,10 @@ tooling; normal users see the gallery read-only.
 
 If you only need the one-line version: the gallery is **code-defined** in
 `src/services/seedCollections.ts`. Edit it, bump `CURRENT_SEED_VERSION`, ship the
-code, then load the app **once while signed in as an admin** — that publishes the
-change to Supabase automatically.
+code, then load the app signed in as an admin **from a browser that already
+carried the previous version** — that publishes the change to Supabase. (A
+brand-new or cleared browser reports seed version `0` and only self-heals
+_structural_ drift, not content edits — see "Seed versioning" below.)
 
 ## How it works
 
@@ -23,12 +25,22 @@ change to Supabase automatically.
   reconciles the cloud copy against the code-defined seed
   (`buildSeedRepairs` → `saveCollection`, in `src/hooks/useCollections.ts` and the
   matching path in `src/App.tsx`). It upserts the seed rows as `is_public: true`.
-  This is self-healing: drift (a row toggled private, a missing item, a stripped
-  photo path) is repaired the next time an admin opens the app. A healthy cloud
-  copy makes the pass a no-op.
-- **Non-admins never write it.** RLS gives everyone public read on `is_public`
-  collections/items but restricts edits to admins, so a visitor or ordinary user
-  can browse the gallery but cannot change it.
+  Two kinds of change behave differently: **structural** drift (a missing
+  collection or item, a row toggled private, a null or superseded photo path) is
+  self-healed on _any_ admin load; **content** edits to an existing item (title,
+  notes, rating, `data` fields, a swapped canonical photo) are only re-pushed when
+  the version gate below opens. A healthy, up-to-date cloud copy makes the pass a
+  no-op.
+- **Only the owner or an admin can write it.** RLS gives everyone public read on
+  `is_public` collections/items, but a write requires either being an admin _or_
+  being the row's `user_id` owner — the policy is
+  `auth.uid() = user_id or (is_public and is_admin)` (`supabase/1_schema.sql`). So
+  a visitor or ordinary signed-in user can browse but not change the gallery. One
+  caveat worth knowing: the admin who first publishes a sample becomes its owner,
+  and the owner branch is independent of `is_admin`, so a former admin who is later
+  demoted keeps DB-level write access to the rows they published. If edits must be
+  strictly admin-only, drop the owner branch from the public rows' update/delete
+  policies.
 
 ### Seed versioning
 
@@ -37,14 +49,19 @@ re-pull your content:
 
 - Each device records the last-applied version in IndexedDB (`seed_version`).
 - Structural drift is always repaired. But a device that already has a **healthy**
-  cloud copy only re-pushes your edited content when its recorded version is lower
-  than `CURRENT_SEED_VERSION`.
+  cloud copy only re-pushes your edited content when it does a _forced_ pass, and
+  the force flag opens only when its recorded version is **greater than 0 and lower
+  than** `CURRENT_SEED_VERSION` (`force: localSeedVersion > 0 && localSeedVersion < CURRENT_SEED_VERSION`).
 - **So: bump `CURRENT_SEED_VERSION` whenever you change seed _content_** (titles,
   notes, ratings, field data, canonical photos). If you skip the bump, admin
   devices that already recorded the current version treat their healthy cloud copy
   as fine and your edit never propagates.
-- A fresh/cleared device reports version `0`, which forces nothing on its own —
-  only a device that recorded an _older_ version forces a content re-push.
+- A fresh or cleared device reports version `0`. Because `0` is not `> 0`, it never
+  forces a content re-push — it only self-heals structural drift. **A content edit
+  therefore publishes only from a browser that recorded the _previous_ version**
+  (typically the same admin browser you published from last time), which after the
+  bump satisfies `0 < recorded < CURRENT_SEED_VERSION`. If you have no such browser,
+  update the affected rows directly in Supabase instead.
 
 ### Admin-curated photos are preserved
 
@@ -91,9 +108,14 @@ as few accounts as possible.
    non-admin/signed-out view. Run `npm test` (the public-assets regression test
    covers the sample images) and `npm run build`.
 5. **Ship the code.** Merge and deploy as usual (Vercel).
-6. **Publish to production.** After the deploy, open the production app **once
-   while signed in as a prod admin**. That load runs the reconciliation and upserts
-   the new seed into the production database as public rows. Reload as a
+6. **Publish to production.** After the deploy, open the production app signed in
+   as a prod admin. For a **content** edit, use a browser profile that already
+   carried the previous seed version (its recorded `seed_version` is now below the
+   new `CURRENT_SEED_VERSION`) — usually the admin browser you published from last
+   time — so the forced pass upserts your change. A **structural** addition (a new
+   collection or item, a restored/broken photo) publishes from any admin load,
+   including a fresh browser. If your only admin browser is fresh and the change is
+   content-only, update the affected rows directly in Supabase. Reload as a
    signed-out visitor to confirm the gallery reflects the update.
 
 ## Local development vs production
@@ -101,18 +123,21 @@ as few accounts as possible.
 The mechanism is identical in both; only the Supabase project and admin account
 differ.
 
-| Step                | Local development                                | Production                                        |
-| ------------------- | ------------------------------------------------ | ------------------------------------------------- |
-| Target database     | Your dev Supabase project (`.env`)               | The production Supabase project                   |
-| Admin account       | An account with `is_admin = true` in the dev DB  | An account with `is_admin = true` in the prod DB  |
-| Trigger the publish | Load `npm run dev` signed in as the dev admin    | Load the deployed app signed in as the prod admin |
-| Verify              | Signed-out browse + `npm test` / `npm run build` | Signed-out browse of the live gallery             |
+| Step                | Local development                                                                              | Production                                                                                         |
+| ------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Target database     | Your dev Supabase project (`.env`)                                                             | The production Supabase project                                                                    |
+| Admin account       | An account with `is_admin = true` in the dev DB                                                | An account with `is_admin = true` in the prod DB                                                   |
+| Trigger the publish | Load `npm run dev` as the dev admin (content edits: from a browser carrying the prior version) | Load the deployed app as the prod admin (content edits: from a browser carrying the prior version) |
+| Verify              | Signed-out browse + `npm test` / `npm run build`                                               | Signed-out browse of the live gallery                                                              |
 
 ## Troubleshooting
 
-- **My edit didn't show up in the cloud.** You likely forgot to bump
-  `CURRENT_SEED_VERSION`; a device with a healthy cloud copy and the current
-  version won't re-push content. Bump it, redeploy, and reload as an admin.
+- **My content edit didn't show up in the cloud.** Either you forgot to bump
+  `CURRENT_SEED_VERSION`, or you published from a fresh/cleared browser (recorded
+  version `0`, so the forced content pass never ran). Bump the version, redeploy,
+  and reload as an admin from a browser that carried the previous version — or
+  update the affected rows directly in Supabase. (Structural additions don't need
+  this; they publish from any admin load.)
 - **The gallery went blank / rows disappeared.** An admin load self-heals
   structural drift — sign in as an admin and reload. If it persists, confirm the
   rows are still `is_public = true` and the account's `is_admin` flag is set.
@@ -124,7 +149,7 @@ differ.
 
 - Code: `src/services/seedCollections.ts`, `src/hooks/useCollections.ts`,
   `src/App.tsx`, `src/hooks/useAuthState.ts`
-- Schema/RLS: `supabase/1_schema.sql` (public read + admin edit),
+- Schema/RLS: `supabase/1_schema.sql` (public read + owner/admin edit),
   `supabase/3_profiles.sql` (`is_admin`)
 - Adding a new template that a sample uses: see "Adding a New Collection Template"
   in `CLAUDE.md`

--- a/docs/ops/PUBLIC_SAMPLE_GALLERY.md
+++ b/docs/ops/PUBLIC_SAMPLE_GALLERY.md
@@ -26,11 +26,15 @@ _structural_ drift, not content edits — see "Seed versioning" below.)
   (`buildSeedRepairs` → `saveCollection`, in `src/hooks/useCollections.ts` and the
   matching path in `src/App.tsx`). It upserts the seed rows as `is_public: true`.
   Two kinds of change behave differently: **structural** drift (a missing
-  collection or item, a row toggled private, a null or superseded photo path) is
-  self-healed on _any_ admin load; **content** edits to an existing item (title,
-  notes, rating, `data` fields, a swapped canonical photo) are only re-pushed when
-  the version gate below opens. A healthy, up-to-date cloud copy makes the pass a
-  no-op.
+  collection or item, a null or superseded photo path) is self-healed on _any_
+  admin load; **content** edits to an existing item (title, notes, rating,
+  `data` fields, a swapped canonical photo) are only re-pushed when the version
+  gate below opens. A healthy, up-to-date cloud copy makes the pass a no-op.
+  One exception: a sample row toggled **private** is visible to, and repairable
+  by, only the admin who owns it — RLS (`collections: select own` /
+  `collections: update own`) hides another admin's private row and denies their
+  upsert — so recovering that specific case needs the owning admin, not just any
+  admin load.
 - **Only the owner or an admin can write it.** RLS gives everyone public read on
   `is_public` collections/items, but a write requires either being an admin _or_
   being the row's owner — broadly `auth.uid() = user_id or (is_public and
@@ -93,7 +97,10 @@ everything else from the new seed but leaves an explicitly curated photo alone.
 ## Granting admin access
 
 Admin status is the `is_admin` flag on the `public.profiles` row for a user
-(`supabase/3_profiles.sql`). The app reads it in `src/hooks/useAuthState.ts`.
+(`supabase/3_profiles.sql`). The live app determines it with an inline
+`profiles.is_admin` query in `src/App.tsx` — the `useAuthState` hook runs the same
+query but is currently wired only into its tests, not the app, so debug the
+`App.tsx` path when admin detection misbehaves.
 
 There is **no in-app UI to grant admin** — by design. The `profiles` RLS update
 policy explicitly forbids a user from changing their own `is_admin`. Set it


### PR DESCRIPTION
## Problem

Updating the pre-login **Public Sample Gallery** (the seed collections a visitor explores before signing in) requires tribal knowledge: the code path through `seedCollections.ts`, bumping `CURRENT_SEED_VERSION`, the admin-only publish-by-loading-the-app mechanism, the `public/assets/` image convention, and the Supabase `is_public` / `seed_key` / `profiles.is_admin` model. No admin-facing guide existed, so this internal task lived only in code and reviewer memory. This protects **trust before growth** (the sample gallery is the first thing a signed-out visitor sees — keeping it correct and maintainable matters) without adding any product surface area.

## Approach

Added `docs/ops/PUBLIC_SAMPLE_GALLERY.md`, a focused admin guide that documents:

- how the gallery works (code-defined seed → self-healing Supabase mirror on admin load, images as public files)
- the `CURRENT_SEED_VERSION` versioning system and when to bump it
- how admin-curated photos are preserved across upgrades
- how to grant admin via `profiles.is_admin` (and why there is no in-app UI for it)
- a step-by-step add/update procedure
- a local-development vs production comparison table
- a short troubleshooting section

Registered the new doc in the README canonical docs list under **Operations**. Every claim was verified against the current code (`seedCollections.ts`, `useCollections.ts`, `App.tsx`, `useAuthState.ts`, `supabase/3_profiles.sql`).

## Why this approach

Documentation-only, no runtime change — the smallest way to satisfy the request while honoring CLAUDE.md's "no duplicate docs" rule (no existing doc covered this; it slots into the existing `docs/ops/` home). It surfaces the process by cross-linking from the README rather than adding new UI.

## Risks

Low — docs only, no runtime code, dependencies, schema, RLS, or build config touched. The only failure mode is documentation drifting from code later; mitigated by anchoring each section to specific source files.

## How to verify

Vercel Preview: https://curio-git-claude-lucid-dijkstra-8uiftm-qs-projects-72b20d9d.vercel.app (docs-only change; the running app is unaffected).

Steps:
1. Read `docs/ops/PUBLIC_SAMPLE_GALLERY.md` end to end.
2. Cross-check against `src/services/seedCollections.ts` (`CURRENT_SEED_VERSION`, `INITIAL_COLLECTIONS`, `buildSeedRepairs`, `isCustomSeedPhoto`), `src/hooks/useCollections.ts` / `src/App.tsx` (admin reconcile path), `src/hooks/useAuthState.ts` (`is_admin` lookup), and `supabase/3_profiles.sql`.
3. Confirm the README **Operations** line links the new doc.

Checks (run locally on the head commit):
- [x] npm run format:check
- [x] npm test (1116 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

Not applicable — documentation-only change, no user-visible UI.

## Issue

Closes #86

## Rollback plan

Revert this PR's single commit (`git revert <sha>`), or delete `docs/ops/PUBLIC_SAMPLE_GALLERY.md` and the one-line README entry. No migrations, flags, storage, or schema involved.