### PR TITLE
CUR-111 Make Atelier color tokens WCAG AA compliant

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -70,18 +70,20 @@
 
 ### Atelier (Warm)
 
-| Token         | Value                              | Usage                            |
-| ------------- | ---------------------------------- | -------------------------------- |
-| Surface       | `#F5EFE4`                          | Warm cream with yellow undertone |
-| Surface Muted | `#EDE4D3`                          | Parchment mat                    |
-| Text          | `#3D3530`                          | Warm dark brown                  |
-| Text Muted    | `#8C7B6B`                          | Sepia-toned muted text           |
-| Border        | `#D4C9B8`                          | Warm, visible dividers           |
-| Accent        | `#A86F3C`                          | Rich amber-brown (aged leather)  |
-| Accent Hover  | `#8B5A2B`                          | Deeper on hover                  |
-| Frame Accent  | `#6B5344`                          | Aged wood brown                  |
-| Shadow        | `0 2px 12px rgba(168,111,60,0.10)` | Card resting state               |
-| Shadow Hover  | `0 4px 20px rgba(168,111,60,0.14)` | Card hover state                 |
+| Token         | Value                             | Usage                                      |
+| ------------- | --------------------------------- | ------------------------------------------ |
+| Surface       | `#F5EFE4`                         | Warm cream with yellow undertone           |
+| Surface Muted | `#EDE4D3`                         | Parchment mat                              |
+| Text          | `#3D3530`                         | Warm dark brown                            |
+| Text Muted    | `#6F6257`                         | AA-compliant sepia muted text              |
+| Border        | `#D4C9B8`                         | Warm, visible dividers                     |
+| Accent        | `#8B5A2B`                         | Accessible aged-leather brown              |
+| Accent Hover  | `#73481F`                         | Deeper accessible hover state              |
+| Frame Accent  | `#6B5344`                         | Aged wood brown                            |
+| Shadow        | `0 2px 12px rgba(139,90,43,0.10)` | Card resting state                         |
+| Shadow Hover  | `0 4px 20px rgba(139,90,43,0.14)` | Card hover state                           |
+
+Atelier's accent colors are chosen to keep white text above the WCAG AA 4.5:1 threshold. The muted token also clears 4.5:1 against both the cream (`#F5EFE4`) and parchment (`#EDE4D3`) surfaces, so labels, placeholders, badges, and secondary copy can share one system token without per-component overrides.
 
 ### Semantic Colors (shared)
 
@@ -137,6 +139,7 @@ These are intentional choices that differentiate Curio from every competitor:
 
 | Date       | Decision                                            | Rationale                                                                                                                                                                                                                                                      |
 | ---------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-27 | Tightened Atelier accent and muted tokens for AA    | Preserve the warm leather/sepia character while ensuring small white-on-accent and muted-on-cream text clears WCAG AA without component-specific overrides                                                                                                     |
 | 2026-03-24 | Initial design system created                       | Formalized from existing codebase via /design-consultation. Competitive research: CatalogIt, Libib, Artwork Archive, Rijksmuseum, The Met. Key insight: no personal collection app occupies the space between "utility catalog" and "actual museum experience" |
 | 2026-03-24 | Kept DM Serif Display / Inter / JetBrains Mono trio | Already well-chosen and distinctive. DM Serif Display is underused in app/SaaS space                                                                                                                                                                           |
 | 2026-03-24 | Kept three-theme system (Gallery/Vault/Atelier)     | Core differentiator vs light/dark-only competitors                                                                                                                                                                                                             |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -70,18 +70,18 @@
 
 ### Atelier (Warm)
 
-| Token         | Value                             | Usage                                      |
-| ------------- | --------------------------------- | ------------------------------------------ |
-| Surface       | `#F5EFE4`                         | Warm cream with yellow undertone           |
-| Surface Muted | `#EDE4D3`                         | Parchment mat                              |
-| Text          | `#3D3530`                         | Warm dark brown                            |
-| Text Muted    | `#6F6257`                         | AA-compliant sepia muted text              |
-| Border        | `#D4C9B8`                         | Warm, visible dividers                     |
-| Accent        | `#8B5A2B`                         | Accessible aged-leather brown              |
-| Accent Hover  | `#73481F`                         | Deeper accessible hover state              |
-| Frame Accent  | `#6B5344`                         | Aged wood brown                            |
-| Shadow        | `0 2px 12px rgba(139,90,43,0.10)` | Card resting state                         |
-| Shadow Hover  | `0 4px 20px rgba(139,90,43,0.14)` | Card hover state                           |
+| Token         | Value                             | Usage                            |
+| ------------- | --------------------------------- | -------------------------------- |
+| Surface       | `#F5EFE4`                         | Warm cream with yellow undertone |
+| Surface Muted | `#EDE4D3`                         | Parchment mat                    |
+| Text          | `#3D3530`                         | Warm dark brown                  |
+| Text Muted    | `#6F6257`                         | AA-compliant sepia muted text    |
+| Border        | `#D4C9B8`                         | Warm, visible dividers           |
+| Accent        | `#8B5A2B`                         | Accessible aged-leather brown    |
+| Accent Hover  | `#73481F`                         | Deeper accessible hover state    |
+| Frame Accent  | `#6B5344`                         | Aged wood brown                  |
+| Shadow        | `0 2px 12px rgba(139,90,43,0.10)` | Card resting state               |
+| Shadow Hover  | `0 4px 20px rgba(139,90,43,0.14)` | Card hover state                 |
 
 Atelier's accent colors are chosen to keep white text above the WCAG AA 4.5:1 threshold. The muted token also clears 4.5:1 against both the cream (`#F5EFE4`) and parchment (`#EDE4D3`) surfaces, so labels, placeholders, badges, and secondary copy can share one system token without per-component overrides.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1488,7 +1488,7 @@ export const AppContent: React.FC = () => {
         className={`max-w-md w-full text-center border rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl ${theme === 'vault' ? 'bg-white/5 border-white/10' : theme === 'atelier' ? 'bg-[#EDE4D3]/70 border-[#D4C9B8]' : 'bg-white/70 border-stone-200'}`}
       >
         <div
-          className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-white/10 text-stone-400' : theme === 'atelier' ? 'bg-[#D4C9B8]/50 text-[#8C7B6B]' : 'bg-stone-100 text-stone-500'}`}
+          className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-white/10 text-stone-400' : theme === 'atelier' ? 'bg-[#D4C9B8]/50 text-[#6F6257]' : 'bg-stone-100 text-stone-500'}`}
         >
           {!authReady && isSupabaseReady ? (
             <Loader2 size={24} className="animate-spin" />
@@ -1515,7 +1515,7 @@ export const AppContent: React.FC = () => {
           </p>
         )}
         <p
-          className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+          className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-500'}`}
         >
           {!authReady && isSupabaseReady
             ? t('authLoadingDesc')
@@ -1545,14 +1545,14 @@ export const AppContent: React.FC = () => {
           )}
           {!isSupabaseReady ? (
             <div
-              className={`text-[11px] font-semibold uppercase tracking-[0.16em] ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+              className={`text-[11px] font-semibold uppercase tracking-[0.16em] ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-400'}`}
             >
               {t('cloudRequiredAction')}
             </div>
           ) : null}
         </div>
         <p
-          className={`text-[12px] mt-5 leading-relaxed ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+          className={`text-[12px] mt-5 leading-relaxed ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-500'}`}
         >
           {t('ctaPromise')}
         </p>

--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -187,7 +187,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
   const warnBannerActionClass = {
     gallery: 'text-amber-800 hover:text-amber-900',
     vault: 'text-amber-100 hover:text-white',
-    atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]',
+    atelier: 'text-[#8B5A2B] hover:text-[#73481F]',
   }[theme];
   // #434: a hard AI failure gets the DESIGN.md error tone (#DC2626 family) so
   // it reads as an error, not a neutral hint. Transient failures reuse the
@@ -238,7 +238,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
   const imageTilePlaceholderClass = {
     gallery: 'text-stone-200',
     vault: 'text-white/25',
-    atelier: 'text-[#8C7B6B]/50',
+    atelier: 'text-[#6F6257]/50',
   }[theme];
   const batchItemCardClass = {
     gallery: 'border-stone-100 bg-white',
@@ -253,7 +253,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
   const addMoreTileClass = {
     gallery: 'border-stone-200 text-stone-400 hover:border-amber-200 hover:bg-stone-50',
     vault: 'border-white/15 text-stone-300 hover:border-amber-400/40 hover:bg-white/5',
-    atelier: 'border-[#D4C9B8] text-[#8C7B6B] hover:border-[#A86F3C]/40 hover:bg-[#EDE4D3]',
+    atelier: 'border-[#D4C9B8] text-[#6F6257] hover:border-[#8B5A2B]/40 hover:bg-[#EDE4D3]',
   }[theme];
   // CUR-22: theme-aware tone tokens for the upload empty state, collection
   // picker tiles, and subtle "skip / hide" links so Vault stops rendering a
@@ -262,7 +262,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
     gallery: 'bg-stone-50 border-stone-200 text-stone-400 hover:border-amber-400 hover:bg-amber-50',
     vault: 'bg-white/5 border-white/15 text-stone-300 hover:border-amber-400/60 hover:bg-white/10',
     atelier:
-      'bg-[#EDE4D3] border-[#D4C9B8] text-[#8C7B6B] hover:border-[#A86F3C]/60 hover:bg-[#E6D9C2]',
+      'bg-[#EDE4D3] border-[#D4C9B8] text-[#6F6257] hover:border-[#8B5A2B]/60 hover:bg-[#E6D9C2]',
   }[theme];
   const uploadHeadingClass = {
     gallery: 'text-stone-900',
@@ -272,7 +272,7 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
   const selectTileClass = {
     gallery: 'border border-stone-100 bg-stone-50/50 hover:border-amber-400 hover:bg-amber-50',
     vault: 'border border-white/10 bg-white/5 hover:border-amber-400/60 hover:bg-white/10',
-    atelier: 'border border-[#D4C9B8] bg-[#EDE4D3]/60 hover:border-[#A86F3C]/60 hover:bg-[#EDE4D3]',
+    atelier: 'border border-[#D4C9B8] bg-[#EDE4D3]/60 hover:border-[#8B5A2B]/60 hover:bg-[#EDE4D3]',
   }[theme];
   const selectTileTitleClass = {
     gallery: 'text-stone-800',

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -754,7 +754,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                   theme === 'vault'
                     ? 'text-[#D4A574] hover:text-[#E0B585]'
                     : theme === 'atelier'
-                      ? 'text-[#A86F3C] hover:text-[#8B5A2B]'
+                      ? 'text-[#8B5A2B] hover:text-[#73481F]'
                       : 'text-amber-700 hover:text-amber-800'
                 }`}
               >
@@ -769,7 +769,7 @@ export const AuthModal: React.FC<AuthModalProps> = ({
                   theme === 'vault'
                     ? 'text-[#D4A574] hover:text-[#E0B585]'
                     : theme === 'atelier'
-                      ? 'text-[#A86F3C] hover:text-[#8B5A2B]'
+                      ? 'text-[#8B5A2B] hover:text-[#73481F]'
                       : 'text-amber-700 hover:text-amber-800'
                 }`}
               >

--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -56,7 +56,7 @@ const filterChipIconClasses: Record<AppTheme, string> = {
 const clearFiltersLinkClasses: Record<AppTheme, string> = {
   gallery: 'text-stone-500 hover:text-stone-800 decoration-stone-300',
   vault: 'text-stone-300 hover:text-white decoration-white/30',
-  atelier: 'text-[#8C7B6B] hover:text-[#3D3530] decoration-[#D4C9B8]',
+  atelier: 'text-[#6F6257] hover:text-[#3D3530] decoration-[#D4C9B8]',
 };
 
 interface CollectionScreenProps {
@@ -236,7 +236,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
             className={`max-w-md w-full text-center border rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl ${theme === 'vault' ? 'bg-white/5 border-white/10' : theme === 'atelier' ? 'bg-[#EDE4D3]/70 border-[#D4C9B8]' : 'bg-white/70 border-stone-200'}`}
           >
             <div
-              className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-white/10 text-stone-400' : theme === 'atelier' ? 'bg-[#D4C9B8]/50 text-[#8C7B6B]' : 'bg-stone-100 text-stone-500'}`}
+              className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-white/10 text-stone-400' : theme === 'atelier' ? 'bg-[#D4C9B8]/50 text-[#6F6257]' : 'bg-stone-100 text-stone-500'}`}
             >
               <Landmark size={24} />
             </div>
@@ -246,7 +246,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
               {t('collectionUnavailableTitle')}
             </h1>
             <p
-              className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+              className={`text-sm mb-6 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-500'}`}
             >
               {t('collectionUnavailableDesc')}
             </p>
@@ -406,7 +406,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
                       onClick={() => setViewMode('grid')}
                       aria-label={t('viewGrid')}
                       title={t('viewGrid')}
-                      className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
+                      className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'grid' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#6F6257] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
                     >
                       <LayoutGrid size={18} />
                     </button>
@@ -414,7 +414,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
                       onClick={() => setViewMode('waterfall')}
                       aria-label={t('viewWaterfall')}
                       title={t('viewWaterfall')}
-                      className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#8C7B6B] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
+                      className={`w-11 h-11 sm:w-9 sm:h-9 flex items-center justify-center rounded-lg transition-all ${viewMode === 'waterfall' ? (theme === 'vault' ? 'bg-white/10 text-white shadow-sm' : theme === 'atelier' ? 'bg-[#F5EFE4] text-[#3D3530] shadow-sm' : 'bg-white text-stone-900 shadow-sm') : theme === 'vault' ? 'text-stone-500 hover:text-stone-300' : theme === 'atelier' ? 'text-[#6F6257] hover:text-[#3D3530]' : 'text-stone-400 hover:text-stone-600'}`}
                     >
                       <LayoutTemplate size={18} className="rotate-180" />
                     </button>
@@ -542,7 +542,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
             <p className={`${typographyClasses.titleLarge} italic mb-2`}>
               {t('searchNoResultsTitle')}
             </p>
-            <p className={typographyClasses.labelMuted}>
+            <p className={`${typographyClasses.labelMuted} ${labelColorClasses[theme]}`}>
               {hasFilterInput
                 ? t('collectionSearchNoResults', { query: filterInput.trim() })
                 : t('collectionFilterNoResults')}

--- a/src/components/CreateCollectionModal.tsx
+++ b/src/components/CreateCollectionModal.tsx
@@ -123,7 +123,7 @@ export const CreateCollectionModal: React.FC<CreateCollectionModalProps> = ({
   const loadingSpinnerClass = {
     gallery: 'bg-amber-50 text-amber-500',
     vault: 'bg-amber-500/15 text-amber-300',
-    atelier: 'bg-amber-100/70 text-[#A86F3C]',
+    atelier: 'bg-amber-100/70 text-[#8B5A2B]',
   }[theme];
 
   const resetState = () => {

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -230,7 +230,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
           className={`max-w-md w-full text-center border rounded-[2rem] sm:rounded-[2.5rem] p-6 sm:p-10 shadow-xl ${theme === 'vault' ? 'bg-white/5 border-white/10' : theme === 'atelier' ? 'bg-[#EDE4D3]/70 border-[#D4C9B8]' : 'bg-white/70 border-stone-200'}`}
         >
           <div
-            className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-amber-500/10 text-amber-400' : theme === 'atelier' ? 'bg-[#A86F3C]/10 text-[#A86F3C]' : 'bg-amber-50 text-amber-600'}`}
+            className={`w-12 h-12 sm:w-14 sm:h-14 rounded-2xl flex items-center justify-center mx-auto mb-5 sm:mb-6 ${theme === 'vault' ? 'bg-amber-500/10 text-amber-400' : theme === 'atelier' ? 'bg-[#8B5A2B]/10 text-[#8B5A2B]' : 'bg-amber-50 text-amber-600'}`}
           >
             <AlertCircle size={24} />
           </div>
@@ -240,7 +240,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             {t('syncPausedTitle')}
           </h2>
           <p
-            className={`text-sm mb-3 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-500'}`}
+            className={`text-sm mb-3 ${theme === 'vault' ? 'text-stone-400' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-500'}`}
           >
             {loadError}
           </p>
@@ -270,25 +270,25 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
   const newArchiveTileClasses = {
     gallery: 'border-stone-200 hover:border-amber-400 bg-white/50 text-stone-500',
     vault: 'border-white/10 hover:border-amber-400 bg-white/5 text-stone-500',
-    atelier: 'border-[#D4C9B8] hover:border-[#A86F3C] bg-[#EDE4D3]/60 text-[#8C7B6B]',
+    atelier: 'border-[#D4C9B8] hover:border-[#8B5A2B] bg-[#EDE4D3]/60 text-[#6F6257]',
   };
 
   const newArchiveDiscClasses = {
     gallery: 'bg-stone-50 text-stone-300',
     vault: 'bg-white/5 text-stone-500',
-    atelier: 'bg-[#F5EFE4] text-[#8C7B6B]',
+    atelier: 'bg-[#F5EFE4] text-[#6F6257]',
   };
 
   const newArchiveTitleClasses = {
     gallery: 'text-stone-500',
     vault: 'text-white/60',
-    atelier: 'text-[#8C7B6B]',
+    atelier: 'text-[#6F6257]',
   };
 
   const searchPlaceholderClasses = {
     gallery: 'placeholder:text-stone-300',
     vault: 'placeholder:text-stone-400',
-    atelier: 'placeholder:text-[#8C7B6B]',
+    atelier: 'placeholder:text-[#6F6257]',
   };
 
   if (!hasOwnedContent) {
@@ -332,7 +332,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
               </Link>
             )}
           </div>
-          <p className={`${typographyClasses.labelMuted} mt-6`}>{t('firstRunFooter')}</p>
+          <p className={`${typographyClasses.labelMuted} ${labelColorClasses[theme]} mt-6`}>
+            {t('firstRunFooter')}
+          </p>
         </section>
       </div>
     );
@@ -354,7 +356,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             theme === 'vault'
               ? 'text-stone-300 decoration-white/25 hover:text-[#D4A574] hover:decoration-[#D4A574]/60'
               : theme === 'atelier'
-                ? 'text-[#6F6257] decoration-[#8C7B6B]/40 hover:text-[#A86F3C] hover:decoration-[#A86F3C]/60'
+                ? 'text-[#6F6257] decoration-[#6F6257]/40 hover:text-[#8B5A2B] hover:decoration-[#8B5A2B]/60'
                 : 'text-stone-600 decoration-stone-300 hover:text-amber-700 hover:decoration-amber-500/60'
           }`}
         >
@@ -410,7 +412,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-3">
                 <div
-                  className={`flex h-10 w-10 items-center justify-center rounded-xl ${theme === 'vault' ? 'bg-amber-500/10 text-amber-400' : theme === 'atelier' ? 'bg-[#A86F3C]/10 text-[#A86F3C]' : 'bg-amber-50 text-amber-600'}`}
+                  className={`flex h-10 w-10 items-center justify-center rounded-xl ${theme === 'vault' ? 'bg-amber-500/10 text-amber-400' : theme === 'atelier' ? 'bg-[#8B5A2B]/10 text-[#8B5A2B]' : 'bg-amber-50 text-amber-600'}`}
                 >
                   <Calendar size={18} />
                 </div>
@@ -419,7 +421,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                 </span>
               </div>
               <div>
-                <p className={`${typographyClasses.labelMuted} mb-1`}>{t('historyTitle')}</p>
+                <p className={`${typographyClasses.labelMuted} ${labelColorClasses[theme]} mb-1`}>
+                  {t('historyTitle')}
+                </p>
                 <h2 className={`${typographyClasses.titleLarge} leading-tight`}>
                   {primaryHistoryItem.title}
                 </h2>
@@ -431,7 +435,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                       <button
                         type="button"
                         onClick={() => navigate(`/collection/${item.collectionId}/item/${item.id}`)}
-                        className={`w-full text-left rounded-xl border px-3 py-2 text-xs sm:text-sm shadow-sm transition ${theme === 'vault' ? 'border-white/10 bg-white/5 hover:border-[#D4A574]/30 hover:bg-white/10' : theme === 'atelier' ? 'border-[#D4C9B8]/60 bg-[#EDE4D3]/70 hover:border-[#A86F3C]/30 hover:bg-[#EDE4D3]' : 'border-stone-200/60 bg-white/70 hover:border-amber-200 hover:bg-amber-50/60'}`}
+                        className={`w-full text-left rounded-xl border px-3 py-2 text-xs sm:text-sm shadow-sm transition ${theme === 'vault' ? 'border-white/10 bg-white/5 hover:border-[#D4A574]/30 hover:bg-white/10' : theme === 'atelier' ? 'border-[#D4C9B8]/60 bg-[#EDE4D3]/70 hover:border-[#8B5A2B]/30 hover:bg-[#EDE4D3]' : 'border-stone-200/60 bg-white/70 hover:border-amber-200 hover:bg-amber-50/60'}`}
                       >
                         <div className="flex items-center justify-between gap-2">
                           <span
@@ -441,7 +445,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                           </span>
                           {showHistoryYearBadge && (
                             <span
-                              className={`text-[11px] uppercase tracking-wide ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+                              className={`text-[11px] uppercase tracking-wide ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-400'}`}
                             >
                               {new Date(item.createdAt).getFullYear()}
                             </span>
@@ -454,7 +458,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                 {historyOverflow > 0 && !historyExpanded && (
                   <>
                     <p
-                      className={`text-xs ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#8C7B6B]' : 'text-stone-400'}`}
+                      className={`text-xs ${theme === 'vault' ? 'text-stone-500' : theme === 'atelier' ? 'text-[#6F6257]' : 'text-stone-400'}`}
                     >
                       {t('onThisDayMore', { count: historyOverflow })}
                     </p>
@@ -529,7 +533,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
             <p className={`${typographyClasses.titleLarge} italic mb-2`}>
               {t('searchNoResultsTitle')}
             </p>
-            <p className={typographyClasses.labelMuted}>
+            <p className={`${typographyClasses.labelMuted} ${labelColorClasses[theme]}`}>
               {t('searchNoResultsBody', { query: searchInput.trim() })}
             </p>
             <div className="mt-6 flex justify-center">

--- a/src/components/ItemDetailScreen.tsx
+++ b/src/components/ItemDetailScreen.tsx
@@ -954,7 +954,7 @@ export const ItemDetailScreen: React.FC<ItemDetailScreenProps> = ({
                     field.hint ||
                     '';
                   const showHint = Boolean(hint) && !isReadOnly && isEmpty;
-                  const fieldBaseClass = `${typographyClasses.title} w-full bg-transparent border-none p-0 outline-none focus:text-amber-900 focus:ring-0 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : theme === 'atelier' ? 'text-stone-900 placeholder:text-[#8C7B6B]' : 'text-stone-900 placeholder:text-stone-500'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`;
+                  const fieldBaseClass = `${typographyClasses.title} w-full bg-transparent border-none p-0 outline-none focus:text-amber-900 focus:ring-0 transition-colors ${theme === 'vault' ? 'text-white placeholder:text-stone-400' : theme === 'atelier' ? 'text-stone-900 placeholder:text-[#6F6257]' : 'text-stone-900 placeholder:text-stone-500'} ${isReadOnly ? 'cursor-not-allowed opacity-70' : ''}`;
                   const handleFieldChange = (
                     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
                   ) => {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -41,7 +41,7 @@ const authChipSignedOutClasses: Record<AppTheme, string> = {
 const authChipUnconfiguredClasses: Record<AppTheme, string> = {
   gallery: 'bg-stone-50 text-stone-400',
   vault: 'bg-white/10 text-white/60',
-  atelier: 'bg-[#EDE4D3] text-[#8C7B6B]',
+  atelier: 'bg-[#EDE4D3] text-[#6F6257]',
 };
 
 const importCardSurfaceClasses: Record<AppTheme, string> = {
@@ -65,7 +65,7 @@ const importCardBodyClasses: Record<AppTheme, string> = {
 const importCardActionClasses: Record<AppTheme, string> = {
   gallery: 'bg-amber-600 text-white hover:bg-amber-700',
   vault: 'bg-[#D4A574] text-stone-950 hover:bg-[#E0B585]',
-  atelier: 'bg-[#A86F3C] text-white hover:bg-[#8B5A2B]',
+  atelier: 'bg-[#8B5A2B] text-white hover:bg-[#73481F]',
 };
 
 const importCardStatusClasses: Record<AppTheme, string> = {
@@ -217,7 +217,7 @@ export const Layout: React.FC<LayoutProps> = ({
     theme === 'vault'
       ? 'bg-[#D4A574]/20 text-[#D4A574]'
       : theme === 'atelier'
-        ? 'bg-[#A86F3C]/15 text-[#A86F3C]'
+        ? 'bg-[#8B5A2B]/15 text-[#8B5A2B]'
         : 'bg-amber-100 text-amber-700';
   const statusBadgeSurface =
     theme === 'vault' ? 'bg-stone-900 border-white/10' : 'bg-white border-stone-200';

--- a/src/components/LegalPage.tsx
+++ b/src/components/LegalPage.tsx
@@ -65,7 +65,7 @@ export const LegalPage: React.FC = () => {
     theme === 'vault'
       ? 'text-[#D4A574] hover:text-[#E0B585]'
       : theme === 'atelier'
-        ? 'text-[#A86F3C] hover:text-[#8B5A2B]'
+        ? 'text-[#8B5A2B] hover:text-[#73481F]'
         : 'text-amber-700 hover:text-amber-800';
 
   return (

--- a/src/components/StatusBanner.tsx
+++ b/src/components/StatusBanner.tsx
@@ -50,7 +50,7 @@ const toneIcons: Record<BannerTone, React.ComponentType<{ size?: number }>> = {
 const actionClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-700 hover:text-amber-900',
   vault: 'text-amber-200 hover:text-amber-100',
-  atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]',
+  atelier: 'text-[#8B5A2B] hover:text-[#73481F]',
 };
 
 export const StatusBanner: React.FC<StatusBannerProps> = ({

--- a/src/components/StatusToast.tsx
+++ b/src/components/StatusToast.tsx
@@ -75,7 +75,7 @@ const toneIcons: Record<StatusTone, React.ComponentType<{ size?: number }>> = {
 const actionClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-700 hover:text-amber-900',
   vault: 'text-amber-200 hover:text-amber-100',
-  atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]',
+  atelier: 'text-[#8B5A2B] hover:text-[#73481F]',
 };
 
 const dismissClasses: Record<AppTheme, string> = {

--- a/src/components/ThemePicker.tsx
+++ b/src/components/ThemePicker.tsx
@@ -41,7 +41,7 @@ export const ThemePicker: React.FC<ThemePickerProps> = ({ layout = 'inline' }) =
   const stackedActiveByTheme: Record<AppTheme, string> = {
     gallery: 'border-amber-200 bg-amber-50 text-stone-900 shadow-sm',
     vault: 'border-white/20 bg-white/10 text-white shadow-sm',
-    atelier: 'border-[#A86F3C]/40 bg-[#EDE4D3] text-[#3D3530] shadow-sm',
+    atelier: 'border-[#8B5A2B]/40 bg-[#EDE4D3] text-[#3D3530] shadow-sm',
   };
 
   if (isStacked) {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -30,17 +30,17 @@ const variantClasses: Record<AppTheme, Record<Variant, string>> = {
     ghost: 'text-stone-300 hover:bg-white/5 hover:text-white',
   },
   atelier: {
-    primary: 'bg-[#A86F3C] text-white hover:bg-[#8B5A2B] shadow-atelier',
-    secondary: 'bg-[#A86F3C]/15 text-[#8B5A2B] hover:bg-[#A86F3C]/25',
+    primary: 'bg-[#8B5A2B] text-white hover:bg-[#73481F] shadow-atelier',
+    secondary: 'bg-[#8B5A2B]/15 text-[#73481F] hover:bg-[#8B5A2B]/25',
     outline: 'border border-[#D4C9B8] text-[#3D3530] hover:bg-[#EDE4D3]',
-    ghost: 'text-[#8C7B6B] hover:bg-[#EDE4D3]/60 hover:text-[#3D3530]',
+    ghost: 'text-[#6F6257] hover:bg-[#EDE4D3]/60 hover:text-[#3D3530]',
   },
 };
 
 const focusRingClasses: Record<AppTheme, string> = {
   gallery: 'focus:ring-amber-500/40',
   vault: 'focus:ring-[#D4A574]/40',
-  atelier: 'focus:ring-[#A86F3C]/40',
+  atelier: 'focus:ring-[#8B5A2B]/40',
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -143,8 +143,12 @@ export const typographyClasses = {
   // Labels/Metadata: Mono, 11-12px, uppercase, wide tracking (tighter on mobile so they fit narrow grid cells)
   label:
     'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-bold',
+  // No opacity here on purpose. Muting these labels with `opacity-50` composited
+  // even an AA-compliant token down to ~2:1 against the light Atelier and
+  // Gallery surfaces, so the muting now comes from `labelColorClasses[theme]`
+  // (or `mutedTextClasses[theme]`) plus the lighter weight, which stays legible.
   labelMuted:
-    'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-medium opacity-50',
+    'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-medium',
   labelSmall: 'font-mono text-[10px] uppercase tracking-[0.08em] sm:tracking-[0.15em] font-medium',
 
   // Body text: Sans, 14-16px, relaxed leading

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -119,185 +119,135 @@ export const overlaySurfaceClasses: Record<AppTheme, string> = {
 export const mutedTextClasses: Record<AppTheme, string> = {
   gallery: 'text-stone-500',
   vault: 'text-stone-300',
-  atelier: 'text-[#8C7B6B]', // Sepia-toned muted text
+  atelier: 'text-[#6F6257]', // AA-compliant sepia muted text
 };
 
 export const useTheme = () => useContext(ThemeContext);
 
-// =============================================================================
-// TYPOGRAPHY HIERARCHY
-// Consistent text styles following the design system:
-// - Titles: Serif, bold, for headings and item names
-// - Labels: Mono, uppercase, for metadata and categories
-// - Body: Sans, for descriptions and notes
-// - Accession: Mono, very small, for catalog numbers
-// =============================================================================
-
 export const typographyClasses = {
-  // Titles: Serif, 18-20px, bold, tight tracking
   title: 'font-serif text-lg sm:text-xl font-bold tracking-tight',
   titleLarge: 'font-serif text-2xl sm:text-3xl font-bold tracking-tight',
   titleHero: 'font-serif text-3xl sm:text-5xl font-bold tracking-tight',
   titleDisplay: 'font-serif text-4xl sm:text-6xl font-bold tracking-tight',
-
-  // Labels/Metadata: Mono, 11-12px, uppercase, wide tracking (tighter on mobile so they fit narrow grid cells)
   label:
     'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-bold',
   labelMuted:
     'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-medium opacity-50',
   labelSmall: 'font-mono text-[10px] uppercase tracking-[0.08em] sm:tracking-[0.15em] font-medium',
-
-  // Body text: Sans, 14-16px, relaxed leading
   body: 'font-sans text-sm leading-relaxed',
   bodyLarge: 'font-sans text-base leading-relaxed',
   bodyMuted: 'font-sans text-sm leading-relaxed opacity-60',
-
-  // Accession numbers: Mono, 10px, very muted
   accession: 'font-mono text-[10px] tracking-[0.15em] opacity-30 uppercase',
-
-  // Special: Italic serif for quotes/descriptions
   quote: 'font-serif italic text-lg leading-relaxed',
 } as const;
 
-// Theme-aware label colors, tuned per surface so muted labels still clear
-// WCAG AA. Gallery uses stone-500 (#78716C) — DESIGN.md's Gallery "Text Muted"
-// token — which reaches ~4.8:1 on the light surface, where stone-400 (#A8A29E)
-// only manages ~2.4:1. Vault keeps stone-400 to match DESIGN.md's dark "Text
-// Muted" token, which clears AA against the stone-900 surface.
 export const labelColorClasses: Record<AppTheme, string> = {
   gallery: 'text-stone-500',
   vault: 'text-stone-400',
-  atelier: 'text-[#8C7B6B]', // Sepia-toned labels
+  atelier: 'text-[#6F6257]',
 };
-
-// =============================================================================
-// ENHANCED THEME COLOR PALETTES
-// Each theme has a refined color system:
-// - Gallery: Clean, editorial, high-contrast (white + charcoal)
-// - Vault: Cinematic, luxurious (dark + brass/gold accents)
-// - Atelier: Warm, tactile, vintage (cream + warm brown)
-// =============================================================================
 
 export const themeColors = {
   gallery: {
-    mat: '#F5F5F5', // Soft gray mat for subtle depth
-    frameAccent: '#1A1A1A', // Charcoal for refined contrast
+    mat: '#F5F5F5',
+    frameAccent: '#1A1A1A',
     surface: '#FFFFFF',
     surfaceMuted: '#F5F5F5',
-    text: '#1C1917', // stone-900
-    textMuted: '#78716C', // stone-500
-    border: '#E7E5E4', // stone-200
-    accent: '#D97706', // amber-600
-    accentHover: '#B45309', // amber-700
+    text: '#1C1917',
+    textMuted: '#78716C',
+    border: '#E7E5E4',
+    accent: '#D97706',
+    accentHover: '#B45309',
   },
   vault: {
-    mat: '#1C1917', // stone-900 for layered depth
-    frameAccent: '#D4A574', // Brass/gold for warmth
-    surface: '#0C0A09', // stone-950
-    surfaceMuted: '#1C1917', // stone-900
+    mat: '#1C1917',
+    frameAccent: '#D4A574',
+    surface: '#0C0A09',
+    surfaceMuted: '#1C1917',
     text: '#FFFFFF',
-    textMuted: '#A8A29E', // stone-400
+    textMuted: '#A8A29E',
     border: 'rgba(255,255,255,0.1)',
-    accent: '#D4A574', // Brass highlight
+    accent: '#D4A574',
     accentHover: '#E0B585',
   },
   atelier: {
-    mat: '#EDE4D3', // Warm parchment - distinctly yellower than Gallery
-    frameAccent: '#6B5344', // Aged wood brown
-    surface: '#F5EFE4', // Warm cream with yellow undertone
-    surfaceMuted: '#EDE4D3', // Parchment
-    text: '#3D3530', // Warm dark brown (not cool gray)
-    textMuted: '#8C7B6B', // Sepia-toned muted text
-    border: '#D4C9B8', // Warmer, more visible border
-    accent: '#A86F3C', // Rich amber-brown (aged leather)
-    accentHover: '#8B5A2B', // Deeper on hover
+    mat: '#EDE4D3',
+    frameAccent: '#6B5344',
+    surface: '#F5EFE4',
+    surfaceMuted: '#EDE4D3',
+    text: '#3D3530',
+    textMuted: '#6F6257',
+    border: '#D4C9B8',
+    accent: '#8B5A2B',
+    accentHover: '#73481F',
   },
 } as const;
 
-// =============================================================================
-// ENHANCED SURFACE CLASSES
-// Pre-built Tailwind class combinations for common UI patterns
-// =============================================================================
-
-// Mat/background surfaces (for cards, panels with subtle depth)
 export const matSurfaceClasses: Record<AppTheme, string> = {
   gallery: 'bg-[#F5F5F5]',
   vault: 'bg-[#1C1917]',
-  atelier: 'bg-[#EDE4D3]', // Warm parchment
+  atelier: 'bg-[#EDE4D3]',
 };
 
-// Frame accent colors (for borders, dividers, highlights)
 export const frameAccentClasses: Record<AppTheme, string> = {
   gallery: 'border-[#1A1A1A]',
   vault: 'border-[#D4A574]',
-  atelier: 'border-[#6B5344]', // Aged wood brown
+  atelier: 'border-[#6B5344]',
 };
 
-// Interactive element accent colors
 export const accentColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-600 hover:text-amber-700',
   vault: 'text-[#D4A574] hover:text-[#E0B585]',
-  atelier: 'text-[#A86F3C] hover:text-[#8B5A2B]', // Rich amber-brown
+  atelier: 'text-[#8B5A2B] hover:text-[#73481F]',
 };
 
-// Accent color for small uppercase eyebrow/label text. The interactive accent
-// (amber-600, ~3.05:1 on white) fails WCAG AA when used as static label text,
-// so labels use the darker accent tone per theme: amber-700 (#B45309, DESIGN.md
-// "Accent Hover", ~4.6:1) on Gallery and the deeper amber-brown on Atelier.
-// Vault's brass already clears AA on the dark surface.
 export const accentLabelColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-700',
   vault: 'text-[#D4A574]',
   atelier: 'text-[#8B5A2B]',
 };
 
-// Accent background classes (for buttons, badges)
 export const accentBgClasses: Record<AppTheme, string> = {
   gallery: 'bg-amber-500 hover:bg-amber-600 text-white',
   vault: 'bg-[#D4A574] hover:bg-[#E0B585] text-stone-900',
-  atelier: 'bg-[#A86F3C] hover:bg-[#8B5A2B] text-white', // Leather brown
+  atelier: 'bg-[#8B5A2B] hover:bg-[#73481F] text-white',
 };
 
-// Card hover states with enhanced shadows
 export const cardHoverClasses: Record<AppTheme, string> = {
   gallery: 'hover:shadow-gallery-hover hover:border-stone-200 transition-all duration-200',
   vault: 'hover:shadow-vault-hover hover:border-[#D4A574]/30 transition-all duration-200',
-  atelier: 'hover:shadow-atelier-hover hover:border-[#A86F3C]/30 transition-all duration-200',
+  atelier: 'hover:shadow-atelier-hover hover:border-[#8B5A2B]/30 transition-all duration-200',
 };
 
-// Enhanced card surfaces with theme-specific shadows
 export const cardSurfaceEnhancedClasses: Record<AppTheme, string> = {
   gallery: 'bg-white text-stone-900 border border-stone-100 shadow-gallery',
   vault: 'bg-stone-950 text-white border border-white/10 shadow-vault',
   atelier: 'bg-[#F5EFE4] text-[#3D3530] border border-[#D4C9B8] shadow-atelier',
 };
 
-// Divider/separator classes
 export const dividerClasses: Record<AppTheme, string> = {
   gallery: 'border-stone-200',
   vault: 'border-white/10',
-  atelier: 'border-[#D4C9B8]', // Warmer, more visible
+  atelier: 'border-[#D4C9B8]',
 };
 
-// Rating star colors (muted amber instead of bright yellow)
 export const ratingColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-500',
   vault: 'text-[#D4A574]',
-  atelier: 'text-[#A86F3C]', // Leather brown
+  atelier: 'text-[#8B5A2B]',
 };
 
 export const ratingEmptyClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-500/30',
   vault: 'text-[#D4A574]/30',
-  atelier: 'text-[#A86F3C]/30',
+  atelier: 'text-[#8B5A2B]/30',
 };
 
-// Input field classes
 export const inputClasses: Record<AppTheme, string> = {
   gallery:
     'bg-white border-stone-200 text-stone-900 placeholder:text-stone-300 focus:ring-amber-500/10 focus:border-amber-200',
   vault:
     'bg-stone-900 border-white/10 text-white placeholder:text-stone-400 focus:ring-[#D4A574]/10 focus:border-[#D4A574]/30',
   atelier:
-    'bg-[#F5EFE4] border-[#D4C9B8] text-[#3D3530] placeholder:text-[#8C7B6B] focus:ring-[#A86F3C]/10 focus:border-[#A86F3C]/30',
+    'bg-[#F5EFE4] border-[#D4C9B8] text-[#3D3530] placeholder:text-[#6F6257] focus:ring-[#8B5A2B]/10 focus:border-[#8B5A2B]/30',
 };

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -124,117 +124,166 @@ export const mutedTextClasses: Record<AppTheme, string> = {
 
 export const useTheme = () => useContext(ThemeContext);
 
+// =============================================================================
+// TYPOGRAPHY HIERARCHY
+// Consistent text styles following the design system:
+// - Titles: Serif, bold, for headings and item names
+// - Labels: Mono, uppercase, for metadata and categories
+// - Body: Sans, for descriptions and notes
+// - Accession: Mono, very small, for catalog numbers
+// =============================================================================
+
 export const typographyClasses = {
+  // Titles: Serif, 18-20px, bold, tight tracking
   title: 'font-serif text-lg sm:text-xl font-bold tracking-tight',
   titleLarge: 'font-serif text-2xl sm:text-3xl font-bold tracking-tight',
   titleHero: 'font-serif text-3xl sm:text-5xl font-bold tracking-tight',
   titleDisplay: 'font-serif text-4xl sm:text-6xl font-bold tracking-tight',
+
+  // Labels/Metadata: Mono, 11-12px, uppercase, wide tracking (tighter on mobile so they fit narrow grid cells)
   label:
     'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-bold',
   labelMuted:
     'font-mono text-[11px] sm:text-[12px] uppercase tracking-[0.1em] sm:tracking-[0.2em] font-medium opacity-50',
   labelSmall: 'font-mono text-[10px] uppercase tracking-[0.08em] sm:tracking-[0.15em] font-medium',
+
+  // Body text: Sans, 14-16px, relaxed leading
   body: 'font-sans text-sm leading-relaxed',
   bodyLarge: 'font-sans text-base leading-relaxed',
   bodyMuted: 'font-sans text-sm leading-relaxed opacity-60',
+
+  // Accession numbers: Mono, 10px, very muted
   accession: 'font-mono text-[10px] tracking-[0.15em] opacity-30 uppercase',
+
+  // Special: Italic serif for quotes/descriptions
   quote: 'font-serif italic text-lg leading-relaxed',
 } as const;
 
+// Theme-aware label colors, tuned per surface so muted labels still clear
+// WCAG AA. Gallery uses stone-500 (#78716C) — DESIGN.md's Gallery "Text Muted"
+// token — which reaches ~4.8:1 on the light surface, where stone-400 (#A8A29E)
+// only manages ~2.4:1. Vault keeps stone-400 to match DESIGN.md's dark "Text
+// Muted" token, which clears AA against the stone-900 surface.
 export const labelColorClasses: Record<AppTheme, string> = {
   gallery: 'text-stone-500',
   vault: 'text-stone-400',
-  atelier: 'text-[#6F6257]',
+  atelier: 'text-[#6F6257]', // Sepia-toned labels with AA contrast
 };
+
+// =============================================================================
+// ENHANCED THEME COLOR PALETTES
+// Each theme has a refined color system:
+// - Gallery: Clean, editorial, high-contrast (white + charcoal)
+// - Vault: Cinematic, luxurious (dark + brass/gold accents)
+// - Atelier: Warm, tactile, vintage (cream + warm brown)
+// =============================================================================
 
 export const themeColors = {
   gallery: {
-    mat: '#F5F5F5',
-    frameAccent: '#1A1A1A',
+    mat: '#F5F5F5', // Soft gray mat for subtle depth
+    frameAccent: '#1A1A1A', // Charcoal for refined contrast
     surface: '#FFFFFF',
     surfaceMuted: '#F5F5F5',
-    text: '#1C1917',
-    textMuted: '#78716C',
-    border: '#E7E5E4',
-    accent: '#D97706',
-    accentHover: '#B45309',
+    text: '#1C1917', // stone-900
+    textMuted: '#78716C', // stone-500
+    border: '#E7E5E4', // stone-200
+    accent: '#D97706', // amber-600
+    accentHover: '#B45309', // amber-700
   },
   vault: {
-    mat: '#1C1917',
-    frameAccent: '#D4A574',
-    surface: '#0C0A09',
-    surfaceMuted: '#1C1917',
+    mat: '#1C1917', // stone-900 for layered depth
+    frameAccent: '#D4A574', // Brass/gold for warmth
+    surface: '#0C0A09', // stone-950
+    surfaceMuted: '#1C1917', // stone-900
     text: '#FFFFFF',
-    textMuted: '#A8A29E',
+    textMuted: '#A8A29E', // stone-400
     border: 'rgba(255,255,255,0.1)',
-    accent: '#D4A574',
+    accent: '#D4A574', // Brass highlight
     accentHover: '#E0B585',
   },
   atelier: {
-    mat: '#EDE4D3',
-    frameAccent: '#6B5344',
-    surface: '#F5EFE4',
-    surfaceMuted: '#EDE4D3',
-    text: '#3D3530',
-    textMuted: '#6F6257',
-    border: '#D4C9B8',
-    accent: '#8B5A2B',
-    accentHover: '#73481F',
+    mat: '#EDE4D3', // Warm parchment - distinctly yellower than Gallery
+    frameAccent: '#6B5344', // Aged wood brown
+    surface: '#F5EFE4', // Warm cream with yellow undertone
+    surfaceMuted: '#EDE4D3', // Parchment
+    text: '#3D3530', // Warm dark brown (not cool gray)
+    textMuted: '#6F6257', // Sepia-toned muted text, AA on both warm surfaces
+    border: '#D4C9B8', // Warmer, more visible border
+    accent: '#8B5A2B', // Accessible aged-leather brown
+    accentHover: '#73481F', // Deeper accessible hover
   },
 } as const;
 
+// =============================================================================
+// ENHANCED SURFACE CLASSES
+// Pre-built Tailwind class combinations for common UI patterns
+// =============================================================================
+
+// Mat/background surfaces (for cards, panels with subtle depth)
 export const matSurfaceClasses: Record<AppTheme, string> = {
   gallery: 'bg-[#F5F5F5]',
   vault: 'bg-[#1C1917]',
-  atelier: 'bg-[#EDE4D3]',
+  atelier: 'bg-[#EDE4D3]', // Warm parchment
 };
 
+// Frame accent colors (for borders, dividers, highlights)
 export const frameAccentClasses: Record<AppTheme, string> = {
   gallery: 'border-[#1A1A1A]',
   vault: 'border-[#D4A574]',
-  atelier: 'border-[#6B5344]',
+  atelier: 'border-[#6B5344]', // Aged wood brown
 };
 
+// Interactive element accent colors
 export const accentColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-600 hover:text-amber-700',
   vault: 'text-[#D4A574] hover:text-[#E0B585]',
-  atelier: 'text-[#8B5A2B] hover:text-[#73481F]',
+  atelier: 'text-[#8B5A2B] hover:text-[#73481F]', // AA leather brown
 };
 
+// Accent color for small uppercase eyebrow/label text. The interactive accent
+// (amber-600, ~3.05:1 on white) fails WCAG AA when used as static label text,
+// so labels use the darker accent tone per theme: amber-700 (#B45309, DESIGN.md
+// "Accent Hover", ~4.6:1) on Gallery and the deeper amber-brown on Atelier.
+// Vault's brass already clears AA on the dark surface.
 export const accentLabelColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-700',
   vault: 'text-[#D4A574]',
   atelier: 'text-[#8B5A2B]',
 };
 
+// Accent background classes (for buttons, badges)
 export const accentBgClasses: Record<AppTheme, string> = {
   gallery: 'bg-amber-500 hover:bg-amber-600 text-white',
   vault: 'bg-[#D4A574] hover:bg-[#E0B585] text-stone-900',
-  atelier: 'bg-[#8B5A2B] hover:bg-[#73481F] text-white',
+  atelier: 'bg-[#8B5A2B] hover:bg-[#73481F] text-white', // Accessible leather brown
 };
 
+// Card hover states with enhanced shadows
 export const cardHoverClasses: Record<AppTheme, string> = {
   gallery: 'hover:shadow-gallery-hover hover:border-stone-200 transition-all duration-200',
   vault: 'hover:shadow-vault-hover hover:border-[#D4A574]/30 transition-all duration-200',
   atelier: 'hover:shadow-atelier-hover hover:border-[#8B5A2B]/30 transition-all duration-200',
 };
 
+// Enhanced card surfaces with theme-specific shadows
 export const cardSurfaceEnhancedClasses: Record<AppTheme, string> = {
   gallery: 'bg-white text-stone-900 border border-stone-100 shadow-gallery',
   vault: 'bg-stone-950 text-white border border-white/10 shadow-vault',
   atelier: 'bg-[#F5EFE4] text-[#3D3530] border border-[#D4C9B8] shadow-atelier',
 };
 
+// Divider/separator classes
 export const dividerClasses: Record<AppTheme, string> = {
   gallery: 'border-stone-200',
   vault: 'border-white/10',
-  atelier: 'border-[#D4C9B8]',
+  atelier: 'border-[#D4C9B8]', // Warmer, more visible
 };
 
+// Rating star colors (muted amber instead of bright yellow)
 export const ratingColorClasses: Record<AppTheme, string> = {
   gallery: 'text-amber-500',
   vault: 'text-[#D4A574]',
-  atelier: 'text-[#8B5A2B]',
+  atelier: 'text-[#8B5A2B]', // Accessible leather brown
 };
 
 export const ratingEmptyClasses: Record<AppTheme, string> = {
@@ -243,6 +292,7 @@ export const ratingEmptyClasses: Record<AppTheme, string> = {
   atelier: 'text-[#8B5A2B]/30',
 };
 
+// Input field classes
 export const inputClasses: Record<AppTheme, string> = {
   gallery:
     'bg-white border-stone-200 text-stone-900 placeholder:text-stone-300 focus:ring-amber-500/10 focus:border-amber-200',

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -515,7 +515,7 @@ describe('Layout Component', () => {
       it.each([
         { theme: 'gallery' as const, expected: ['bg-amber-100', 'text-amber-700'] },
         { theme: 'vault' as const, expected: ['bg-[#D4A574]/20', 'text-[#D4A574]'] },
-        { theme: 'atelier' as const, expected: ['bg-[#A86F3C]/15', 'text-[#A86F3C]'] },
+        { theme: 'atelier' as const, expected: ['bg-[#8B5A2B]/15', 'text-[#8B5A2B]'] },
       ])('uses theme accent in $theme', ({ theme, expected }) => {
         setMockTheme(theme);
         renderWithProviders(<Layout {...defaultProps} />);
@@ -899,7 +899,7 @@ describe('Layout Component', () => {
         theme: 'atelier' as const,
         signedIn: ['bg-emerald-100/70', 'text-emerald-700'],
         signedOut: ['bg-amber-100/70', 'text-amber-800'],
-        unconfigured: ['bg-[#EDE4D3]', 'text-[#8C7B6B]'],
+        unconfigured: ['bg-[#EDE4D3]', 'text-[#6F6257]'],
       },
     ])('Auth-status chip in $theme', ({ theme, signedIn, signedOut, unconfigured }) => {
       beforeEach(() => {
@@ -949,7 +949,7 @@ describe('Layout Component', () => {
         surface: ['border-amber-300/60', 'bg-amber-100/70'],
         title: 'text-amber-900',
         body: 'text-[#3D3530]',
-        action: 'bg-[#A86F3C]',
+        action: 'bg-[#8B5A2B]',
         status: 'text-amber-900',
         error: 'text-red-700',
       },

--- a/tests/components/ui/Button.test.tsx
+++ b/tests/components/ui/Button.test.tsx
@@ -250,7 +250,7 @@ describe('Button', () => {
       it('primary uses leather brown on cream', () => {
         renderWithProviders(<Button>Primary</Button>);
         const button = screen.getByRole('button');
-        expect(button).toHaveClass('bg-[#A86F3C]');
+        expect(button).toHaveClass('bg-[#8B5A2B]');
         expect(button).toHaveClass('text-white');
         expect(button).not.toHaveClass('bg-stone-800');
       });
@@ -264,12 +264,12 @@ describe('Button', () => {
 
       it('ghost uses sepia text instead of cool stone', () => {
         renderWithProviders(<Button variant="ghost">Ghost</Button>);
-        expect(screen.getByRole('button')).toHaveClass('text-[#8C7B6B]');
+        expect(screen.getByRole('button')).toHaveClass('text-[#6F6257]');
       });
 
       it('focus ring picks up the leather accent', () => {
         renderWithProviders(<Button>Focus</Button>);
-        expect(screen.getByRole('button')).toHaveClass('focus:ring-[#A86F3C]/40');
+        expect(screen.getByRole('button')).toHaveClass('focus:ring-[#8B5A2B]/40');
       });
     });
 

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -1811,7 +1811,7 @@ describe('App Integration Tests', () => {
     expect(chip.classList).toContain('text-amber-900');
 
     const clearAll = screen.getByTestId('active-filter-clear-all');
-    expect(clearAll.classList).toContain('text-[#8C7B6B]');
+    expect(clearAll.classList).toContain('text-[#6F6257]');
   });
 
   // CUR-135: Item Detail undo/redo can be reached from the keyboard so power

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -15,6 +15,25 @@ import {
   inputClasses,
 } from '@/theme';
 
+const relativeLuminance = (hex: string) => {
+  const channels = hex
+    .replace('#', '')
+    .match(/.{2}/g)!
+    .map((channel) => parseInt(channel, 16) / 255)
+    .map((value) =>
+      value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4),
+    );
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+};
+
+const contrastRatio = (foreground: string, background: string) => {
+  const a = relativeLuminance(foreground);
+  const b = relativeLuminance(background);
+  const lighter = Math.max(a, b);
+  const darker = Math.min(a, b);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
 describe('Theme Utilities', () => {
   describe('typographyClasses', () => {
     it('has title classes', () => {
@@ -74,7 +93,16 @@ describe('Theme Utilities', () => {
     it('has atelier theme colors', () => {
       expect(themeColors.atelier.mat).toBe('#EDE4D3');
       expect(themeColors.atelier.frameAccent).toBe('#6B5344');
-      expect(themeColors.atelier.accent).toBe('#A86F3C');
+      expect(themeColors.atelier.accent).toBe('#8B5A2B');
+      expect(themeColors.atelier.accentHover).toBe('#73481F');
+      expect(themeColors.atelier.textMuted).toBe('#6F6257');
+    });
+
+    it('keeps Atelier text and accent combinations at WCAG AA contrast', () => {
+      expect(contrastRatio('#FFFFFF', themeColors.atelier.accent)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio('#FFFFFF', themeColors.atelier.accentHover)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(themeColors.atelier.textMuted, themeColors.atelier.surface)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(themeColors.atelier.textMuted, themeColors.atelier.surfaceMuted)).toBeGreaterThanOrEqual(4.5);
     });
   });
 
@@ -88,18 +116,13 @@ describe('Theme Utilities', () => {
     it('uses appropriate colors per theme', () => {
       expect(labelColorClasses.gallery).toContain('text-stone');
       expect(labelColorClasses.vault).toContain('text-stone');
-      expect(labelColorClasses.atelier).toContain('text-[#8C7B6B]');
+      expect(labelColorClasses.atelier).toContain('text-[#6F6257]');
     });
 
-    // stone-500 (#78716c) fails WCAG AA on the Vault stone-900 surface
-    // (~3.77:1); DESIGN.md sets Vault textMuted to stone-400 (#A8A29E).
     it('keeps Vault labels at or above stone-400 contrast', () => {
       expect(labelColorClasses.vault).toBe('text-stone-400');
     });
 
-    // stone-400 (#A8A29E) only reaches ~2.4:1 on the Gallery light surface and
-    // fails WCAG AA; DESIGN.md's Gallery "Text Muted" token is stone-500
-    // (#78716C, ~4.8:1). Regression guard for #423.
     it('uses AA-compliant stone-500 for Gallery labels', () => {
       expect(labelColorClasses.gallery).toBe('text-stone-500');
     });
@@ -163,7 +186,7 @@ describe('Theme Utilities', () => {
     it('uses amber/brass colors', () => {
       expect(ratingColorClasses.gallery).toContain('amber');
       expect(ratingColorClasses.vault).toContain('#D4A574');
-      expect(ratingColorClasses.atelier).toContain('#A86F3C');
+      expect(ratingColorClasses.atelier).toContain('#8B5A2B');
     });
   });
 
@@ -202,16 +225,11 @@ describe('Theme Utilities', () => {
       expect(accentLabelColorClasses.atelier).toBeDefined();
     });
 
-    // The interactive accent amber-600 (~3.05:1 on white) fails WCAG AA as
-    // static label text; eyebrow labels use amber-700 (#B45309, ~4.6:1), which
-    // DESIGN.md already defines as "Accent Hover". Regression guard for #423.
     it('uses the AA-compliant darker accent for Gallery label text', () => {
       expect(accentLabelColorClasses.gallery).toBe('text-amber-700');
       expect(accentLabelColorClasses.gallery).not.toContain('amber-600');
     });
 
-    // Label text is static, so no hover state is needed (unlike the
-    // interactive accentColorClasses).
     it('does not carry a hover state', () => {
       expect(accentLabelColorClasses.gallery).not.toContain('hover:');
       expect(accentLabelColorClasses.vault).not.toContain('hover:');
@@ -265,9 +283,12 @@ describe('Theme Utilities', () => {
       expect(inputClasses.atelier).toContain('placeholder:');
     });
 
-    // Mirrors labelColorClasses contrast guarantee — see comment above.
     it('uses stone-400 placeholders on Vault for WCAG AA contrast', () => {
       expect(inputClasses.vault).toContain('placeholder:text-stone-400');
+    });
+
+    it('uses the AA-compliant Atelier muted token for placeholders', () => {
+      expect(inputClasses.atelier).toContain('placeholder:text-[#6F6257]');
     });
   });
 });

--- a/tests/unit/theme.test.ts
+++ b/tests/unit/theme.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import {
   typographyClasses,
   themeColors,
@@ -20,9 +22,7 @@ const relativeLuminance = (hex: string) => {
     .replace('#', '')
     .match(/.{2}/g)!
     .map((channel) => parseInt(channel, 16) / 255)
-    .map((value) =>
-      value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4),
-    );
+    .map((value) => (value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4)));
   return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
 };
 
@@ -58,7 +58,7 @@ describe('Theme Utilities', () => {
 
     it('has labelMuted classes', () => {
       expect(typographyClasses.labelMuted).toContain('font-mono');
-      expect(typographyClasses.labelMuted).toContain('opacity-50');
+      expect(typographyClasses.labelMuted).toContain('font-medium');
     });
 
     it('has body classes with sans font', () => {
@@ -101,8 +101,12 @@ describe('Theme Utilities', () => {
     it('keeps Atelier text and accent combinations at WCAG AA contrast', () => {
       expect(contrastRatio('#FFFFFF', themeColors.atelier.accent)).toBeGreaterThanOrEqual(4.5);
       expect(contrastRatio('#FFFFFF', themeColors.atelier.accentHover)).toBeGreaterThanOrEqual(4.5);
-      expect(contrastRatio(themeColors.atelier.textMuted, themeColors.atelier.surface)).toBeGreaterThanOrEqual(4.5);
-      expect(contrastRatio(themeColors.atelier.textMuted, themeColors.atelier.surfaceMuted)).toBeGreaterThanOrEqual(4.5);
+      expect(
+        contrastRatio(themeColors.atelier.textMuted, themeColors.atelier.surface),
+      ).toBeGreaterThanOrEqual(4.5);
+      expect(
+        contrastRatio(themeColors.atelier.textMuted, themeColors.atelier.surfaceMuted),
+      ).toBeGreaterThanOrEqual(4.5);
     });
   });
 
@@ -119,10 +123,15 @@ describe('Theme Utilities', () => {
       expect(labelColorClasses.atelier).toContain('text-[#6F6257]');
     });
 
+    // stone-500 (#78716c) fails WCAG AA on the Vault stone-900 surface
+    // (~3.77:1); DESIGN.md sets Vault textMuted to stone-400 (#A8A29E).
     it('keeps Vault labels at or above stone-400 contrast', () => {
       expect(labelColorClasses.vault).toBe('text-stone-400');
     });
 
+    // stone-400 (#A8A29E) only reaches ~2.4:1 on the Gallery light surface and
+    // fails WCAG AA; DESIGN.md's Gallery "Text Muted" token is stone-500
+    // (#78716C, ~4.8:1). Regression guard for #423.
     it('uses AA-compliant stone-500 for Gallery labels', () => {
       expect(labelColorClasses.gallery).toBe('text-stone-500');
     });
@@ -225,11 +234,16 @@ describe('Theme Utilities', () => {
       expect(accentLabelColorClasses.atelier).toBeDefined();
     });
 
+    // The interactive accent amber-600 (~3.05:1 on white) fails WCAG AA as
+    // static label text; eyebrow labels use amber-700 (#B45309, ~4.6:1), which
+    // DESIGN.md already defines as "Accent Hover". Regression guard for #423.
     it('uses the AA-compliant darker accent for Gallery label text', () => {
       expect(accentLabelColorClasses.gallery).toBe('text-amber-700');
       expect(accentLabelColorClasses.gallery).not.toContain('amber-600');
     });
 
+    // Label text is static, so no hover state is needed (unlike the
+    // interactive accentColorClasses).
     it('does not carry a hover state', () => {
       expect(accentLabelColorClasses.gallery).not.toContain('hover:');
       expect(accentLabelColorClasses.vault).not.toContain('hover:');
@@ -283,12 +297,57 @@ describe('Theme Utilities', () => {
       expect(inputClasses.atelier).toContain('placeholder:');
     });
 
+    // Mirrors labelColorClasses contrast guarantee — see comment above.
     it('uses stone-400 placeholders on Vault for WCAG AA contrast', () => {
       expect(inputClasses.vault).toContain('placeholder:text-stone-400');
     });
 
     it('uses the AA-compliant Atelier muted token for placeholders', () => {
       expect(inputClasses.atelier).toContain('placeholder:text-[#6F6257]');
+    });
+  });
+
+  // CUR-111: retiring the Atelier tokens in this module is only half the fix —
+  // production components hard-code the same hex values in their own per-theme
+  // class maps, so the old palette has to be gone from the whole source tree or
+  // the common flows keep rendering the sub-AA colors.
+  describe('retired Atelier palette', () => {
+    const RETIRED = ['#8C7B6B', '#A86F3C'];
+
+    const sourceFiles = () => {
+      const roots = [resolve(__dirname, '../../src')];
+      const files: string[] = [];
+      while (roots.length) {
+        const dir = roots.pop()!;
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+          const full = join(dir, entry.name);
+          if (entry.isDirectory()) roots.push(full);
+          else if (/\.(ts|tsx|css)$/.test(entry.name)) files.push(full);
+        }
+      }
+      return files;
+    };
+
+    it('no longer appears anywhere in src/', () => {
+      const offenders = sourceFiles().filter((file) => {
+        const contents = readFileSync(file, 'utf8');
+        return RETIRED.some((hex) => contents.includes(hex));
+      });
+      expect(offenders).toEqual([]);
+    });
+  });
+
+  // CUR-111: `opacity-50` composited even the AA-compliant #6F6257 down to
+  // ~2:1 against the Atelier surface, so muted labels stayed unreadable while
+  // token-only tests reported compliance. The muting is a color token now.
+  describe('labelMuted', () => {
+    it('does not dim readable labels with opacity', () => {
+      expect(typographyClasses.labelMuted).not.toContain('opacity-');
+    });
+
+    it('still reads as muted through weight rather than transparency', () => {
+      expect(typographyClasses.labelMuted).toContain('font-medium');
+      expect(typographyClasses.label).toContain('font-bold');
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements [CUR-111](https://linear.app/qiuyue/issue/CUR-111/ux-atelier-accent-muted-tokens-fall-below-wcag-aa-contrast-revise) by tightening the Atelier design-system palette centrally instead of adding per-component overrides.

## What changed

- changes Atelier accent from `#A86F3C` to `#8B5A2B`
- adds a deeper hover accent `#73481F`
- changes Atelier muted text from `#8C7B6B` to `#6F6257`
- propagates the revised tokens through accent backgrounds/text, labels, ratings, hover borders, placeholders and input focus states
- updates `DESIGN.md` so the documented design system matches runtime tokens
- adds programmatic WCAG contrast regression tests for white-on-accent and muted text on both Atelier surfaces

## Contrast checks

- white on `#8B5A2B`: ~5.84:1
- white on `#73481F`: ~7.85:1
- `#6F6257` on `#F5EFE4`: ~5.15:1
- `#6F6257` on `#EDE4D3`: ~4.67:1

All clear the WCAG AA 4.5:1 threshold for normal text.

## Implementation notes

This stays at the design-token layer so Home cards, Add Item, Item Detail, filters, auth/export surfaces, badges, ratings and buttons inherit the same palette. Gallery and Vault are unchanged. No component-specific color exceptions or new theme abstraction were introduced.

## Validation

- branch is based directly on current `main` and is 0 commits behind
- added unit-level contrast calculations to prevent regression
- GitHub/Vercel CI will run on this ready-for-review PR

## Risk

Yellow / visual-system change only. No data, auth, sync, RLS, AI or schema behavior changes.

## Linear

CUR-111