### PR TITLE
[CURIO-412] Describe Rapid-Fire Mode on the Add Item upload step

### DIFF
--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1249,13 +1249,16 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
             {t('editPhoto')}
           </Button>
         )}
-        <Button
-          variant="secondary"
-          onClick={() => batchInputRef.current?.click()}
-          icon={<Zap size={18} />}
-        >
-          {t('batchMode')}
-        </Button>
+        <div className="flex flex-col gap-1.5">
+          <Button
+            variant="secondary"
+            onClick={() => batchInputRef.current?.click()}
+            icon={<Zap size={18} />}
+          >
+            {t('batchMode')}
+          </Button>
+          <p className={`text-[11px] sm:text-xs ${mutedText}`}>{t('batchModeHint')}</p>
+        </div>
         <button
           onClick={switchToManual}
           data-testid="add-item-skip-manual"

--- a/src/components/AddItemModal.tsx
+++ b/src/components/AddItemModal.tsx
@@ -1254,10 +1254,13 @@ export const AddItemModal: React.FC<AddItemModalProps> = ({
             variant="secondary"
             onClick={() => batchInputRef.current?.click()}
             icon={<Zap size={18} />}
+            aria-describedby="add-item-batch-hint"
           >
             {t('batchMode')}
           </Button>
-          <p className={`text-[11px] sm:text-xs ${mutedText}`}>{t('batchModeHint')}</p>
+          <p id="add-item-batch-hint" className={`text-[11px] sm:text-xs ${mutedText}`}>
+            {t('batchModeHint')}
+          </p>
         </div>
         <button
           onClick={switchToManual}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -245,6 +245,7 @@ export const translations = {
     // New features
     batchMode: 'Rapid-Fire Mode',
     batchModeDesc: 'Process multiple items in a single session.',
+    batchModeHint: "Add several photos at once, then review each one's details.",
     addMore: 'Add More',
     archiveArtifact: 'Save {count} piece',
     archiveArtifacts: 'Save {count} pieces',
@@ -819,6 +820,7 @@ export const translations = {
     // New Features ZH
     batchMode: '连拍录入模式',
     batchModeDesc: '在一次会话中处理多件藏品。',
+    batchModeHint: '一次性添加多张照片，之后逐一确认细节。',
     addMore: '继续添加',
     archiveArtifact: '保存 {count} 件藏品',
     archiveArtifacts: '保存 {count} 件藏品',

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -204,6 +204,27 @@ describe('AddItemModal', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('describes the Rapid-Fire batch option on the upload step (#412)', () => {
+    const c1 = createMockCollection({ id: 'c1', name: 'Vinyl Vault' });
+
+    renderWithProviders(
+      <AddItemModal
+        isOpen
+        onClose={mockOnClose}
+        collections={[c1]}
+        defaultCollectionId="c1"
+        onSave={mockOnSave}
+      />,
+    );
+
+    // The emphasized alternate mode must explain itself before selection, so it
+    // reads as a clear choice next to the primary upload — not an opaque button.
+    expect(screen.getByText('Rapid-Fire Mode')).toBeInTheDocument();
+    expect(
+      screen.getByText("Add several photos at once, then review each one's details."),
+    ).toBeInTheDocument();
+  });
+
   it('falls back to collection picker when defaultCollectionId does not match any collection', async () => {
     const c1 = createMockCollection({ id: 'c1', name: 'Vinyl Vault' });
     const c2 = createMockCollection({ id: 'c2', name: 'Chocolate Vault' });

--- a/tests/components/AddItemModal.test.tsx
+++ b/tests/components/AddItemModal.test.tsx
@@ -219,10 +219,14 @@ describe('AddItemModal', () => {
 
     // The emphasized alternate mode must explain itself before selection, so it
     // reads as a clear choice next to the primary upload — not an opaque button.
-    expect(screen.getByText('Rapid-Fire Mode')).toBeInTheDocument();
-    expect(
-      screen.getByText("Add several photos at once, then review each one's details."),
-    ).toBeInTheDocument();
+    const hint = screen.getByText("Add several photos at once, then review each one's details.");
+    expect(hint).toBeInTheDocument();
+
+    // The hint must be programmatically tied to the button so screen-reader
+    // users tabbing to it hear the explanation, not just "Rapid-Fire Mode".
+    const batchButton = screen.getByRole('button', { name: /Rapid-Fire Mode/ });
+    expect(batchButton).toHaveAttribute('aria-describedby', hint.id);
+    expect(hint.id).toBeTruthy();
   });
 
   it('falls back to collection picker when defaultCollectionId does not match any collection', async () => {


### PR DESCRIPTION
## Problem

On the Add Item modal's upload step, three actions compete: **Upload Photo** (with the subtitle "Add a photo and Gemini will suggest the details."), **Rapid-Fire Mode** (a visually emphasized amber secondary button with **no** description), and **Skip and add manually** (a self-explanatory text link). Rapid-Fire Mode is the only emphasized option besides the primary, yet a first-time user has no way to know what it does — batch capture? no-AI quick add? — before committing to it. That's friction at the exact moment the product wants a fast, confident "add my first item." Protects **beauty before bureaucracy** (one clear hierarchy of affordances) and **trust** (controls should be legible about what they do).

The description shipped only on the *batch-verify* screen (`batchModeDesc`); the upload-step button itself had none. Ref: #412.

## Approach

- `src/components/AddItemModal.tsx`: wrap the Rapid-Fire button and a one-line caption in a tight `flex flex-col gap-1.5` container, rendering a new `batchModeHint` string in muted type directly beneath the button — mirroring the primary Upload Photo subtitle so the three options read as primary upload → described alternate mode → manual skip.
- `src/i18n.ts`: add `batchModeHint`, localized EN + ZH, with copy accurate to the batch flow (add several photos at once, then review each one's details) and in Curio's calmer museum voice rather than the drier verify-banner string.
- Test: an `AddItemModal` case asserting the Rapid-Fire button **and** its description both render on the upload step.

**Reason for a new key (not reusing `batchModeDesc`):** the existing verify-banner string ("Process multiple items in a single session.") reads more enterprise than Curio's copy voice; a purpose-built button subtitle stays warm and parallels the Upload Photo subtitle without changing the verify banner.

## Why this approach

Adding one muted caption line is the smallest taste-aligned fix that satisfies the issue's three acceptance criteria (described mode, accurate + localized copy, clear hierarchy). It touches no visual token, layout system, or data flow, and the batch input, manual-skip fallback, and AI-optional path are all untouched.

## Risks

Low (Green). Presentational + copy only — no behaviour, data, sync, AI, auth, or read-only change. One new i18n key (EN + ZH); no visual-token change. AI remains non-blocking and the manual path is unaffected.

## How to verify

Vercel Preview: _(auto-deployed on this PR)_

Steps:
1. Sign in and start Add Item (bottom-nav **Add**, or a collection's **Add Item**).
2. On the upload step, confirm **Rapid-Fire Mode** now shows the caption "Add several photos at once, then review each one's details." directly beneath it.
3. Switch language to 中文 and confirm the caption localizes ("一次性添加多张照片，之后逐一确认细节。").
4. Confirm the three options still read as primary upload → described alternate mode → manual skip.

Checks:
- [x] npm run format:check
- [x] npm test (1117 passed, 2 skipped, 1 todo)
- [x] npm run build
- [x] npm run test:e2e (44 passed, 8 skipped)

## Screenshot / GIF

No visual-token or layout-system change — this adds one muted caption line beneath the existing Rapid-Fire button. The signed-in Add Item upload step requires Supabase auth, which isn't available in this headless environment, so the live result is best seen on the Vercel preview above; the added caption (both states) is pinned by the new `AddItemModal` test.

## Linear

Closes #412

## Rollback plan

Not required for Green tier. If needed: `git revert 3a4ec45` — the change is isolated to the Rapid-Fire block in `AddItemModal.tsx`, one i18n key (EN + ZH) in `i18n.ts`, and one test. No migrations, flags, storage, or schema involved.

---
_Generated by [Claude Code](https://claude.ai/code/session_012zW6LNbyDBsXbxUCHc6xE8)_