### PR TITLE
CUR-24 Add lightweight month timeline browsing

### DIFF
--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -26,7 +26,11 @@ import { DeleteCollectionModal } from './DeleteCollectionModal';
 import { DeleteItemsModal } from './DeleteItemsModal';
 import type { StatusTone } from './StatusToast';
 import { sortCollectionItems, type ItemSort } from '../utils/collectionSorting';
-import { matchesItemFilters } from '../utils/itemFilter';
+import {
+  ADDED_MONTH_FILTER_KEY,
+  formatAddedMonthLabel,
+  matchesItemFilters,
+} from '../utils/itemFilter';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 
 // CUR-93: Active filter chips and the "Clear all" link used to hardcode
@@ -90,7 +94,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
   removeCollection,
   showStatus,
 }) => {
-  const { t } = useTranslation();
+  const { t, language } = useTranslation();
   const { theme } = useTheme();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -167,6 +171,17 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
 
   const getFieldLabel = (fieldId: string) =>
     getFieldTranslation(t, fieldId, collection?.customFields.find((f) => f.id === fieldId)?.label);
+
+  // Reserved filter keys are implementation details, not custom fields, so the
+  // active-filter chip has to translate both halves itself. Without this the
+  // chip would read "__addedMonth · 2026-03" in every language.
+  const getFilterLabel = (key: string) =>
+    key === ADDED_MONTH_FILTER_KEY ? t('addedOn', { date: '' }).trim() : getFieldLabel(key);
+
+  const getFilterValueLabel = (key: string, value: string) =>
+    key === ADDED_MONTH_FILTER_KEY
+      ? formatAddedMonthLabel(value, language === 'zh' ? 'zh-CN' : 'en-US')
+      : value;
 
   const handleRemoveFilter = (key: string) => {
     setActiveFilters((prev) => {
@@ -488,9 +503,9 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
               onClick={() => handleRemoveFilter(key)}
               title={t('clearFilter')}
             >
-              <span className="font-semibold">{getFieldLabel(key)}</span>
+              <span className="font-semibold">{getFilterLabel(key)}</span>
               <span className={filterChipSeparatorClasses[theme]}>·</span>
-              <span className="font-medium">{value}</span>
+              <span className="font-medium">{getFilterValueLabel(key, value)}</span>
               <X size={14} className={filterChipIconClasses[theme]} />
             </button>
           ))}

--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -1,11 +1,15 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
-import { X, Filter, RotateCcw, ChevronDown } from 'lucide-react';
+import { X, Filter, RotateCcw, ChevronDown, CalendarDays } from 'lucide-react';
 import { CollectionItem, FieldDefinition } from '../types';
 import { Button } from './ui/Button';
 import { useTranslation, getFieldTranslation } from '../i18n';
 import { useTheme, panelSurfaceClasses, overlaySurfaceClasses, mutedTextClasses } from '../theme';
 import { useModalA11y } from '../hooks/useModalA11y';
-import { deriveSelectOptions } from '../utils/itemFilter';
+import {
+  ADDED_MONTH_FILTER_KEY,
+  deriveAddedMonthOptions,
+  deriveSelectOptions,
+} from '../utils/itemFilter';
 
 interface FilterModalProps {
   isOpen: boolean;
@@ -24,7 +28,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({
   activeFilters,
   onApply,
 }) => {
-  const { t } = useTranslation();
+  const { t, language } = useTranslation();
   const { theme } = useTheme();
   const [localFilters, setLocalFilters] = useState<Record<string, string>>(activeFilters);
   const surfaceClass = panelSurfaceClasses[theme];
@@ -51,6 +55,15 @@ export const FilterModal: React.FC<FilterModalProps> = ({
     return map;
   }, [fields, items]);
 
+  // CUR-24: keep timeline browsing inside the existing filter surface rather
+  // than creating a second navigation mode. Only months that actually contain
+  // items are offered, newest first. Values are stable YYYY-MM keys while labels
+  // follow the active locale (for example "March 2026" / "2026年3月").
+  const addedMonthOptions = useMemo(
+    () => deriveAddedMonthOptions(items, language === 'zh' ? 'zh-CN' : 'en-US'),
+    [items, language],
+  );
+
   useEffect(() => {
     if (isOpen) setLocalFilters(activeFilters);
   }, [isOpen, activeFilters]);
@@ -72,6 +85,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({
   };
 
   const activeCount = Object.values(localFilters).filter(Boolean).length;
+  const addedOnLabel = t('addedOn', { date: '' }).trim();
 
   return (
     <div
@@ -108,6 +122,41 @@ export const FilterModal: React.FC<FilterModalProps> = ({
           </button>
         </div>
         <div className="px-6 py-5 pb-24 sm:pb-5 space-y-5 overflow-y-auto flex-1">
+          {addedMonthOptions.length > 0 && (
+            <div className="space-y-2">
+              <label
+                htmlFor="filter-field-added-month"
+                className={`flex items-center gap-1.5 text-[12px] sm:text-[11px] font-semibold uppercase tracking-[0.18em] ${mutedText}`}
+              >
+                <CalendarDays size={13} aria-hidden="true" />
+                {addedOnLabel}
+              </label>
+              <div className="relative">
+                <select
+                  id="filter-field-added-month"
+                  value={localFilters[ADDED_MONTH_FILTER_KEY] || ''}
+                  onChange={(e) =>
+                    setLocalFilters({
+                      ...localFilters,
+                      [ADDED_MONTH_FILTER_KEY]: e.target.value,
+                    })
+                  }
+                  className={`w-full p-3 rounded-2xl text-sm outline-none appearance-none ${inputSurface}`}
+                >
+                  <option value="">{t('anyValue')}</option>
+                  {addedMonthOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  size={16}
+                  className={`absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none ${theme === 'vault' ? 'text-white/50' : 'text-stone-400'}`}
+                />
+              </div>
+            </div>
+          )}
           <div className="space-y-2">
             <label
               htmlFor="filter-field-rating"

--- a/src/utils/itemFilter.ts
+++ b/src/utils/itemFilter.ts
@@ -2,9 +2,48 @@ import { CollectionItem, FieldDefinition } from '../types';
 
 const normalize = (value: string) => value.trim().toLocaleLowerCase();
 
-// `rating` is a reserved filter key that always compares against the item's
-// top-level rating field, not a custom-field lookup on `item.data`.
+// `rating` and `__addedMonth` are reserved filter keys that compare against
+// top-level item properties rather than custom-field values in `item.data`.
 export const RATING_FILTER_KEY = 'rating';
+export const ADDED_MONTH_FILTER_KEY = '__addedMonth';
+
+export type AddedMonthOption = {
+  value: string;
+  label: string;
+};
+
+const getAddedMonthKey = (createdAt: string): string | null => {
+  const date = new Date(createdAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+};
+
+export function deriveAddedMonthOptions(
+  items: CollectionItem[],
+  locale: string,
+): AddedMonthOption[] {
+  const keys = new Set<string>();
+  for (const item of items) {
+    const key = getAddedMonthKey(item.createdAt);
+    if (key) keys.add(key);
+  }
+
+  const formatter = new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+  });
+
+  return Array.from(keys)
+    .sort((a, b) => b.localeCompare(a))
+    .map((value) => {
+      const [year, month] = value.split('-').map(Number);
+      return {
+        value,
+        label: formatter.format(new Date(Date.UTC(year, month - 1, 1))),
+      };
+    });
+}
 
 export function matchesItemFilters(
   item: CollectionItem,
@@ -15,6 +54,7 @@ export function matchesItemFilters(
   return Object.entries(activeFilters).every(([key, value]) => {
     if (!value) return true;
     if (key === RATING_FILTER_KEY) return item.rating >= parseInt(value, 10);
+    if (key === ADDED_MONTH_FILTER_KEY) return getAddedMonthKey(item.createdAt) === value;
     const itemVal = item.data[key];
     if (itemVal === undefined || itemVal === null || itemVal === '') return false;
     const field = fieldById.get(key);

--- a/src/utils/itemFilter.ts
+++ b/src/utils/itemFilter.ts
@@ -18,6 +18,22 @@ const getAddedMonthKey = (createdAt: string): string | null => {
   return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
 };
 
+// Renders a stable `YYYY-MM` filter value as a localized month name. Returns
+// the raw value unchanged when it is not a month key, so callers can use this
+// for display without pre-validating.
+export function formatAddedMonthLabel(value: string, locale: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(value);
+  if (!match) return value;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) return value;
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(year, month - 1, 1)));
+}
+
 export function deriveAddedMonthOptions(
   items: CollectionItem[],
   locale: string,
@@ -28,21 +44,12 @@ export function deriveAddedMonthOptions(
     if (key) keys.add(key);
   }
 
-  const formatter = new Intl.DateTimeFormat(locale, {
-    year: 'numeric',
-    month: 'long',
-    timeZone: 'UTC',
-  });
-
   return Array.from(keys)
     .sort((a, b) => b.localeCompare(a))
-    .map((value) => {
-      const [year, month] = value.split('-').map(Number);
-      return {
-        value,
-        label: formatter.format(new Date(Date.UTC(year, month - 1, 1))),
-      };
-    });
+    .map((value) => ({
+      value,
+      label: formatAddedMonthLabel(value, locale),
+    }));
 }
 
 export function matchesItemFilters(

--- a/tests/integration/AppNavigation.test.tsx
+++ b/tests/integration/AppNavigation.test.tsx
@@ -1721,10 +1721,45 @@ describe('App Integration Tests', () => {
   const applyRatingFilter = async () => {
     fireEvent.click(screen.getByRole('button', { name: 'Filter Collection' }));
     const dialog = await screen.findByRole('dialog', { name: 'Filter Collection' });
-    const ratingSelect = within(dialog).getByRole('combobox');
+    // The dialog can render several comboboxes (rating plus reserved filters
+    // such as the added-month timeline), so select the rating control by label.
+    const ratingSelect = within(dialog).getByLabelText('Rating');
     fireEvent.change(ratingSelect, { target: { value: '5' } });
     fireEvent.click(within(dialog).getByRole('button', { name: /apply/i }));
   };
+
+  // CUR-24: `__addedMonth` is a reserved filter key rather than a custom field,
+  // so the chip has to localize both halves itself; otherwise the active state
+  // leaks the implementation key and an unlocalized `2026-03` value.
+  it('renders the added-month chip with localized label and month name (CUR-24)', async () => {
+    const { ThemeProvider } = await import('@/theme');
+
+    render(
+      <MemoryRouter initialEntries={['/collection/col1']}>
+        <ThemeProvider>
+          <LanguageProvider>
+            <AppContent />
+          </LanguageProvider>
+        </ThemeProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Collection')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter Collection' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Filter Collection' });
+    const monthSelect = within(dialog).getByLabelText('Added on');
+    const monthValue = (within(monthSelect).getAllByRole('option')[1] as HTMLOptionElement).value;
+    fireEvent.change(monthSelect, { target: { value: monthValue } });
+    fireEvent.click(within(dialog).getByRole('button', { name: /apply/i }));
+
+    const chip = await screen.findByTestId('active-filter-chip');
+    expect(chip.textContent).toContain('Added on');
+    expect(chip.textContent).not.toContain('__addedMonth');
+    expect(chip.textContent).not.toContain(monthValue);
+  });
 
   it('renders active filter chips with theme-aware tokens on Vault (CUR-93)', async () => {
     const { ThemeProvider } = await import('@/theme');

--- a/tests/utils/itemFilter.test.ts
+++ b/tests/utils/itemFilter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { deriveSelectOptions, matchesItemFilters } from '@/utils/itemFilter';
+import {
+  ADDED_MONTH_FILTER_KEY,
+  deriveAddedMonthOptions,
+  deriveSelectOptions,
+  matchesItemFilters,
+} from '@/utils/itemFilter';
 import { CollectionItem, FieldDefinition } from '@/types';
 
 const createItem = (overrides: Partial<CollectionItem> = {}): CollectionItem => ({
@@ -65,10 +70,31 @@ describe('matchesItemFilters', () => {
     expect(matchesItemFilters(createItem({ rating: 3 }), { rating: '4' }, fields)).toBe(false);
   });
 
+  it('filters by the item created month using a stable UTC year-month key', () => {
+    const march = createItem({ createdAt: '2026-03-31T23:30:00.000Z' });
+    expect(
+      matchesItemFilters(march, { [ADDED_MONTH_FILTER_KEY]: '2026-03' }, fields),
+    ).toBe(true);
+    expect(
+      matchesItemFilters(march, { [ADDED_MONTH_FILTER_KEY]: '2026-04' }, fields),
+    ).toBe(false);
+  });
+
   it('requires all active filters to match', () => {
-    const item = createItem({ rating: 5, data: { genre: 'Jazz', artist: 'Coltrane' } });
+    const item = createItem({
+      rating: 5,
+      createdAt: '2026-03-15T12:00:00.000Z',
+      data: { genre: 'Jazz', artist: 'Coltrane' },
+    });
     expect(matchesItemFilters(item, { genre: 'Jazz', artist: 'davis' }, fields)).toBe(false);
     expect(matchesItemFilters(item, { genre: 'Jazz', artist: 'coltrane' }, fields)).toBe(true);
+    expect(
+      matchesItemFilters(
+        item,
+        { genre: 'Jazz', [ADDED_MONTH_FILTER_KEY]: '2026-03' },
+        fields,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -101,5 +127,29 @@ describe('deriveSelectOptions', () => {
       createItem({ data: {} }),
     ];
     expect(deriveSelectOptions('genre', undefined, items)).toEqual(['Jazz']);
+  });
+});
+
+describe('deriveAddedMonthOptions', () => {
+  it('returns only months represented by valid item dates, newest first', () => {
+    const items = [
+      createItem({ createdAt: '2025-12-04T12:00:00.000Z' }),
+      createItem({ createdAt: '2026-03-02T12:00:00.000Z' }),
+      createItem({ createdAt: '2026-03-28T12:00:00.000Z' }),
+      createItem({ createdAt: 'not-a-date' }),
+    ];
+
+    expect(deriveAddedMonthOptions(items, 'en-US')).toEqual([
+      { value: '2026-03', label: 'March 2026' },
+      { value: '2025-12', label: 'December 2025' },
+    ]);
+  });
+
+  it('formats labels using the active locale without changing filter keys', () => {
+    const items = [createItem({ createdAt: '2026-03-02T12:00:00.000Z' })];
+    const [option] = deriveAddedMonthOptions(items, 'zh-CN');
+    expect(option.value).toBe('2026-03');
+    expect(option.label).toContain('2026');
+    expect(option.label).toContain('3');
   });
 });

--- a/tests/utils/itemFilter.test.ts
+++ b/tests/utils/itemFilter.test.ts
@@ -3,6 +3,7 @@ import {
   ADDED_MONTH_FILTER_KEY,
   deriveAddedMonthOptions,
   deriveSelectOptions,
+  formatAddedMonthLabel,
   matchesItemFilters,
 } from '@/utils/itemFilter';
 import { CollectionItem, FieldDefinition } from '@/types';
@@ -72,12 +73,8 @@ describe('matchesItemFilters', () => {
 
   it('filters by the item created month using a stable UTC year-month key', () => {
     const march = createItem({ createdAt: '2026-03-31T23:30:00.000Z' });
-    expect(
-      matchesItemFilters(march, { [ADDED_MONTH_FILTER_KEY]: '2026-03' }, fields),
-    ).toBe(true);
-    expect(
-      matchesItemFilters(march, { [ADDED_MONTH_FILTER_KEY]: '2026-04' }, fields),
-    ).toBe(false);
+    expect(matchesItemFilters(march, { [ADDED_MONTH_FILTER_KEY]: '2026-03' }, fields)).toBe(true);
+    expect(matchesItemFilters(march, { [ADDED_MONTH_FILTER_KEY]: '2026-04' }, fields)).toBe(false);
   });
 
   it('requires all active filters to match', () => {
@@ -89,11 +86,7 @@ describe('matchesItemFilters', () => {
     expect(matchesItemFilters(item, { genre: 'Jazz', artist: 'davis' }, fields)).toBe(false);
     expect(matchesItemFilters(item, { genre: 'Jazz', artist: 'coltrane' }, fields)).toBe(true);
     expect(
-      matchesItemFilters(
-        item,
-        { genre: 'Jazz', [ADDED_MONTH_FILTER_KEY]: '2026-03' },
-        fields,
-      ),
+      matchesItemFilters(item, { genre: 'Jazz', [ADDED_MONTH_FILTER_KEY]: '2026-03' }, fields),
     ).toBe(true);
   });
 });
@@ -151,5 +144,17 @@ describe('deriveAddedMonthOptions', () => {
     expect(option.value).toBe('2026-03');
     expect(option.label).toContain('2026');
     expect(option.label).toContain('3');
+  });
+});
+
+describe('formatAddedMonthLabel', () => {
+  it('localizes a YYYY-MM filter value for chip display', () => {
+    expect(formatAddedMonthLabel('2026-03', 'en-US')).toBe('March 2026');
+    expect(formatAddedMonthLabel('2026-03', 'zh-CN')).toContain('2026');
+  });
+
+  it('returns the raw value when it is not a month key', () => {
+    expect(formatAddedMonthLabel('5', 'en-US')).toBe('5');
+    expect(formatAddedMonthLabel('2026-13', 'en-US')).toBe('2026-13');
   });
 });


### PR DESCRIPTION
## Summary

Implements [CUR-24](https://linear.app/qiuyue/issue/CUR-24/add-lightweight-timeline-browsing-yearmonth-based-on-item-created-date) with a small extension to Curio's existing collection filter flow.

- Adds an **Added on** month selector to the existing Filter modal.
- Derives only months that actually contain items, ordered newest-first.
- Uses existing `CollectionItem.createdAt`; no schema or persistence changes.
- Keeps stable `YYYY-MM` filter keys while formatting labels in the active EN/ZH locale.
- Composes with existing rating and metadata filters rather than introducing a separate timeline state or route.

## Implementation notes

The timeline filter is deliberately implemented as a reserved top-level item filter alongside `rating`. Month bucketing uses UTC so the same stored timestamp always maps to the same month across devices and time zones. Display labels use `Intl.DateTimeFormat` and remain localized.

This is intentionally lightweight: no calendar, no new screen, and no duplicated collection-browsing logic.

## Validation

- Added focused unit coverage for month derivation, locale formatting, invalid dates, UTC month boundaries, and composition with existing filters.
- Branch is based directly on current `main` and is 0 commits behind.
- GitHub CI will validate formatting, tests, type/build checks, and repository-level checks on this PR.
