### PR TITLE
Revive two PRs closed only for branch staleness (#416, #418)

### DIFF
--- a/src/components/CollectionScreen.tsx
+++ b/src/components/CollectionScreen.tsx
@@ -363,6 +363,7 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({
                 onClick={() => openAddItemModal(collection.id)}
                 icon={<Plus size={16} />}
                 className="shadow-md flex-1 sm:flex-none sm:w-auto"
+                data-testid="collection-add-item"
               >
                 {t('addItem')}
               </Button>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from '../i18n';
+import { Button } from './ui/Button';
 import { ThemeQuickToggle } from './ThemeQuickToggle';
 import { useTheme, cardSurfaceClasses, dividerClasses } from '../theme';
 import { AppTheme } from '../types';
@@ -391,6 +392,28 @@ export const Layout: React.FC<LayoutProps> = ({
           </Link>
 
           <nav className="flex items-center gap-2 justify-end">
+            {/* CURIO-410: the global Add-item affordance lived only on the
+                mobile bottom-nav Add pill (`sm:hidden`), so a signed-in desktop
+                user on the home screen had no way to add an item without first
+                drilling into a collection. This mirrors that pill on desktop
+                widths (`hidden sm:inline-flex`, so the two never overlap) using
+                the same `onAddItem` handler, which already routes through auth /
+                collection-picker gating. Gated on `isAuthenticated` to keep the
+                pre-auth first run single-path — signed-out users still land on
+                the access gate's one primary CTA. */}
+            {isAuthenticated && onAddItem && (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={onAddItem}
+                icon={<Plus size={14} strokeWidth={2.5} />}
+                className="hidden sm:inline-flex motion-fade"
+                data-testid="header-add-item"
+              >
+                {t('addItem')}
+              </Button>
+            )}
+
             {headerExtras}
 
             <ThemeQuickToggle />

--- a/tests/components/DeleteItemModal.test.tsx
+++ b/tests/components/DeleteItemModal.test.tsx
@@ -45,6 +45,19 @@ describe('DeleteItemModal', () => {
     expect(screen.getByText(/Arcade Cabinet/)).toBeInTheDocument();
   });
 
+  // CUR-163 added an "Untitled" fallback for blank titles; this pins the
+  // rendered warning copy so a future change to the confirmation text cannot
+  // silently drop it. (Coverage originally proposed in the closed #418.)
+  it('falls back to Untitled in the warning when the item title is blank', () => {
+    const untitledItem = createMockItem({ title: '   ' });
+
+    renderWithProviders(<DeleteItemModal {...defaultProps} item={untitledItem} />);
+
+    expect(
+      screen.getByText('This will permanently delete "Untitled". This action cannot be undone.'),
+    ).toBeInTheDocument();
+  });
+
   it('calls onClose when cancel is clicked', async () => {
     const user = userEvent.setup();
     renderWithProviders(<DeleteItemModal {...defaultProps} />);

--- a/tests/components/Layout.test.tsx
+++ b/tests/components/Layout.test.tsx
@@ -668,6 +668,38 @@ describe('Layout Component', () => {
     });
   });
 
+  describe('CURIO-410 Desktop header Add-item entry point', () => {
+    const authenticatedUser = { id: 'user-1', email: 'test@example.com' };
+
+    it('renders a desktop Add Item button for signed-in users', () => {
+      renderWithProviders(
+        <Layout {...defaultProps} user={authenticatedUser} onAddItem={vi.fn()} />,
+      );
+
+      const addButton = screen.getByTestId('header-add-item');
+      expect(addButton).toHaveTextContent('Add Item');
+      // Hidden on mobile so it never overlaps the bottom-nav Add pill.
+      expect(addButton.className).toContain('hidden');
+      expect(addButton.className).toContain('sm:inline-flex');
+    });
+
+    it('calls onAddItem when the desktop Add Item button is clicked', () => {
+      const onAddItem = vi.fn();
+      renderWithProviders(
+        <Layout {...defaultProps} user={authenticatedUser} onAddItem={onAddItem} />,
+      );
+
+      fireEvent.click(screen.getByTestId('header-add-item'));
+      expect(onAddItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the desktop Add Item button when signed out', () => {
+      renderWithProviders(<Layout {...defaultProps} user={null} onAddItem={vi.fn()} />);
+
+      expect(screen.queryByTestId('header-add-item')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Theme Support', () => {
     describe.each([
       { theme: 'gallery' as const, bgPattern: /bg-white/, description: 'light background' },

--- a/tests/e2e/authenticated-user.spec.ts
+++ b/tests/e2e/authenticated-user.spec.ts
@@ -55,8 +55,10 @@ test.describe('Authenticated User Experience', () => {
     await expect(page.getByText('E2E Collection')).toBeVisible({ timeout: 15000 });
     await page.getByText('E2E Collection').click();
 
-    // Add item (manual path — recoverable AI)
-    await page.getByRole('button', { name: /add item/i }).click();
+    // Add item (manual path — recoverable AI). Target the in-screen CTA by
+    // testid: on desktop the global header Add Item button (CURIO-410) shares
+    // the same accessible name, so a name-based locator is ambiguous here.
+    await page.getByTestId('collection-add-item').click();
     await page.getByText(/skip and add manually/i).click();
 
     const title = page.getByRole('textbox').first();
@@ -88,7 +90,7 @@ test.describe('Authenticated User Experience', () => {
     await expect(page.getByText(name).first()).toBeVisible({ timeout: 15000 });
     await page.getByText(name).first().click();
 
-    await page.getByRole('button', { name: /add item/i }).click();
+    await page.getByTestId('collection-add-item').click();
     await page.getByText(/skip and add manually/i).click();
 
     await page.getByRole('textbox').first().fill('CUR-142 Item');


### PR DESCRIPTION
Reapplies two changes that were closed on merit-neutral grounds — the branches had drifted from `main`, not the ideas — against current `main`. Both closure comments explicitly called the substance still valid.

## CURIO-410 — desktop header Add-item entry point (was #416)

The global Add-item affordance existed only on the mobile bottom-nav pill (`sm:hidden`), so a signed-in desktop user on the home screen had no way to add an item without first drilling into a collection.

- `Layout.tsx` renders an Add Item button at `sm:` and above (`hidden sm:inline-flex`, so it never overlaps the mobile pill), reusing the existing `onAddItem` handler that already routes through auth and collection-picker gating.
- Gated on `isAuthenticated`, which keeps the pre-auth first run single-path — signed-out users still see one primary CTA on the access gate.
- The in-collection CTA in `CollectionScreen.tsx` gains `data-testid="collection-add-item"`, and the e2e specs target it: on desktop both buttons now share the accessible name "Add Item", so a name-based locator would be ambiguous. This was the review fix on the original PR, carried over here.

## CUR-163 — blank-title delete-confirmation coverage (was #418)

Pins the rendered warning copy for an item with a blank title, so the "Untitled" fallback in the delete confirmation cannot be silently dropped by a future change to that text. The production fallback already exists on `main`; this is coverage only.

## Validation

`npm run format:check`, `npm test` (1160 passed), `npm run build`, and `npm run test:e2e` (44 passed) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbKLKYsCYiUSgGBTaAXJsB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbKLKYsCYiUSgGBTaAXJsB)_