### PR TITLE
Fix four defects in code merged without a Codex re-review

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -82,6 +82,20 @@ interface AiCapabilities {
   imageEditingAvailable: boolean;
 }
 
+// One /api/health round trip serves every capability question. Without this
+// share, the four per-feature refreshers each issue their own request on a cold
+// start — four identical calls where one will do.
+let capabilitiesPromise: Promise<AiCapabilities> | null = null;
+
+const loadAiCapabilities = (): Promise<AiCapabilities> => {
+  if (!capabilitiesPromise) {
+    capabilitiesPromise = fetchAiCapabilities().finally(() => {
+      capabilitiesPromise = null;
+    });
+  }
+  return capabilitiesPromise;
+};
+
 const fetchAiCapabilities = async (): Promise<AiCapabilities> => {
   try {
     const response = await fetch(`${API_BASE_URL}/api/health`);
@@ -111,7 +125,7 @@ const fetchAiCapabilities = async (): Promise<AiCapabilities> => {
 export const refreshAiEnabled = async (): Promise<boolean> => {
   if (aiEnabledCache !== null) return aiEnabledCache;
   if (aiEnabledPromise) return aiEnabledPromise;
-  aiEnabledPromise = fetchAiCapabilities()
+  aiEnabledPromise = loadAiCapabilities()
     .then((capabilities) => {
       aiEnabledCache = capabilities.metadataAnalysisAvailable;
       return aiEnabledCache;
@@ -127,7 +141,7 @@ export const isAiEnabled = () => aiEnabledCache === true;
 export const refreshStoryPromptsEnabled = async (): Promise<boolean> => {
   if (storyPromptsEnabledCache !== null) return storyPromptsEnabledCache;
   if (storyPromptsEnabledPromise) return storyPromptsEnabledPromise;
-  storyPromptsEnabledPromise = fetchAiCapabilities()
+  storyPromptsEnabledPromise = loadAiCapabilities()
     .then((capabilities) => {
       storyPromptsEnabledCache = capabilities.storyPromptsAvailable;
       return storyPromptsEnabledCache;
@@ -141,7 +155,7 @@ export const refreshStoryPromptsEnabled = async (): Promise<boolean> => {
 export const refreshFieldSuggestionsEnabled = async (): Promise<boolean> => {
   if (fieldSuggestionsEnabledCache !== null) return fieldSuggestionsEnabledCache;
   if (fieldSuggestionsEnabledPromise) return fieldSuggestionsEnabledPromise;
-  fieldSuggestionsEnabledPromise = fetchAiCapabilities()
+  fieldSuggestionsEnabledPromise = loadAiCapabilities()
     .then((capabilities) => {
       fieldSuggestionsEnabledCache = capabilities.fieldSuggestionsAvailable;
       return fieldSuggestionsEnabledCache;
@@ -159,7 +173,7 @@ export const refreshAiImageEditEnabled = async (): Promise<boolean> => {
     return false;
   }
   if (aiImageEditEnabledPromise) return aiImageEditEnabledPromise;
-  aiImageEditEnabledPromise = fetchAiCapabilities()
+  aiImageEditEnabledPromise = loadAiCapabilities()
     .then((capabilities) => {
       aiImageEditEnabledCache = capabilities.imageEditingAvailable;
       return aiImageEditEnabledCache;

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -103,10 +103,22 @@ const applyAiCapabilities = (capabilities: AiCapabilities): AiCapabilities => {
   return capabilities;
 };
 
+const UNAVAILABLE_CAPABILITIES: AiCapabilities = {
+  metadataAnalysisAvailable: false,
+  fieldSuggestionsAvailable: false,
+  storyPromptsAvailable: false,
+  imageEditingAvailable: false,
+};
+
 const loadAiCapabilities = (): Promise<AiCapabilities> => {
   if (!capabilitiesPromise) {
     capabilitiesPromise = fetchAiCapabilities()
+      // Only a SUCCESSFUL response may settle the other features' caches. A
+      // transient failure must stay confined to the caller: seeding all four
+      // with false would leave every AI feature off for the life of the page,
+      // with nothing left unset to trigger a retry once the backend recovers.
       .then(applyAiCapabilities)
+      .catch(() => UNAVAILABLE_CAPABILITIES)
       .finally(() => {
         capabilitiesPromise = null;
       });
@@ -127,12 +139,9 @@ const fetchAiCapabilities = async (): Promise<AiCapabilities> => {
       imageEditingAvailable: payload?.imageEditingAvailable ?? fallback,
     };
   } catch {
-    return {
-      metadataAnalysisAvailable: false,
-      fieldSuggestionsAvailable: false,
-      storyPromptsAvailable: false,
-      imageEditingAvailable: false,
-    };
+    // Rethrow so loadAiCapabilities can tell "health says unavailable" from
+    // "health could not be reached" — only the former may be cached broadly.
+    throw new Error('AI health unavailable');
   }
 };
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -87,11 +87,29 @@ interface AiCapabilities {
 // start — four identical calls where one will do.
 let capabilitiesPromise: Promise<AiCapabilities> | null = null;
 
+// Settle every per-feature cache from the one response. Sharing only the
+// in-flight promise would dedupe a concurrent burst but not the realistic
+// sequential case — analysis checked in AddItemModal, image editing later in
+// ItemDetailScreen — because the promise is cleared once it resolves and each
+// caller only populates its own cache.
+const applyAiCapabilities = (capabilities: AiCapabilities): AiCapabilities => {
+  if (aiEnabledCache === null) aiEnabledCache = capabilities.metadataAnalysisAvailable;
+  if (storyPromptsEnabledCache === null)
+    storyPromptsEnabledCache = capabilities.storyPromptsAvailable;
+  if (fieldSuggestionsEnabledCache === null)
+    fieldSuggestionsEnabledCache = capabilities.fieldSuggestionsAvailable;
+  if (aiImageEditEnabledCache === null)
+    aiImageEditEnabledCache = capabilities.imageEditingAvailable;
+  return capabilities;
+};
+
 const loadAiCapabilities = (): Promise<AiCapabilities> => {
   if (!capabilitiesPromise) {
-    capabilitiesPromise = fetchAiCapabilities().finally(() => {
-      capabilitiesPromise = null;
-    });
+    capabilitiesPromise = fetchAiCapabilities()
+      .then(applyAiCapabilities)
+      .finally(() => {
+        capabilitiesPromise = null;
+      });
   }
   return capabilitiesPromise;
 };

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1759,6 +1759,17 @@ const saveCollectionToCloud = async (collection: UserCollection): Promise<void> 
 
   // Sync Items
   if (itemsForSync.length > 0) {
+    // Public sample collections are exempt from the inline-photo migration.
+    // `curio-assets` is a PRIVATE bucket (`public = false`) whose select policy
+    // is `auth.uid() = split_part(name, '/', 1)`, so an object uploaded there is
+    // unreadable by the signed-out visitors the Public Sample Gallery exists
+    // for. That is exactly why `applyEditedPhoto` keeps an admin-curated public
+    // photo as an inline `data:` URL instead of calling `saveAsset`. Migrating
+    // it would repoint the public row at an object anonymous readers get a 400
+    // on, rendering a broken card on the pre-login gallery. Row bloat on a
+    // handful of curated samples is the lesser cost.
+    const migrateInlinePhotos = !latestCollectionForItems.isPublic;
+
     // Pass 1 — migrate inline photos. A `data:`/`blob:` photoUrl is a raw image
     // payload that must never be upserted into the item row (issue #369). Move
     // each onto the Storage-backed asset track via `saveAsset` (which stashes
@@ -1768,7 +1779,7 @@ const saveCollectionToCloud = async (collection: UserCollection): Promise<void> 
     // local write-back below can tell "still the payload we moved" from "the
     // user swapped the photo while the upload was in flight".
     const migratedPhotoUrls = new Map<string, string>();
-    for (const item of itemsForSync) {
+    for (const item of migrateInlinePhotos ? itemsForSync : []) {
       const photoUrl = item.photoUrl || '';
       if (photoUrl === 'asset' || !isInlinePhotoUrl(photoUrl)) continue;
       const blob = dataUrlToBlob(photoUrl);
@@ -1849,10 +1860,19 @@ const saveCollectionToCloud = async (collection: UserCollection): Promise<void> 
           photoOriginalPath = `${basePath}/original.jpg`;
           photoDisplayPath = `${basePath}/display.jpg`;
         } else if (isInlinePhotoUrl(photoUrl)) {
-          // Still inline means the migration above couldn't recover the bytes;
-          // store null rather than the blob and leave the local photo for retry.
-          photoOriginalPath = null;
-          photoDisplayPath = null;
+          // On a public collection the inline URL is the intended, readable
+          // form, so keep it in the row — the anonymous gallery depends on it.
+          // On a private one, still-inline means the migration above couldn't
+          // recover the bytes; store null rather than the blob and leave the
+          // local photo for retry.
+          if (!migrateInlinePhotos) {
+            const { originalPath, displayPath } = normalizePhotoPaths(photoUrl);
+            photoOriginalPath = originalPath;
+            photoDisplayPath = displayPath;
+          } else {
+            photoOriginalPath = null;
+            photoDisplayPath = null;
+          }
         } else {
           const { originalPath, displayPath } = normalizePhotoPaths(photoUrl);
           photoOriginalPath = originalPath;
@@ -1891,11 +1911,45 @@ const saveCollectionToCloud = async (collection: UserCollection): Promise<void> 
   }
 };
 
+// Once an inline photo has been migrated onto the asset track, the stored
+// record says `photoUrl: 'asset'` but the caller's in-memory collection still
+// carries the original `data:` URL — App.tsx saves from React state, which is
+// not re-hydrated from IndexedDB after a sync. Writing that stale value back
+// would undo the migration and make the next sync decode and re-upload the same
+// multi-megabyte payload, in-session, on every edit.
+//
+// Only a private collection is reconciled: on a public one an inline `data:`
+// URL is the intended form (see the migration guard in saveCollectionToCloud),
+// so `applyEditedPhoto` legitimately moves a public item from 'asset' back to an
+// inline URL and that must be honoured.
+const reconcileMigratedPhotoUrls = (
+  incoming: UserCollection,
+  stored: UserCollection | undefined,
+): UserCollection => {
+  if (!stored || incoming.isPublic) return incoming;
+  const storedById = new Map(stored.items.map((item) => [item.id, item]));
+  let changed = false;
+  const items = incoming.items.map((item) => {
+    if (storedById.get(item.id)?.photoUrl !== 'asset') return item;
+    if (!isInlinePhotoUrl(item.photoUrl || '')) return item;
+    changed = true;
+    return { ...item, photoUrl: 'asset' };
+  });
+  return changed ? { ...incoming, items } : incoming;
+};
+
 export const saveCollection = async (collection: UserCollection): Promise<void> => {
   const db = await initDB();
-  const collectionToSave = collection.updatedAt
-    ? collection
-    : { ...collection, updatedAt: new Date().toISOString() };
+  const storedCollection = await new Promise<UserCollection | undefined>((resolve) => {
+    const transaction = db.transaction(COLLECTIONS_STORE, 'readonly');
+    const request = transaction.objectStore(COLLECTIONS_STORE).get(collection.id);
+    request.onsuccess = () => resolve(request.result || undefined);
+    request.onerror = () => resolve(undefined);
+  });
+  const reconciled = reconcileMigratedPhotoUrls(collection, storedCollection);
+  const collectionToSave = reconciled.updatedAt
+    ? reconciled
+    : { ...reconciled, updatedAt: new Date().toISOString() };
   const shouldSyncToCloud = isSupabaseConfigured() && Boolean(supabase);
 
   // 1. Local Persistence (IndexedDB) - always succeeds. When a cloud sync will

--- a/tests/services/db.operations.test.ts
+++ b/tests/services/db.operations.test.ts
@@ -363,6 +363,118 @@ describe('Phase 2.2 — services/db.ts dual-write operations', () => {
     expect(savedLocally?.items[0].photoUrl).toBe('asset');
   });
 
+  it('saveCollection: a stale in-memory inline photoUrl does not trigger a re-upload (#369)', async () => {
+    /**
+     * The migration flips the LOCAL record to `photoUrl: 'asset'`, but App.tsx
+     * calls saveCollection with the in-memory React collection, which still
+     * holds the inline `data:` URL until a reload re-hydrates from IndexedDB.
+     * Without a guard that stale object overwrites the flip on the next save
+     * and the same multi-megabyte payload is decoded and uploaded again — the
+     * exact in-session repeat the migration was supposed to end.
+     */
+    const { supabase, upload } = createSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const collection: UserCollection = {
+      id: 'col-1',
+      templateId: 'vinyl',
+      name: 'My Collection',
+      icon: '🎵',
+      customFields: [],
+      items: [
+        {
+          id: 'item-1',
+          collectionId: 'col-1',
+          photoUrl: `data:image/jpeg;base64,${'AAAA'.repeat(20)}`,
+          title: 'Inline photo item',
+          rating: 4,
+          data: {},
+          createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+          updatedAt: new Date('2024-01-02T00:00:00Z').toISOString(),
+          notes: '',
+        },
+      ],
+      ownerId: 'test-user-id',
+      updatedAt: new Date('2024-01-03T00:00:00Z').toISOString(),
+    };
+
+    await dbMod.saveCollection(collection);
+    const uploadsAfterMigration = upload.mock.calls.length;
+    expect(uploadsAfterMigration).toBeGreaterThan(0);
+
+    // Save again from the SAME in-memory object the app still holds — it was
+    // never refreshed from IndexedDB, so it still carries the data: URL.
+    await dbMod.saveCollection({
+      ...collection,
+      name: 'Renamed',
+      updatedAt: new Date('2024-01-04T00:00:00Z').toISOString(),
+    });
+
+    expect(upload.mock.calls.length).toBe(uploadsAfterMigration);
+  });
+
+  it("saveCollection: leaves a public collection's inline photo inline (#369)", async () => {
+    /**
+     * Public sample collections deliberately keep an admin-curated photo as an
+     * inline `data:` URL: `applyEditedPhoto` skips `saveAsset` when
+     * `collection.isPublic`, because `curio-assets` is a PRIVATE bucket whose
+     * select policy is `auth.uid() = split_part(name,'/',1)`. Migrating such a
+     * photo into Storage points the public item row at an object no signed-out
+     * visitor can read, so the pre-login gallery renders a broken card.
+     */
+    const { supabase, itemsUpsert, upload } = createSupabaseMock();
+    const dbMod = await importDbModuleFreshWithSupabaseMock(supabase);
+
+    const db = await dbMod.initDB();
+    openDb = db;
+    await clearStores(db, ['collections', 'assets', 'display', 'settings']);
+
+    const dataUrl = `data:image/jpeg;base64,${'AAAA'.repeat(20)}`;
+    const collection: UserCollection = {
+      id: 'col-public',
+      templateId: 'vinyl',
+      name: 'The Vinyl Vault',
+      icon: '🎵',
+      isPublic: true,
+      customFields: [],
+      items: [
+        {
+          id: 'item-1',
+          collectionId: 'col-public',
+          photoUrl: dataUrl,
+          title: 'Curated sample',
+          rating: 4,
+          data: {},
+          createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+          updatedAt: new Date('2024-01-02T00:00:00Z').toISOString(),
+          notes: '',
+        },
+      ],
+      ownerId: 'test-user-id',
+      updatedAt: new Date('2024-01-03T00:00:00Z').toISOString(),
+    } as UserCollection;
+
+    await dbMod.saveCollection(collection);
+
+    // Nothing was pushed into the private bucket for a public collection.
+    expect(upload.mock.calls.map((call) => call[0])).toEqual([]);
+
+    // And the row still carries the inline photo rather than a private path
+    // the anonymous gallery cannot read.
+    const [itemsPayload] = itemsUpsert.mock.calls[0];
+    expect(itemsPayload[0].photo_original_path).not.toContain('test-user-id/collections');
+    expect(itemsPayload[0].photo_display_path).not.toContain('test-user-id/collections');
+
+    // The local record keeps the inline URL too, so the admin's curated photo
+    // survives the next seed reconciliation (isCustomSeedPhoto).
+    const savedLocally = await readFromStore<UserCollection>(db, 'collections', 'col-public');
+    expect(savedLocally?.items[0].photoUrl).toBe(dataUrl);
+  });
+
   it('saveCollection: a migrated inline photo is not re-uploaded on the next save (#369)', async () => {
     /**
      * Migration only rewrote the cloud row, so the local item kept its inline

--- a/tests/services/geminiService.test.ts
+++ b/tests/services/geminiService.test.ts
@@ -625,6 +625,28 @@ describe('services/aiService.ts - per-feature capability gating (CUR-166)', () =
     expect(healthCalls).toHaveLength(1);
   });
 
+  it('serves sequential capability checks from the one health response', async () => {
+    // The realistic order: AddItemModal asks about analysis, and only later
+    // does ItemDetailScreen ask about image editing. Sharing just the in-flight
+    // promise would not cover this, since it is cleared once it resolves.
+    const mod = await withHealth({
+      metadataAnalysisAvailable: true,
+      storyPromptsAvailable: true,
+      fieldSuggestionsAvailable: true,
+      imageEditingAvailable: true,
+    });
+
+    await mod.refreshAiEnabled();
+    await mod.refreshStoryPromptsEnabled();
+    await mod.refreshFieldSuggestionsEnabled();
+    await mod.refreshAiImageEditEnabled();
+
+    const healthCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(([url]) =>
+      (url as string).includes('/health'),
+    );
+    expect(healthCalls).toHaveLength(1);
+  });
+
   it('does not call an endpoint health reports as unavailable', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const mod = await withHealth({

--- a/tests/services/geminiService.test.ts
+++ b/tests/services/geminiService.test.ts
@@ -604,6 +604,27 @@ describe('services/aiService.ts - per-feature capability gating (CUR-166)', () =
     await expect(mod.analyzeImage('BASE64', fields)).resolves.toEqual({ status: 'disabled' });
   });
 
+  it('resolves every capability from a single health request', async () => {
+    const mod = await withHealth({
+      metadataAnalysisAvailable: true,
+      storyPromptsAvailable: true,
+      fieldSuggestionsAvailable: true,
+      imageEditingAvailable: true,
+    });
+
+    await Promise.all([
+      mod.refreshAiEnabled(),
+      mod.refreshStoryPromptsEnabled(),
+      mod.refreshFieldSuggestionsEnabled(),
+      mod.refreshAiImageEditEnabled(),
+    ]);
+
+    const healthCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(([url]) =>
+      (url as string).includes('/health'),
+    );
+    expect(healthCalls).toHaveLength(1);
+  });
+
   it('does not call an endpoint health reports as unavailable', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const mod = await withHealth({

--- a/tests/services/geminiService.test.ts
+++ b/tests/services/geminiService.test.ts
@@ -647,6 +647,43 @@ describe('services/aiService.ts - per-feature capability gating (CUR-166)', () =
     expect(healthCalls).toHaveLength(1);
   });
 
+  it('does not let a failed health check disable features that never asked', async () => {
+    // A transient failure must not seed every cache with false: with nothing
+    // left unset, no later feature would retry and the whole AI surface would
+    // stay off for the life of the page even once the backend recovered.
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_AI_ENABLED', undefined as unknown as string);
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost:8787');
+
+    let healthCalls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => {
+        if (url.includes('/health')) {
+          healthCalls += 1;
+          // First check fails; the backend recovers before the second feature asks.
+          if (healthCalls === 1) throw new Error('Network down');
+          return createOkJsonResponse({
+            metadataAnalysisAvailable: true,
+            storyPromptsAvailable: true,
+            fieldSuggestionsAvailable: true,
+            imageEditingAvailable: true,
+          });
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }),
+    );
+
+    const mod = await import('@/services/aiService');
+
+    // The feature that hit the outage is disabled, as before.
+    await expect(mod.refreshAiEnabled()).resolves.toBe(false);
+    // A different feature asked later still retries and sees the recovery.
+    await expect(mod.refreshAiImageEditEnabled()).resolves.toBe(true);
+    expect(healthCalls).toBe(2);
+  });
+
   it('does not call an endpoint health reports as unavailable', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const mod = await withHealth({


### PR DESCRIPTION
Codex reviewed only 2 of the 11 heads merged in the last batch — the rest either exhausted the review quota or were never re-reviewed after their fix commits landed. Auditing those unreviewed deltas turned up three real defects, one of them user-facing. Codex then found a fourth on this PR.

## 1. Public Sample Gallery regression (from #447) — severe

The inline-photo migration had no `isPublic` guard. `curio-assets` is a **private** bucket (`public = false`) whose select policy is `auth.uid()::text = split_part(name, '/', 1)`, so:

1. An admin swaps a photo on a public sample item. `applyEditedPhoto` deliberately stores it as an inline `data:` URL and skips `saveAsset`, precisely because public samples must not depend on private storage.
2. The migration uploaded that photo to `user_id/collections/.../original.jpg` and repointed the public item row at it.
3. A signed-out visitor hits `getAsset` with no local blob and no session, the download 400s under RLS, and the pre-login gallery renders a broken card.

That breaks the "delight before auth" constraint in `CLAUDE.md` and contradicts the invariant stated in `docs/ops/PUBLIC_SAMPLE_GALLERY.md`: *"The gallery never depends on private Supabase Storage — that is what lets a signed-out visitor see it."*

Public collections are now exempt from the migration and keep the inline URL in the row, which is the pre-#447 behaviour. Row bloat on a handful of curated samples is the lesser cost.

## 2. The migration's local write-back was defeated by stale state (from #447)

`App.tsx` calls `saveCollection` with the in-memory React collection, which is never re-hydrated from IndexedDB after a sync. So the next save wrote the `data:` URL back over the `'asset'` flip, and the same multi-megabyte payload was decoded and re-uploaded on every in-session edit — the repeat upload the migration was meant to end.

`saveCollection` now reconciles an incoming inline `photoUrl` against a stored `'asset'` one, for private collections only (a public collection legitimately moves back to inline, per defect 1).

## 3. Redundant health requests (from #439)

Splitting capability gating per feature gave each of the four `refresh*Enabled` functions its own `fetchAiCapabilities()` call, so a cold start issued four identical `/api/health` requests. A successful response now settles all four per-feature caches, so the first resolved request serves every later capability question. Caches already seeded by `VITE_AI_ENABLED` / `VITE_AI_IMAGE_EDIT_ENABLED` are left alone, so the env override still wins.

## 4. A failed health check disabled every AI feature (introduced by fix 3)

Found by Codex on this PR. `fetchAiCapabilities` converted any transient failure or malformed payload into an all-false object, which fix 3 then wrote into all four caches. With nothing left unset, no feature retried — one blip disabled the entire AI surface for the life of the page, where previously a feature first used later issued its own request and could see the backend recover.

`fetchAiCapabilities` now rethrows; only a successful response settles the shared caches, and a failure is returned to the calling refresher alone, restoring the per-feature recovery path.

## A note on the testing mistakes this PR corrects

Defects 2, 3 and 4 were all in code I had already "fixed" and signed off on, with passing tests. The tests were shaped around my fix rather than the path the app takes:

- **Defect 2**: the test re-read the collection from IndexedDB before the second save. The app saves from React state, which is never re-hydrated — so the fix worked in the test and not in the app.
- **Defect 3**: the test used `Promise.all`, the concurrent burst the old code already handled, so it passed either way.
- **Defect 4**: I considered this case while writing fix 3 and dismissed it as pre-existing. The pre-existing part was one feature caching its own failure; what the shared cache added was the blast radius.

Every test now drives the real path.

## Validation

Each fix has a regression test verified to fail against the previous revision, by reverting the fix in turn:

| Fix | Before | After |
| --- | --- | --- |
| public collection exempt | 2 uploads into the private bucket | 0 |
| stale-state reconcile | 4 uploads | 2 |
| sequential capability checks | 4 `/api/health` requests | 1 |
| recovery after failed health check | image editing stuck `false` | retries and recovers |

`npm run format:check`, `npm test` (1165 passed), `npm run build` and `npm run test:e2e` (44 passed) all pass.

## Open question for the reviewer

This PR patches #447's migration. The alternative is reverting the migration outright: it optimises item-row size at the cost of the gallery's core guarantee, and it has now produced two defects of its own. That guarantee is currently enforced by a guard rather than by structure. Worth deciding before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbKLKYsCYiUSgGBTaAXJsB